### PR TITLE
Add basic RTCP support (RFC 3550)

### DIFF
--- a/call.go
+++ b/call.go
@@ -162,6 +162,7 @@ type call struct {
 	rtpPortMin  int            // minimum RTP port (0 = OS-assigned)
 	rtpPortMax  int            // maximum RTP port (0 = OS-assigned)
 	rtpConn     net.PacketConn // bound UDP socket to keep port reserved
+	rtcpConn    net.PacketConn // RTCP socket (RTP port + 1), nil if bind fails
 	remoteAddr  net.Addr       // remote RTP endpoint (from remote SDP)
 	remoteIP    string         // cached remote IP (from remote SDP)
 	remotePort  int            // cached remote port (from remote SDP)
@@ -580,7 +581,11 @@ func (c *call) fireOnEnded(reason EndReason) {
 		}
 		c.mediaActive = false
 	}
-	// Close RTP socket (also stops the RTP reader goroutine).
+	// Close RTP and RTCP sockets (also stops the RTP reader goroutine).
+	if c.rtcpConn != nil {
+		c.rtcpConn.Close()
+		c.rtcpConn = nil
+	}
 	if c.rtpConn != nil {
 		c.rtpConn.Close()
 		c.rtpConn = nil

--- a/internal/rtcp/rtcp.go
+++ b/internal/rtcp/rtcp.go
@@ -1,0 +1,362 @@
+// Package rtcp implements basic RTCP (RFC 3550) Sender/Receiver Reports
+// for trunk compatibility. Most SIP trunks expect periodic RTCP traffic
+// and may tear down calls if none is received.
+package rtcp
+
+import (
+	"encoding/binary"
+	"time"
+)
+
+const (
+	ptSR      = 200 // Sender Report (RFC 3550 §6.4.1)
+	ptRR      = 201 // Receiver Report (RFC 3550 §6.4.2)
+	rtcpVer   = 2   // RTCP version (matches RTP)
+	reportLen = 24  // bytes per report block
+
+	// NTPEpochOffset is seconds between 1900-01-01 and 1970-01-01.
+	ntpEpochOffset = 2_208_988_800
+
+	// IntervalSecs is the minimum RTCP send interval (RFC 3550 §6.2).
+	IntervalSecs = 5
+)
+
+// Stats tracks RTP statistics for RTCP report generation.
+type Stats struct {
+	// Outbound (for SR sender info).
+	PacketsSent      uint32
+	OctetsSent       uint32
+	LastRTPTimestamp uint32
+
+	// Inbound (for RR report block).
+	PacketsReceived uint32
+	RemoteSSRC      uint32
+
+	// Sequence tracking for loss calculation.
+	baseSeq        uint16
+	maxSeq         uint16
+	cycles         uint32
+	seqInitialized bool
+
+	// Jitter calculation (RFC 3550 A.8).
+	jitter            float64
+	prevTransit       int64
+	jitterInitialized bool
+	baseline          time.Time // monotonic baseline for RTP clock conversion
+
+	// Loss fraction between RR intervals.
+	expectedPrior uint32
+	receivedPrior uint32
+
+	// Round-trip time: middle 32 bits of last received SR NTP timestamp.
+	lastSRNTPMiddle uint32
+	lastSRRecvTime  time.Time
+	lastSRReceived  bool
+}
+
+// NewStats creates a new stats tracker.
+func NewStats() *Stats {
+	return &Stats{baseline: time.Now()}
+}
+
+// RecordRTPSent records an outbound RTP packet for SR sender info.
+func (s *Stats) RecordRTPSent(payloadLen int, rtpTimestamp uint32) {
+	s.PacketsSent++
+	s.OctetsSent += uint32(payloadLen)
+	s.LastRTPTimestamp = rtpTimestamp
+}
+
+// RecordRTPReceived records an inbound RTP packet for RR report block.
+func (s *Stats) RecordRTPReceived(seq uint16, timestamp uint32, ssrc uint32, clockRate uint32) {
+	s.PacketsReceived++
+	s.RemoteSSRC = ssrc
+
+	if !s.seqInitialized {
+		s.baseSeq = seq
+		s.maxSeq = seq
+		s.seqInitialized = true
+	} else {
+		udelta := seq - s.maxSeq
+		if udelta < 0x8000 {
+			if seq < s.maxSeq {
+				s.cycles++
+			}
+			s.maxSeq = seq
+		}
+	}
+
+	// Jitter calculation per RFC 3550 A.8.
+	if clockRate > 0 {
+		elapsed := time.Since(s.baseline)
+		arrival := int64(elapsed.Seconds() * float64(clockRate))
+		transit := arrival - int64(timestamp)
+		if s.jitterInitialized {
+			d := transit - s.prevTransit
+			if d < 0 {
+				d = -d
+			}
+			s.jitter += (float64(d) - s.jitter) / 16.0
+		}
+		s.prevTransit = transit
+		s.jitterInitialized = true
+	}
+}
+
+// ProcessIncomingSR records a received SR's NTP timestamp for RTT calculation.
+func (s *Stats) ProcessIncomingSR(ntpSec, ntpFrac uint32) {
+	s.lastSRNTPMiddle = ((ntpSec & 0xFFFF) << 16) | ((ntpFrac >> 16) & 0xFFFF)
+	s.lastSRRecvTime = time.Now()
+	s.lastSRReceived = true
+}
+
+func (s *Stats) extendedMaxSeq() uint32 {
+	return (s.cycles << 16) | uint32(s.maxSeq)
+}
+
+func (s *Stats) expected() uint32 {
+	if !s.seqInitialized {
+		return 0
+	}
+	return s.extendedMaxSeq() - uint32(s.baseSeq) + 1
+}
+
+func (s *Stats) cumulativeLost() uint32 {
+	exp := s.expected()
+	if s.PacketsReceived >= exp {
+		return 0
+	}
+	return exp - s.PacketsReceived
+}
+
+func (s *Stats) fractionLost() uint8 {
+	exp := s.expected()
+	expectedInterval := exp - s.expectedPrior
+	receivedInterval := s.PacketsReceived - s.receivedPrior
+	s.expectedPrior = exp
+	s.receivedPrior = s.PacketsReceived
+
+	if expectedInterval == 0 || receivedInterval >= expectedInterval {
+		return 0
+	}
+	lostInterval := expectedInterval - receivedInterval
+	frac := (lostInterval * 256) / expectedInterval
+	if frac > 255 {
+		return 255
+	}
+	return uint8(frac)
+}
+
+func (s *Stats) delaySinceLastSR() uint32 {
+	if !s.lastSRReceived {
+		return 0
+	}
+	elapsed := time.Since(s.lastSRRecvTime)
+	secs := uint32(elapsed.Seconds())
+	frac := uint32((uint64(elapsed.Nanoseconds()%1e9) * 65536) / 1_000_000_000)
+	return (secs << 16) | (frac & 0xFFFF)
+}
+
+// NTPNow returns the current time as an NTP timestamp.
+func NTPNow() (sec, frac uint32) {
+	now := time.Now()
+	unix := now.Unix()
+	sec = uint32(uint64(unix) + ntpEpochOffset)
+	frac = uint32((uint64(now.Nanosecond()) * (1 << 32)) / 1_000_000_000)
+	return
+}
+
+// BuildSR builds an RTCP Sender Report (RFC 3550 §6.4.1).
+// Includes one RR report block if we've received at least one RTP packet.
+func BuildSR(ssrc uint32, stats *Stats) []byte {
+	hasReport := stats.seqInitialized
+	rc := byte(0)
+	if hasReport {
+		rc = 1
+	}
+
+	ntpSec, ntpFrac := NTPNow()
+
+	lengthWords := uint16(6) // 28/4 - 1
+	if hasReport {
+		lengthWords = 12 // (28+24)/4 - 1
+	}
+	totalLen := int(lengthWords+1) * 4
+
+	buf := make([]byte, 0, totalLen)
+
+	// Header: V=2, P=0, RC, PT=200.
+	buf = append(buf, (rtcpVer<<6)|rc)
+	buf = append(buf, ptSR)
+	buf = binary.BigEndian.AppendUint16(buf, lengthWords)
+
+	// SSRC.
+	buf = binary.BigEndian.AppendUint32(buf, ssrc)
+
+	// NTP timestamp.
+	buf = binary.BigEndian.AppendUint32(buf, ntpSec)
+	buf = binary.BigEndian.AppendUint32(buf, ntpFrac)
+
+	// RTP timestamp.
+	buf = binary.BigEndian.AppendUint32(buf, stats.LastRTPTimestamp)
+
+	// Sender's packet count & octet count.
+	buf = binary.BigEndian.AppendUint32(buf, stats.PacketsSent)
+	buf = binary.BigEndian.AppendUint32(buf, stats.OctetsSent)
+
+	if hasReport {
+		buf = appendReportBlock(buf, stats)
+	}
+
+	return buf
+}
+
+// BuildRR builds an RTCP Receiver Report (RFC 3550 §6.4.2).
+func BuildRR(ssrc uint32, stats *Stats) []byte {
+	hasReport := stats.seqInitialized
+	rc := byte(0)
+	if hasReport {
+		rc = 1
+	}
+
+	lengthWords := uint16(1) // 8/4 - 1
+	if hasReport {
+		lengthWords = 7 // (8+24)/4 - 1
+	}
+	totalLen := int(lengthWords+1) * 4
+
+	buf := make([]byte, 0, totalLen)
+
+	// Header: V=2, P=0, RC, PT=201.
+	buf = append(buf, (rtcpVer<<6)|rc)
+	buf = append(buf, ptRR)
+	buf = binary.BigEndian.AppendUint16(buf, lengthWords)
+
+	// SSRC.
+	buf = binary.BigEndian.AppendUint32(buf, ssrc)
+
+	if hasReport {
+		buf = appendReportBlock(buf, stats)
+	}
+
+	return buf
+}
+
+func appendReportBlock(buf []byte, stats *Stats) []byte {
+	// SSRC of source being reported.
+	buf = binary.BigEndian.AppendUint32(buf, stats.RemoteSSRC)
+
+	fractionLost := stats.fractionLost()
+	cumLost := stats.cumulativeLost()
+	if cumLost > 0x7FFFFF {
+		cumLost = 0x7FFFFF
+	}
+
+	// Fraction lost (8 bits) + cumulative lost (24 bits).
+	buf = append(buf, fractionLost)
+	buf = append(buf, byte((cumLost>>16)&0xFF))
+	buf = append(buf, byte((cumLost>>8)&0xFF))
+	buf = append(buf, byte(cumLost&0xFF))
+
+	// Extended highest sequence number.
+	buf = binary.BigEndian.AppendUint32(buf, stats.extendedMaxSeq())
+
+	// Interarrival jitter.
+	buf = binary.BigEndian.AppendUint32(buf, uint32(stats.jitter))
+
+	// Last SR (LSR).
+	buf = binary.BigEndian.AppendUint32(buf, stats.lastSRNTPMiddle)
+
+	// Delay since last SR (DLSR).
+	buf = binary.BigEndian.AppendUint32(buf, stats.delaySinceLastSR())
+
+	return buf
+}
+
+// ReportBlock is a parsed RTCP report block.
+type ReportBlock struct {
+	SSRC         uint32
+	FractionLost uint8
+	CumLost      uint32
+	HighestSeq   uint32
+	Jitter       uint32
+	LastSR       uint32
+	DelaySinceSR uint32
+}
+
+// Packet is a parsed RTCP packet.
+type Packet struct {
+	Type         uint8 // ptSR or ptRR
+	SSRC         uint32
+	NTPSec       uint32 // SR only
+	NTPFrac      uint32 // SR only
+	RTPTimestamp uint32 // SR only
+	PacketCount  uint32 // SR only
+	OctetCount   uint32 // SR only
+	Reports      []ReportBlock
+}
+
+// IsSenderReport returns true if the packet is an SR.
+func (p *Packet) IsSenderReport() bool { return p.Type == ptSR }
+
+// Parse parses an RTCP packet from raw bytes. Returns nil for unknown types or truncated data.
+func Parse(data []byte) *Packet {
+	if len(data) < 8 {
+		return nil
+	}
+	version := (data[0] >> 6) & 0x03
+	if version != rtcpVer {
+		return nil
+	}
+	rc := data[0] & 0x1F
+	pt := data[1]
+	ssrc := binary.BigEndian.Uint32(data[4:8])
+
+	switch pt {
+	case ptSR:
+		if len(data) < 28 {
+			return nil
+		}
+		p := &Packet{
+			Type:         ptSR,
+			SSRC:         ssrc,
+			NTPSec:       binary.BigEndian.Uint32(data[8:12]),
+			NTPFrac:      binary.BigEndian.Uint32(data[12:16]),
+			RTPTimestamp: binary.BigEndian.Uint32(data[16:20]),
+			PacketCount:  binary.BigEndian.Uint32(data[20:24]),
+			OctetCount:   binary.BigEndian.Uint32(data[24:28]),
+			Reports:      parseReportBlocks(data[28:], rc),
+		}
+		return p
+
+	case ptRR:
+		return &Packet{
+			Type:    ptRR,
+			SSRC:    ssrc,
+			Reports: parseReportBlocks(data[8:], rc),
+		}
+
+	default:
+		return nil
+	}
+}
+
+func parseReportBlocks(data []byte, count uint8) []ReportBlock {
+	blocks := make([]ReportBlock, 0, int(count))
+	for i := 0; i < int(count); i++ {
+		off := i * reportLen
+		if off+reportLen > len(data) {
+			break
+		}
+		b := data[off : off+reportLen]
+		blocks = append(blocks, ReportBlock{
+			SSRC:         binary.BigEndian.Uint32(b[0:4]),
+			FractionLost: b[4],
+			CumLost:      uint32(b[5])<<16 | uint32(b[6])<<8 | uint32(b[7]),
+			HighestSeq:   binary.BigEndian.Uint32(b[8:12]),
+			Jitter:       binary.BigEndian.Uint32(b[12:16]),
+			LastSR:       binary.BigEndian.Uint32(b[16:20]),
+			DelaySinceSR: binary.BigEndian.Uint32(b[20:24]),
+		})
+	}
+	return blocks
+}

--- a/internal/rtcp/rtcp_test.go
+++ b/internal/rtcp/rtcp_test.go
@@ -1,0 +1,232 @@
+package rtcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNTPTimestampReasonable(t *testing.T) {
+	sec, _ := NTPNow()
+	// NTP timestamp for 2024-01-01 is ~3,913,056,000.
+	assert.Greater(t, sec, uint32(3_900_000_000), "NTP sec too low")
+}
+
+func TestBuildSRNoReportBlock(t *testing.T) {
+	stats := NewStats()
+	stats.PacketsSent = 100
+	stats.OctetsSent = 16000
+	stats.LastRTPTimestamp = 320000
+
+	sr := BuildSR(0xDEADBEEF, stats)
+	assert.Equal(t, 28, len(sr))
+
+	// Version=2, RC=0, PT=200.
+	assert.Equal(t, byte(2), (sr[0]>>6)&0x03)
+	assert.Equal(t, byte(0), sr[0]&0x1F)
+	assert.Equal(t, byte(200), sr[1])
+
+	// SSRC.
+	assert.Equal(t, uint32(0xDEADBEEF), be32(sr[4:8]))
+
+	// Packet count.
+	assert.Equal(t, uint32(100), be32(sr[20:24]))
+	// Octet count.
+	assert.Equal(t, uint32(16000), be32(sr[24:28]))
+}
+
+func TestBuildSRWithReportBlock(t *testing.T) {
+	stats := NewStats()
+	stats.PacketsSent = 50
+	stats.OctetsSent = 8000
+	stats.LastRTPTimestamp = 160000
+
+	stats.RecordRTPReceived(42, 6720, 0xCAFEBABE, 8000)
+
+	sr := BuildSR(0x12345678, stats)
+	assert.Equal(t, 52, len(sr)) // 28 + 24
+
+	// RC=1.
+	assert.Equal(t, byte(1), sr[0]&0x1F)
+
+	// Report block SSRC.
+	assert.Equal(t, uint32(0xCAFEBABE), be32(sr[28:32]))
+}
+
+func TestBuildRRFormat(t *testing.T) {
+	stats := NewStats()
+	rr := BuildRR(0xABCD1234, stats)
+	assert.Equal(t, 8, len(rr))
+
+	assert.Equal(t, byte(2), (rr[0]>>6)&0x03)
+	assert.Equal(t, byte(0), rr[0]&0x1F)
+	assert.Equal(t, byte(201), rr[1])
+	assert.Equal(t, uint32(0xABCD1234), be32(rr[4:8]))
+}
+
+func TestBuildRRWithReportBlock(t *testing.T) {
+	stats := NewStats()
+	stats.RecordRTPReceived(10, 1600, 0x11111111, 8000)
+
+	rr := BuildRR(0x22222222, stats)
+	assert.Equal(t, 32, len(rr)) // 8 + 24
+	assert.Equal(t, byte(1), rr[0]&0x1F)
+}
+
+func TestParseSR(t *testing.T) {
+	stats := NewStats()
+	stats.PacketsSent = 200
+	stats.OctetsSent = 32000
+	stats.LastRTPTimestamp = 640000
+
+	sr := BuildSR(0xAAAAAAAA, stats)
+	parsed := Parse(sr)
+	require.NotNil(t, parsed)
+
+	assert.True(t, parsed.IsSenderReport())
+	assert.Equal(t, uint32(0xAAAAAAAA), parsed.SSRC)
+	assert.Equal(t, uint32(200), parsed.PacketCount)
+	assert.Equal(t, uint32(32000), parsed.OctetCount)
+	assert.Equal(t, uint32(640000), parsed.RTPTimestamp)
+	assert.Empty(t, parsed.Reports)
+}
+
+func TestParseRR(t *testing.T) {
+	stats := NewStats()
+	rr := BuildRR(0xBBBBBBBB, stats)
+	parsed := Parse(rr)
+	require.NotNil(t, parsed)
+
+	assert.False(t, parsed.IsSenderReport())
+	assert.Equal(t, uint32(0xBBBBBBBB), parsed.SSRC)
+	assert.Empty(t, parsed.Reports)
+}
+
+func TestParseTooShort(t *testing.T) {
+	assert.Nil(t, Parse(nil))
+	assert.Nil(t, Parse([]byte{0x80, 200, 0, 0})) // only 4 bytes
+}
+
+func TestParseUnknownPT(t *testing.T) {
+	data := []byte{0x80, 202, 0, 1, 0, 0, 0, 0} // PT=202 (SDES)
+	assert.Nil(t, Parse(data))
+}
+
+func TestParseBadVersion(t *testing.T) {
+	data := make([]byte, 28)
+	data[0] = 0x40 // Version=1
+	data[1] = 200
+	assert.Nil(t, Parse(data))
+}
+
+func TestRecordRTPSent(t *testing.T) {
+	stats := NewStats()
+	stats.RecordRTPSent(160, 0)
+	stats.RecordRTPSent(160, 160)
+	stats.RecordRTPSent(160, 320)
+
+	assert.Equal(t, uint32(3), stats.PacketsSent)
+	assert.Equal(t, uint32(480), stats.OctetsSent)
+	assert.Equal(t, uint32(320), stats.LastRTPTimestamp)
+}
+
+func TestRecordRTPReceivedSeqTracking(t *testing.T) {
+	stats := NewStats()
+	for seq := uint16(0); seq < 5; seq++ {
+		stats.RecordRTPReceived(seq, uint32(seq)*160, 1234, 8000)
+	}
+
+	assert.Equal(t, uint32(5), stats.PacketsReceived)
+	assert.Equal(t, uint16(4), stats.maxSeq)
+	assert.Equal(t, uint16(0), stats.baseSeq)
+	assert.Equal(t, uint32(0), stats.cycles)
+	assert.Equal(t, uint32(4), stats.extendedMaxSeq())
+}
+
+func TestSeqWraparound(t *testing.T) {
+	stats := NewStats()
+	for _, seq := range []uint16{65534, 65535, 0, 1, 2} {
+		stats.RecordRTPReceived(seq, 0, 1234, 0)
+	}
+
+	assert.Equal(t, uint16(2), stats.maxSeq)
+	assert.Equal(t, uint32(1), stats.cycles)
+	// Extended: (1 << 16) | 2 = 65538.
+	assert.Equal(t, uint32(65538), stats.extendedMaxSeq())
+}
+
+func TestLossFractionCalculation(t *testing.T) {
+	stats := NewStats()
+	// Receive packets 0, 1, 2, 4, 5 (skip 3).
+	for _, seq := range []uint16{0, 1, 2, 4, 5} {
+		stats.RecordRTPReceived(seq, 0, 1234, 0)
+	}
+
+	assert.Equal(t, uint32(1), stats.cumulativeLost())
+	assert.Equal(t, uint32(6), stats.expected()) // 0..=5
+
+	// fraction_lost should be ~42 (1/6 * 256 = 42.67).
+	frac := stats.fractionLost()
+	assert.Equal(t, uint8(42), frac)
+}
+
+func TestSRRoundTripBuildParse(t *testing.T) {
+	stats := NewStats()
+	stats.PacketsSent = 1000
+	stats.OctetsSent = 160000
+	stats.LastRTPTimestamp = 160000
+
+	for seq := uint16(0); seq < 10; seq++ {
+		stats.RecordRTPReceived(seq, uint32(seq)*160, 0xFEEDFACE, 8000)
+	}
+
+	sr := BuildSR(0x99887766, stats)
+	parsed := Parse(sr)
+	require.NotNil(t, parsed)
+
+	assert.True(t, parsed.IsSenderReport())
+	assert.Equal(t, uint32(0x99887766), parsed.SSRC)
+	assert.Equal(t, uint32(1000), parsed.PacketCount)
+	assert.Equal(t, uint32(160000), parsed.OctetCount)
+	assert.Equal(t, uint32(160000), parsed.RTPTimestamp)
+	require.Len(t, parsed.Reports, 1)
+	assert.Equal(t, uint32(0xFEEDFACE), parsed.Reports[0].SSRC)
+	assert.Equal(t, uint32(9), parsed.Reports[0].HighestSeq)
+}
+
+func TestProcessIncomingSRStoresNTP(t *testing.T) {
+	stats := NewStats()
+	stats.ProcessIncomingSR(0xAABBCCDD, 0x11223344)
+
+	// Middle 32 bits: low 16 of sec (0xCCDD) << 16 | high 16 of frac (0x1122).
+	assert.Equal(t, uint32(0xCCDD1122), stats.lastSRNTPMiddle)
+	assert.True(t, stats.lastSRReceived)
+}
+
+func TestDelaySinceLastSRZeroWhenNoSR(t *testing.T) {
+	stats := NewStats()
+	assert.Equal(t, uint32(0), stats.delaySinceLastSR())
+}
+
+func TestParseSRWithReportBlock(t *testing.T) {
+	stats := NewStats()
+	stats.PacketsSent = 50
+	stats.OctetsSent = 8000
+
+	stats.RecordRTPReceived(100, 16000, 0x55555555, 8000)
+
+	sr := BuildSR(0x66666666, stats)
+	parsed := Parse(sr)
+	require.NotNil(t, parsed)
+
+	require.Len(t, parsed.Reports, 1)
+	assert.Equal(t, uint32(0x55555555), parsed.Reports[0].SSRC)
+	assert.Equal(t, uint32(100), parsed.Reports[0].HighestSeq)
+	assert.Equal(t, uint32(0), parsed.Reports[0].CumLost)
+}
+
+// be32 is a test helper to read a big-endian uint32.
+func be32(b []byte) uint32 {
+	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+}

--- a/media.go
+++ b/media.go
@@ -3,10 +3,13 @@ package xphone
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/pion/rtp"
 	"github.com/x-phone/xphone-go/internal/media"
+	"github.com/x-phone/xphone-go/internal/rtcp"
 )
 
 // Default media configuration values.
@@ -137,6 +140,24 @@ func (c *call) startMedia() {
 	c.mediaActive = true
 	done := c.mediaDone
 	conn := c.rtpConn
+
+	// Bind RTCP socket (RTP port + 1). Non-fatal if it fails.
+	if conn != nil && c.rtcpConn == nil {
+		rtpLocal := conn.LocalAddr().(*net.UDPAddr)
+		rtcpAddr := net.JoinHostPort(rtpLocal.IP.String(), strconv.Itoa(rtpLocal.Port+1))
+		if rc, err := net.ListenPacket("udp", rtcpAddr); err == nil {
+			c.rtcpConn = rc
+		} else {
+			c.logger.Warn("RTCP port bind failed, RTCP disabled", "rtcp_addr", rtcpAddr, "error", err)
+		}
+	}
+	rtcpConn := c.rtcpConn
+
+	// Compute remote RTCP address (remote RTP port + 1).
+	var rtcpRemoteAddr net.Addr
+	if c.remotePort > 0 && c.remoteIP != "" {
+		rtcpRemoteAddr, _ = net.ResolveUDPAddr("udp", net.JoinHostPort(c.remoteIP, strconv.Itoa(c.remotePort+1)))
+	}
 	c.mu.Unlock()
 
 	jb := media.NewJitterBuffer(jitterDepth)
@@ -156,6 +177,29 @@ func (c *call) startMedia() {
 	var lastDTMFTimestamp uint32 // dedup RFC 4733 redundant end events
 	var lastDTMFSeen bool
 
+	// Start RTCP reader goroutine if we have an RTCP socket.
+	rtcpInbound := make(chan []byte, 16)
+	if rtcpConn != nil {
+		go func() {
+			buf := make([]byte, 1500)
+			for {
+				n, _, err := rtcpConn.ReadFrom(buf)
+				if err != nil {
+					return // socket closed
+				}
+				if n < 8 {
+					continue
+				}
+				cp := make([]byte, n)
+				copy(cp, buf[:n])
+				select {
+				case rtcpInbound <- cp:
+				default: // drop if full
+				}
+			}
+		}()
+	}
+
 	go func() {
 		mediaTimer := time.NewTimer(timeout)
 		defer mediaTimer.Stop()
@@ -163,6 +207,16 @@ func (c *call) startMedia() {
 		defer jitterTick.Stop()
 		// Close output channels so consumers unblock on call end.
 		defer c.closeOutputChannels()
+
+		// RTCP state.
+		rtcpStats := rtcp.NewStats()
+		var rtcpTick <-chan time.Time
+		var rtcpTicker *time.Ticker
+		if rtcpConn != nil {
+			rtcpTicker = time.NewTicker(time.Duration(rtcp.IntervalSecs) * time.Second)
+			rtcpTick = rtcpTicker.C
+			defer rtcpTicker.Stop()
+		}
 
 		resetTimer := func() {
 			if !mediaTimer.Stop() {
@@ -208,6 +262,7 @@ func (c *call) startMedia() {
 					continue
 				}
 
+				rtcpStats.RecordRTPReceived(pkt.SequenceNumber, pkt.Timestamp, pkt.SSRC, uint32(pcmRate))
 				jb.Push(pkt)
 				resetTimer()
 				c.drainJB(jb, cp)
@@ -227,6 +282,7 @@ func (c *call) startMedia() {
 				if muted {
 					continue
 				}
+				rtcpStats.RecordRTPSent(len(pkt.Payload), pkt.Timestamp)
 				if c.sentRTP != nil {
 					sendDropOldest(c.sentRTP, pkt)
 				}
@@ -266,6 +322,7 @@ func (c *call) startMedia() {
 				}
 				outSeq++
 				outTimestamp += cp.SamplesPerFrame()
+				rtcpStats.RecordRTPSent(len(outPkt.Payload), outPkt.Timestamp)
 				if c.sentRTP != nil {
 					sendDropOldest(c.sentRTP, outPkt)
 				}
@@ -279,6 +336,17 @@ func (c *call) startMedia() {
 						}
 						conn.WriteTo(data, dst)
 					}
+				}
+
+			case <-rtcpTick:
+				if rtcpConn != nil && rtcpRemoteAddr != nil {
+					sr := rtcp.BuildSR(outSSRC, rtcpStats)
+					rtcpConn.WriteTo(sr, rtcpRemoteAddr)
+				}
+
+			case data := <-rtcpInbound:
+				if pkt := rtcp.Parse(data); pkt != nil && pkt.IsSenderReport() {
+					rtcpStats.ProcessIncomingSR(pkt.NTPSec, pkt.NTPFrac)
 				}
 
 			case <-mediaTimer.C:


### PR DESCRIPTION
## Summary
- New `internal/rtcp` package: Stats tracking, BuildSR/BuildRR, Parse, NTPNow
- Media pipeline integration: RTCP socket binding (RTP+1), 5s SR ticker, inbound SR processing for RTT
- 15 unit tests covering build/parse round-trips, sequence wraparound, loss fraction, NTP timestamps
- IPv6-safe addressing via `net.JoinHostPort`, MTU-sized read buffers

Ports Rust commit `5e9b02f` (basic RTCP support) to Go.

## Test plan
- [x] `make check` passes (fmt, build, test, vet, race)
- [x] 15 new RTCP unit tests all green
- [x] Race detector clean

## Review notes
4-way code review (3 Claude agents + Codex/gpt-5) completed. Two fixes applied:
- IPv6 address formatting: `fmt.Sprintf` → `net.JoinHostPort`
- RTCP read buffer: 512 → 1500 bytes (MTU-sized for compound packets)