### PR TITLE
Add 302 redirect following for INVITE

### DIFF
--- a/fakepbx_test.go
+++ b/fakepbx_test.go
@@ -2,11 +2,14 @@ package xphone
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/emiago/sipgo/sip"
 	"github.com/pion/rtp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,10 +40,10 @@ func pbxConfig(t *testing.T, pbx *fakepbx.FakePBX) Config {
 	}
 }
 
-// connectPBX creates a Phone connected and registered to the given FakePBX.
-func connectPBX(t *testing.T, pbx *fakepbx.FakePBX) Phone {
+// connectWithConfig creates a Phone, connects it, waits for registration, and
+// registers a cleanup. Shared by connectPBX and connectPBXNoAuth.
+func connectWithConfig(t *testing.T, cfg Config) Phone {
 	t.Helper()
-	cfg := pbxConfig(t, pbx)
 	p := newPhone(cfg)
 
 	registered := make(chan struct{}, 1)
@@ -65,6 +68,22 @@ func connectPBX(t *testing.T, pbx *fakepbx.FakePBX) Phone {
 
 	t.Cleanup(func() { p.Disconnect() })
 	return p
+}
+
+// connectPBX creates a Phone connected and registered to the given FakePBX.
+func connectPBX(t *testing.T, pbx *fakepbx.FakePBX) Phone {
+	t.Helper()
+	return connectWithConfig(t, pbxConfig(t, pbx))
+}
+
+// connectPBXNoAuth creates a Phone connected and registered to a FakePBX that
+// has no auth configured. Used by redirect tests to avoid auth-related INVITE
+// retries interfering with redirect counting.
+func connectPBXNoAuth(t *testing.T, pbx *fakepbx.FakePBX) Phone {
+	t.Helper()
+	cfg := pbxConfig(t, pbx)
+	cfg.Password = ""
+	return connectWithConfig(t, cfg)
 }
 
 // bindRTP allocates a UDP socket on loopback for use as the PBX's RTP endpoint.
@@ -418,5 +437,113 @@ func TestFakePBX_Provisionals(t *testing.T) {
 	// At this point the call should be Active.
 	c.OnState(func(s CallState) { states <- s })
 	assert.Equal(t, StateActive, c.State())
+	c.End()
+}
+
+// --- 302 Redirect Tests ---
+
+// F12: Dial target returns 302, xphone follows redirect to new target.
+func TestFakePBX_Dial302Redirect(t *testing.T) {
+	pbx := fakepbx.NewFakePBX(t)
+	_, rtpPort := bindRTP(t)
+
+	var inviteCount atomic.Int32
+	pbxAddr := pbx.Addr() // includes host:port
+	pbx.OnInvite(func(inv *fakepbx.Invite) {
+		n := inviteCount.Add(1)
+		if n == 1 {
+			// First INVITE → 302 redirect to different target.
+			inv.Respond(302, "Moved Temporarily",
+				sip.NewHeader("Contact", fmt.Sprintf("<sip:redirected@%s>", pbxAddr)))
+			return
+		}
+		// Second INVITE (after redirect) → answer.
+		inv.Trying()
+		inv.Ringing()
+		inv.Answer(fakepbx.SDP("127.0.0.1", rtpPort, fakepbx.PCMU))
+	})
+
+	p := connectPBXNoAuth(t, pbx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c, err := p.Dial(ctx, "9999")
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, c.State())
+	assert.Equal(t, int32(2), inviteCount.Load(), "expected 2 INVITEs (original + redirect)")
+
+	c.End()
+}
+
+// F13: 302 redirect with no Contact header returns error.
+func TestFakePBX_Dial302NoContact(t *testing.T) {
+	pbx := fakepbx.NewFakePBX(t)
+
+	pbx.OnInvite(func(inv *fakepbx.Invite) {
+		// 302 with no Contact header.
+		inv.Respond(302, "Moved Temporarily")
+	})
+
+	p := connectPBXNoAuth(t, pbx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := p.Dial(ctx, "9999")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Contact")
+}
+
+// F14: Too many 302 redirects returns error.
+func TestFakePBX_Dial302TooManyRedirects(t *testing.T) {
+	pbx := fakepbx.NewFakePBX(t)
+
+	pbxAddr := pbx.Addr()
+	pbx.OnInvite(func(inv *fakepbx.Invite) {
+		// Always redirect — should hit the max limit.
+		inv.Respond(302, "Moved Temporarily",
+			sip.NewHeader("Contact", fmt.Sprintf("<sip:loop@%s>", pbxAddr)))
+	})
+
+	p := connectPBXNoAuth(t, pbx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := p.Dial(ctx, "9999")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many redirects")
+}
+
+// F15: 100 Trying then 302 redirect — redirect after provisional.
+func TestFakePBX_Dial302AfterProvisional(t *testing.T) {
+	pbx := fakepbx.NewFakePBX(t)
+	_, rtpPort := bindRTP(t)
+
+	var inviteCount atomic.Int32
+	pbxAddr := pbx.Addr()
+	pbx.OnInvite(func(inv *fakepbx.Invite) {
+		n := inviteCount.Add(1)
+		if n == 1 {
+			inv.Trying()
+			inv.Respond(302, "Moved Temporarily",
+				sip.NewHeader("Contact", fmt.Sprintf("<sip:target2@%s>", pbxAddr)))
+			return
+		}
+		inv.Trying()
+		inv.Ringing()
+		inv.Answer(fakepbx.SDP("127.0.0.1", rtpPort, fakepbx.PCMU))
+	})
+
+	p := connectPBXNoAuth(t, pbx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c, err := p.Dial(ctx, "9999")
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, c.State())
+
 	c.End()
 }

--- a/sipua.go
+++ b/sipua.go
@@ -2,6 +2,7 @@ package xphone
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -30,8 +31,19 @@ func parseSIPTarget(target, defaultHost string, defaultPort int) sip.Uri {
 		port := defaultPort
 		if at := strings.Index(rest, "@"); at >= 0 {
 			user = rest[:at]
-			host = rest[at+1:]
-			port = 0 // let sipgo resolve from the host part
+			hostPart := rest[at+1:]
+			// Strip URI parameters (;transport=udp, etc.)
+			if semi := strings.Index(hostPart, ";"); semi >= 0 {
+				hostPart = hostPart[:semi]
+			}
+			// Parse host:port if present.
+			if h, p, err := net.SplitHostPort(hostPart); err == nil {
+				host = h
+				port, _ = strconv.Atoi(p)
+			} else {
+				host = hostPart
+				port = 0 // let sipgo resolve via SRV/default
+			}
 		}
 		return sip.Uri{Scheme: scheme, User: user, Host: host, Port: port}
 	}
@@ -123,20 +135,43 @@ func newSipUA(cfg Config, contactIP string) (*sipUA, error) {
 	}, nil
 }
 
+// maxRedirects is the maximum number of 3xx redirect hops before giving up.
+const maxRedirects = 3
+
 // dial establishes an outbound SIP dialog using sipgo's dialog API.
 // It sends INVITE with SDP, waits for the answer (handling provisionals via
-// onResponse), sends ACK, and returns a sipgoDialogUAC.
+// onResponse and 3xx redirects), sends ACK, and returns a sipgoDialogUAC.
 //
 // target may be a full SIP URI ("sip:1002@pbx.example.com") or just the
 // user part ("1002"), in which case the configured Host and Port are used.
 func (s *sipUA) dial(ctx context.Context, target string, onResponse func(code int, reason string)) (dialog, error) {
+	currentTarget := target
+	for redirects := 0; ; redirects++ {
+		dlg, redirectURI, err := s.dialOnce(ctx, currentTarget, onResponse)
+		if err != nil {
+			return nil, err
+		}
+		if redirectURI == "" {
+			return dlg, nil
+		}
+		// 3xx redirect — retry with the new target.
+		if redirects+1 > maxRedirects {
+			return nil, fmt.Errorf("xphone: too many redirects (max %d)", maxRedirects)
+		}
+		currentTarget = redirectURI
+	}
+}
+
+// dialOnce sends a single INVITE attempt. Returns (dialog, "", nil) on success,
+// or (nil, redirectURI, nil) on 3xx redirect.
+func (s *sipUA) dialOnce(ctx context.Context, target string, onResponse func(code int, reason string)) (dialog, string, error) {
 	recipient := parseSIPTarget(target, s.cfg.Host, s.cfg.Port)
 
 	// Build SDP offer with cached local IP and an allocated RTP port.
 	ip := s.localIP
 	rtpConn, err := listenRTPPort(s.cfg.RTPPortMin, s.cfg.RTPPortMax)
 	if err != nil {
-		return nil, fmt.Errorf("xphone: allocate RTP port: %w", err)
+		return nil, "", fmt.Errorf("xphone: allocate RTP port: %w", err)
 	}
 	rtpPort := rtpConn.LocalAddr().(*net.UDPAddr).Port
 	codecPT := codecPrefsToInts(s.cfg.CodecPrefs)
@@ -149,7 +184,7 @@ func (s *sipUA) dial(ctx context.Context, target string, onResponse func(code in
 		key, err := srtp.GenerateKeyingMaterial()
 		if err != nil {
 			rtpConn.Close()
-			return nil, fmt.Errorf("xphone: generate SRTP key: %w", err)
+			return nil, "", fmt.Errorf("xphone: generate SRTP key: %w", err)
 		}
 		srtpLocalKey = key
 		sdpOffer = sdp.BuildOfferSRTP(ip, rtpPort, codecPT, sdp.DirSendRecv, key)
@@ -164,7 +199,7 @@ func (s *sipUA) dial(ctx context.Context, target string, onResponse func(code in
 	sess, err := s.dc.Invite(ctx, recipient, []byte(sdpOffer), contentType)
 	if err != nil {
 		rtpConn.Close()
-		return nil, fmt.Errorf("xphone: invite: %w", err)
+		return nil, "", fmt.Errorf("xphone: invite: %w", err)
 	}
 
 	// Ensure cleanup on any error after Invite succeeds.
@@ -191,12 +226,25 @@ func (s *sipUA) dial(ctx context.Context, target string, onResponse func(code in
 		Password: s.cfg.Password,
 	})
 	if err != nil {
-		return nil, err
+		// Check for 3xx redirect.
+		var errResp *sipgo.ErrDialogResponse
+		if errors.As(err, &errResp) && errResp.Res.StatusCode >= 300 && errResp.Res.StatusCode < 400 {
+			contact := errResp.Res.Contact()
+			if contact == nil {
+				return nil, "", fmt.Errorf("xphone: %d redirect with no Contact header", errResp.Res.StatusCode)
+			}
+			newTarget := contact.Address.String()
+			if newTarget == "" {
+				return nil, "", fmt.Errorf("xphone: %d redirect with empty Contact URI", errResp.Res.StatusCode)
+			}
+			return nil, newTarget, nil
+		}
+		return nil, "", err
 	}
 
 	// ACK the 200 OK.
 	if err := sess.Ack(ctx); err != nil {
-		return nil, fmt.Errorf("xphone: ack: %w", err)
+		return nil, "", fmt.Errorf("xphone: ack: %w", err)
 	}
 
 	ok = true
@@ -209,7 +257,7 @@ func (s *sipUA) dial(ctx context.Context, target string, onResponse func(code in
 		cancelFn:     waitCancel,
 		rtpConn:      rtpConn,
 		srtpLocalKey: srtpLocalKey,
-	}, nil
+	}, "", nil
 }
 
 // startServer registers sipgo server handlers for inbound SIP requests.


### PR DESCRIPTION
## Summary
- Refactor `dial()` into `dial()` + `dialOnce()` retry loop that detects 3xx responses via `ErrDialogResponse`, extracts Contact URI, and re-INVITEs the new target (max 3 hops)
- Fix `parseSIPTarget` to properly parse `host:port` from full SIP URIs — was defaulting to port 0, causing redirected INVITEs to go to port 5060 instead of the actual target
- Use sipgo's typed `res.Contact()` accessor instead of hand-parsed `sipHeaderURI` for redirect Contact extraction

## Test plan
- [x] `TestFakePBX_Dial302Redirect` — 302 followed to new target, call established
- [x] `TestFakePBX_Dial302NoContact` — 302 with no Contact header returns error
- [x] `TestFakePBX_Dial302TooManyRedirects` — redirect loop capped at 3 hops
- [x] `TestFakePBX_Dial302AfterProvisional` — 100 Trying then 302 handled correctly
- [x] `make check` passes (fmt, build, test, vet, race)