### PR TITLE
Add SRTP replay protection (RFC 3711 §3.3.2)

### DIFF
--- a/internal/srtp/srtp.go
+++ b/internal/srtp/srtp.go
@@ -31,6 +31,91 @@ const (
 	CryptoSuite = "AES_CM_128_HMAC_SHA1_80"
 )
 
+// replayWindowSize is the number of packets tracked by the sliding window.
+// Covers ~2.5 seconds of audio at 50 packets/second.
+// Must not exceed 128 (bitmap is uint128).
+const replayWindowSize = 128
+
+// Compile-time assert: replayWindowSize <= 128.
+const _ = uint(128 - replayWindowSize)
+
+// replayWindow implements sliding-window replay protection per RFC 3711 §3.3.2.
+// Tracks the highest accepted packet index and a bitmask of which of the
+// previous replayWindowSize packets have been received.
+type replayWindow struct {
+	top         uint64  // highest accepted 48-bit packet index
+	bitmap      uint128 // bit 0 = top, bit 1 = top-1, etc.
+	initialized bool
+}
+
+// uint128 represents a 128-bit unsigned integer as two 64-bit halves.
+type uint128 struct {
+	hi, lo uint64
+}
+
+func (u uint128) bit(n uint64) uint64 {
+	if n < 64 {
+		return (u.lo >> n) & 1
+	}
+	return (u.hi >> (n - 64)) & 1
+}
+
+func (u uint128) setBit(n uint64) uint128 {
+	if n < 64 {
+		return uint128{u.hi, u.lo | (1 << n)}
+	}
+	return uint128{u.hi | (1 << (n - 64)), u.lo}
+}
+
+func (u uint128) shl(n uint64) uint128 {
+	if n >= 128 {
+		return uint128{}
+	}
+	if n >= 64 {
+		return uint128{u.lo << (n - 64), 0}
+	}
+	return uint128{(u.hi << n) | (u.lo >> (64 - n)), u.lo << n}
+}
+
+// isReplay returns true if the packet should be rejected (duplicate or too old).
+func (w *replayWindow) isReplay(index uint64) bool {
+	if !w.initialized {
+		return false
+	}
+	if index > w.top {
+		return false
+	}
+	delta := w.top - index
+	if delta >= replayWindowSize {
+		return true
+	}
+	return w.bitmap.bit(delta) == 1
+}
+
+// accept marks a packet index as received. Call only after successful authentication.
+func (w *replayWindow) accept(index uint64) {
+	if !w.initialized {
+		w.top = index
+		w.bitmap = uint128{0, 1}
+		w.initialized = true
+		return
+	}
+	if index > w.top {
+		shift := index - w.top
+		if shift >= replayWindowSize {
+			w.bitmap = uint128{0, 1}
+		} else {
+			w.bitmap = w.bitmap.shl(shift).setBit(0)
+		}
+		w.top = index
+	} else {
+		delta := w.top - index
+		if delta < replayWindowSize {
+			w.bitmap = w.bitmap.setBit(delta)
+		}
+	}
+}
+
 // Context holds the derived session keys for one direction of SRTP.
 type Context struct {
 	sessionSalt [14]byte // session salt
@@ -40,6 +125,8 @@ type Context struct {
 	roc            uint32 // rollover counter
 	lastSeq        uint16
 	seqInitialized bool
+
+	replay replayWindow // replay protection (used by Unprotect only)
 }
 
 // New derives session keys from master key (16 bytes) and master salt (14 bytes).
@@ -139,16 +226,27 @@ func (c *Context) Unprotect(srtpPacket []byte) ([]byte, error) {
 	estimatedROC := c.estimateROC(seq)
 	index := (uint64(estimatedROC) << 16) | uint64(seq)
 
+	// Replay check (RFC 3711 §3.3.2) — cheap, before expensive HMAC.
+	if c.replay.isReplay(index) {
+		return nil, fmt.Errorf("srtp: replay detected")
+	}
+
 	// Verify auth tag.
 	expectedTag := c.computeAuthTag(authPortion, estimatedROC)
 	if subtle.ConstantTimeCompare(receivedTag, expectedTag[:]) != 1 {
 		return nil, fmt.Errorf("srtp: authentication failed")
 	}
 
-	// Auth verified — commit ROC update.
-	c.roc = estimatedROC
-	c.lastSeq = seq
-	c.seqInitialized = true
+	// Auth verified — commit replay window and ROC/seq state.
+	// Only advance ROC/lastSeq when this packet's index exceeds the current
+	// highest (RFC 3711 §3.3.1: s_l tracks the highest received index).
+	c.replay.accept(index)
+	currentHighest := (uint64(c.roc) << 16) | uint64(c.lastSeq)
+	if !c.seqInitialized || index > currentHighest {
+		c.roc = estimatedROC
+		c.lastSeq = seq
+		c.seqInitialized = true
+	}
 
 	// Decrypt payload.
 	rtp := make([]byte, authOffset)

--- a/internal/srtp/srtp_test.go
+++ b/internal/srtp/srtp_test.go
@@ -239,6 +239,133 @@ func TestEmptyPayload(t *testing.T) {
 	assert.Equal(t, original, decrypted)
 }
 
+// --- Replay window unit tests ---
+
+func TestReplayWindowRejectsDuplicate(t *testing.T) {
+	var w replayWindow
+	assert.False(t, w.isReplay(100))
+	w.accept(100)
+	assert.True(t, w.isReplay(100)) // exact duplicate
+}
+
+func TestReplayWindowAcceptsNewPackets(t *testing.T) {
+	var w replayWindow
+	for i := uint64(0); i < 200; i++ {
+		assert.False(t, w.isReplay(i))
+		w.accept(i)
+	}
+}
+
+func TestReplayWindowRejectsOldPackets(t *testing.T) {
+	var w replayWindow
+	w.accept(200)
+	assert.True(t, w.isReplay(200-replayWindowSize)) // just outside window
+	assert.True(t, w.isReplay(0))                    // way too old
+}
+
+func TestReplayWindowAcceptsOutOfOrderWithinWindow(t *testing.T) {
+	var w replayWindow
+	for i := uint64(0); i <= 50; i++ {
+		w.accept(i)
+	}
+	// Jump ahead.
+	w.accept(100)
+	// Packets 51..99 are within window and not yet seen.
+	for i := uint64(51); i < 100; i++ {
+		assert.False(t, w.isReplay(i), "packet %d should not be a replay", i)
+		w.accept(i)
+	}
+	// All should now be replays.
+	for i := uint64(0); i <= 100; i++ {
+		assert.True(t, w.isReplay(i), "packet %d should be a replay", i)
+	}
+}
+
+func TestReplayWindowBoundary(t *testing.T) {
+	var w replayWindow
+	w.accept(replayWindowSize)     // top = 128
+	assert.False(t, w.isReplay(1)) // delta=127, within window
+	assert.True(t, w.isReplay(0))  // delta=128, too old
+}
+
+func TestReplayWindowLargeJump(t *testing.T) {
+	var w replayWindow
+	w.accept(0)
+	w.accept(1000)
+	assert.True(t, w.isReplay(1000))  // duplicate
+	assert.True(t, w.isReplay(0))     // way behind window
+	assert.False(t, w.isReplay(999))  // within window, not yet seen
+	assert.False(t, w.isReplay(1001)) // ahead of top
+}
+
+// --- SRTP replay integration tests ---
+
+func TestSRTPReplayDetected(t *testing.T) {
+	sender, receiver := testContext()
+
+	rtp := makeTestRTP(1, 160, 0x12345678, []byte("audio"))
+	protected, err := sender.Protect(rtp)
+	require.NoError(t, err)
+
+	// First unprotect succeeds.
+	_, err = receiver.Unprotect(protected)
+	require.NoError(t, err)
+
+	// Replay of the same packet is rejected.
+	_, err = receiver.Unprotect(protected)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replay")
+}
+
+func TestSRTPOutOfOrderWithinWindowOK(t *testing.T) {
+	sender, receiver := testContext()
+
+	// Protect packets 1..=5.
+	protected := make([][]byte, 5)
+	for i := 0; i < 5; i++ {
+		seq := uint16(i + 1)
+		rtp := makeTestRTP(seq, uint32(seq)*160, 0xAABBCCDD, []byte{byte(seq)})
+		p, err := sender.Protect(rtp)
+		require.NoError(t, err)
+		protected[i] = p
+	}
+
+	// Receive out of order: 5, 3, 1, 2, 4.
+	for _, idx := range []int{4, 2, 0, 1, 3} {
+		_, err := receiver.Unprotect(protected[idx])
+		assert.NoError(t, err, "seq %d should succeed", idx+1)
+	}
+
+	// All should now be replays.
+	for i, pkt := range protected {
+		_, err := receiver.Unprotect(pkt)
+		assert.Error(t, err, "seq %d should be rejected as replay", i+1)
+	}
+}
+
+func TestSRTPOldPacketRejected(t *testing.T) {
+	sender, receiver := testContext()
+
+	// Protect and save packet with seq=1.
+	oldRTP := makeTestRTP(1, 160, 0x12345678, []byte("old"))
+	oldProtected, err := sender.Protect(oldRTP)
+	require.NoError(t, err)
+
+	// Send 200 more packets to push seq=1 out of the window.
+	for seq := uint16(2); seq < 202; seq++ {
+		rtp := makeTestRTP(seq, uint32(seq)*160, 0x12345678, []byte{byte(seq)})
+		p, err := sender.Protect(rtp)
+		require.NoError(t, err)
+		_, err = receiver.Unprotect(p)
+		require.NoError(t, err)
+	}
+
+	// Old packet (seq=1) is now behind the window.
+	_, err = receiver.Unprotect(oldProtected)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replay")
+}
+
 func TestDeriveSessionKeyDeterministic(t *testing.T) {
 	var key [16]byte
 	var salt [14]byte


### PR DESCRIPTION
## Summary
- 128-packet sliding window using a zero-allocation `uint128` bitmap rejects duplicate and too-old packets before the expensive HMAC check
- ROC/lastSeq only advance on the highest received index, per RFC 3711 §3.3.1 (bug caught by Codex review — unconditional update regressed state on out-of-order packets)
- Compile-time assert ensures `replayWindowSize <= 128`

## Test plan
- [x] 6 unit tests for `replayWindow`: duplicate, sequential, old, out-of-order, boundary, large jump
- [x] 3 SRTP integration tests: replay detected, out-of-order within window, old packet rejected
- [x] All existing SRTP tests pass (round-trip, auth failure, ROC rollover, etc.)
- [x] `make check` passes (fmt, build, test, vet, race)