### PR TITLE
Fix NOTIFY dispatch for blind transfer

### DIFF
--- a/call.go
+++ b/call.go
@@ -70,6 +70,8 @@ type dialog interface {
 	SendRefer(target string) error
 	// OnNotify registers a callback for NOTIFY events (REFER progress).
 	OnNotify(fn func(code int))
+	// FireNotify fires the on_notify callback with the given status code.
+	FireNotify(code int)
 	// CallID returns the SIP Call-ID.
 	CallID() string
 	// Header returns values for a SIP header (case-insensitive).

--- a/sipgo_dialog.go
+++ b/sipgo_dialog.go
@@ -63,6 +63,15 @@ func (d *dialogBase) OnNotify(fn func(code int)) {
 	d.onNotify = fn
 }
 
+func (d *dialogBase) FireNotify(code int) {
+	d.mu.Lock()
+	fn := d.onNotify
+	d.mu.Unlock()
+	if fn != nil {
+		fn(code)
+	}
+}
+
 func (d *dialogBase) CallID() string {
 	if h := d.invite.CallID(); h != nil {
 		return h.Value()

--- a/sipua.go
+++ b/sipua.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -59,6 +60,10 @@ type sipUA struct {
 	// onDialogBye is called when an inbound BYE is received for a server dialog.
 	// The phone uses this to transition the call to StateEnded.
 	onDialogBye func(callID string)
+
+	// onDialogNotify is called when an inbound NOTIFY is received (REFER progress).
+	// The phone uses this to fire the dialog's OnNotify callback.
+	onDialogNotify func(callID string, code int)
 }
 
 // newSipUA creates a sipgo-backed SIP transport.
@@ -285,6 +290,30 @@ func (s *sipUA) startServer() {
 		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
 		tx.Respond(res)
 	})
+
+	s.server.OnNotify(func(req *sip.Request, tx sip.ServerTransaction) {
+		// Always respond 200 OK to NOTIFY.
+		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
+		tx.Respond(res)
+
+		// Parse status code from sipfrag body (e.g. "SIP/2.0 200 OK").
+		code := parseSipfragStatus(string(req.Body()))
+		if code <= 0 {
+			return
+		}
+
+		callID := ""
+		if h := req.CallID(); h != nil {
+			callID = h.Value()
+		}
+
+		s.mu.Lock()
+		fn := s.onDialogNotify
+		s.mu.Unlock()
+		if fn != nil && callID != "" {
+			go fn(callID, code)
+		}
+	})
 }
 
 // --- sipTransport interface ---
@@ -383,6 +412,28 @@ func (s *sipUA) Close() error {
 	s.server.Close()
 	s.client.Close()
 	return s.ua.Close()
+}
+
+// parseSipfragStatus extracts the status code from a message/sipfrag body.
+// Example: "SIP/2.0 200 OK" → 200
+func parseSipfragStatus(body string) int {
+	line := body
+	if i := strings.Index(body, "\n"); i >= 0 {
+		line = body[:i]
+	}
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "SIP/") {
+		return 0
+	}
+	parts := strings.SplitN(line, " ", 3)
+	if len(parts) < 2 {
+		return 0
+	}
+	code, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0
+	}
+	return code
 }
 
 // Ensure sipUA satisfies sipTransport at compile time.

--- a/testutil/mock_dialog.go
+++ b/testutil/mock_dialog.go
@@ -106,6 +106,16 @@ func (d *MockDialog) OnNotify(fn func(code int)) {
 	d.onNotify = fn
 }
 
+// FireNotify fires the on_notify callback with the given status code.
+func (d *MockDialog) FireNotify(code int) {
+	d.mu.Lock()
+	fn := d.onNotify
+	d.mu.Unlock()
+	if fn != nil {
+		fn(code)
+	}
+}
+
 // CallID returns the SIP Call-ID.
 func (d *MockDialog) CallID() string {
 	d.mu.Lock()

--- a/xphone.go
+++ b/xphone.go
@@ -172,10 +172,11 @@ func (p *phone) Connect(ctx context.Context) error {
 	p.dialFn = tr.dial
 	p.mu.Unlock()
 
-	// Wire inbound INVITE and BYE handlers for sipgo path.
+	// Wire inbound INVITE, BYE, and NOTIFY handlers for sipgo path.
 	tr.mu.Lock()
 	tr.onDialogInvite = p.handleDialogInvite
 	tr.onDialogBye = p.handleDialogBye
+	tr.onDialogNotify = p.handleDialogNotify
 	tr.mu.Unlock()
 	tr.startServer()
 
@@ -386,6 +387,15 @@ func (p *phone) handleDialogBye(callID string) {
 	}
 }
 
+// handleDialogNotify is called by sipUA's OnNotify handler when a NOTIFY is received.
+// It looks up the call by Call-ID and fires the dialog's OnNotify callback.
+func (p *phone) handleDialogNotify(callID string, code int) {
+	c := p.findCall(callID)
+	if c != nil {
+		c.dlg.FireNotify(code)
+	}
+}
+
 // handleIncoming is called by the mock transport when an incoming INVITE arrives.
 // It auto-sends 100 Trying via the transport, creates an inbound call, fires
 // OnIncoming, and auto-sends 180 Ringing via the transport.
@@ -526,6 +536,15 @@ func (d *phoneDialog) OnNotify(fn func(code int)) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.onNotify = fn
+}
+
+func (d *phoneDialog) FireNotify(code int) {
+	d.mu.Lock()
+	fn := d.onNotify
+	d.mu.Unlock()
+	if fn != nil {
+		fn(code)
+	}
 }
 
 func (d *phoneDialog) CallID() string {


### PR DESCRIPTION
## Summary
- Incoming NOTIFY requests were silently dropped by `sipUA.startServer()`, so `BlindTransfer()` would send the REFER but the transfer-complete NOTIFY from the PBX never fired the `OnNotify` callback — the call never transitioned to `Ended(Transfer)`
- Added `FireNotify(code int)` to the `dialog` interface and all implementations (`dialogBase`, `phoneDialog`, `MockDialog`)
- Registered `server.OnNotify()` handler in `sipUA.startServer()` — responds 200 OK, parses sipfrag body for status code (e.g. `SIP/2.0 200 OK` → 200)
- Wired `phone.handleDialogNotify()` to look up call by Call-ID and fire `dlg.FireNotify(code)`

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Same fix applied and tested in xphone-rust