### PR TITLE
Fix stale SRTP context after re-INVITE

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,10 +8,6 @@
 
 ## Correctness
 
-- [ ] **`startRTPReader` captures stale `srtpIn` after re-INVITE** — `media.go:74`
-  SRTP context is captured once at startup. If a re-INVITE changes keys,
-  the RTP reader continues using the old context.
-
 - [ ] **Media timeout fully suspended during hold** — `media.go:286`
   If the network drops while a call is on hold, the call stays in OnHold
   forever. Consider extending (not suspending) the timer during hold

--- a/media.go
+++ b/media.go
@@ -82,10 +82,6 @@ func (c *call) startRTPReader() {
 		return
 	}
 
-	c.mu.Lock()
-	srtpIn := c.srtpIn
-	c.mu.Unlock()
-
 	go func() {
 		buf := make([]byte, 1500)
 		for {
@@ -97,7 +93,10 @@ func (c *call) startRTPReader() {
 			cp := make([]byte, n)
 			copy(cp, buf[:n])
 
-			// SRTP decrypt before unmarshal.
+			// Re-read srtpIn each iteration so a re-INVITE key change takes effect.
+			c.mu.Lock()
+			srtpIn := c.srtpIn
+			c.mu.Unlock()
 			if srtpIn != nil {
 				cp, err = srtpIn.Unprotect(cp)
 				if err != nil {
@@ -135,7 +134,6 @@ func (c *call) startMedia() {
 		pcmRate = defaultPCMRate
 	}
 	codec := c.codec
-	srtpOut := c.srtpOut
 	c.mediaDone = make(chan struct{})
 	c.mediaActive = true
 	done := c.mediaDone
@@ -284,6 +282,7 @@ func (c *call) startMedia() {
 				c.mu.Lock()
 				muted := c.muted
 				dst := c.remoteAddr
+				srtpOut := c.srtpOut
 				c.mu.Unlock()
 				if muted {
 					continue
@@ -311,6 +310,7 @@ func (c *call) startMedia() {
 				c.mu.Lock()
 				muted := c.muted
 				dst := c.remoteAddr
+				srtpOut := c.srtpOut
 				c.mu.Unlock()
 				if muted {
 					continue

--- a/xphone.go
+++ b/xphone.go
@@ -118,9 +118,11 @@ func (p *phone) setupSRTP(c *call, localKey, remoteKey string) {
 		p.logger.Error("SRTP inbound context setup failed", "err", err)
 		return
 	}
+	c.mu.Lock()
 	c.srtpLocalKey = localKey
 	c.srtpOut = outCtx
 	c.srtpIn = inCtx
+	c.mu.Unlock()
 	p.logger.Info("SRTP enabled for call", "id", c.id)
 }
 


### PR DESCRIPTION
## Summary
- `srtpIn`/`srtpOut` were captured once before media goroutines started, becoming stale if a re-INVITE changed SRTP keys
- Now re-read under `c.mu` lock on each packet in both inbound reader and outbound writer paths
- Guard `setupSRTP` writes with `c.mu` for writer-side synchronization

## Test plan
- [x] `make check` passes (build, test, vet, race)
- [x] Existing SRTP tests pass with race detector
- [x] Outbound paths piggyback on existing lock (zero extra lock ops)