### PR TITLE
Enforce 5-minute media timeout during hold

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,13 +6,6 @@
   Each callback fires via `go fn()`. Consider a single dispatch goroutine
   per call to reduce GC pressure under hundreds of concurrent calls.
 
-## Correctness
-
-- [ ] **Media timeout fully suspended during hold** — `media.go:286`
-  If the network drops while a call is on hold, the call stays in OnHold
-  forever. Consider extending (not suspending) the timer during hold
-  (e.g., 5 minutes).
-
 ## Other
 
 - [ ] SIP INFO DTMF

--- a/call.go
+++ b/call.go
@@ -174,19 +174,20 @@ type call struct {
 	srtpIn       *srtp.Context // inbound SRTP decryption context
 	srtpOut      *srtp.Context // outbound SRTP encryption context
 
-	codec        Codec // negotiated codec (default CodecPCMU)
-	sessionTimer *time.Timer
-	mediaActive  bool
-	mediaTimeout time.Duration
-	mediaDone    chan struct{}
-	rtpInbound   chan *rtp.Packet
-	rtpReader    chan *rtp.Packet
-	rtpRawReader chan *rtp.Packet
-	rtpWriter    chan *rtp.Packet
-	pcmReader    chan []int16
-	pcmWriter    chan []int16
-	sentRTP      chan *rtp.Packet // test hook: outbound packets copied here
-	closeChOnce  sync.Once        // ensures output channels are closed exactly once
+	codec           Codec // negotiated codec (default CodecPCMU)
+	sessionTimer    *time.Timer
+	mediaActive     bool
+	mediaTimeout    time.Duration
+	mediaDone       chan struct{}
+	rtpInbound      chan *rtp.Packet
+	rtpReader       chan *rtp.Packet
+	rtpRawReader    chan *rtp.Packet
+	rtpWriter       chan *rtp.Packet
+	pcmReader       chan []int16
+	pcmWriter       chan []int16
+	sentRTP         chan *rtp.Packet   // test hook: outbound packets copied here
+	mediaTimerReset chan time.Duration // signals the media goroutine to reset the timeout
+	closeChOnce     sync.Once          // ensures output channels are closed exactly once
 }
 
 func newInboundCall(d dialog) *call {
@@ -719,6 +720,7 @@ func (c *call) Hold() error {
 	c.dlg.SendReInvite([]byte(c.localSDP))
 	c.state = StateOnHold
 	c.fireOnState(StateOnHold)
+	c.signalMediaTimerReset(defaultHoldMediaTimeout)
 	c.logger.Info("call hold", "id", c.id)
 	return nil
 }
@@ -733,6 +735,7 @@ func (c *call) Resume() error {
 	c.dlg.SendReInvite([]byte(c.localSDP))
 	c.state = StateActive
 	c.fireOnState(StateActive)
+	c.signalMediaTimerReset(c.effectiveMediaTimeout())
 	c.logger.Info("call resumed", "id", c.id)
 	return nil
 }
@@ -952,10 +955,12 @@ func (c *call) simulateReInvite(rawSDP string) {
 		c.state = StateOnHold
 		holdFn = c.onHoldFn
 		c.fireOnState(StateOnHold)
+		c.signalMediaTimerReset(defaultHoldMediaTimeout)
 	case dir == sdp.DirSendRecv && c.state == StateOnHold:
 		c.state = StateActive
 		resumeFn = c.onResumeFn
 		c.fireOnState(StateActive)
+		c.signalMediaTimerReset(c.effectiveMediaTimeout())
 	}
 
 	c.negotiateCodec(sess)

--- a/media.go
+++ b/media.go
@@ -14,9 +14,10 @@ import (
 
 // Default media configuration values.
 const (
-	defaultMediaTimeout = 30 * time.Second
-	defaultJitterDepth  = 50 * time.Millisecond
-	defaultPCMRate      = 8000
+	defaultMediaTimeout     = 30 * time.Second
+	defaultHoldMediaTimeout = 5 * time.Minute
+	defaultJitterDepth      = 50 * time.Millisecond
+	defaultPCMRate          = 8000
 )
 
 // clonePacket returns a deep copy of an RTP packet so taps are independent.
@@ -121,10 +122,7 @@ func (c *call) startMedia() {
 		c.mu.Unlock()
 		return // already running
 	}
-	timeout := c.mediaTimeout
-	if timeout == 0 {
-		timeout = defaultMediaTimeout
-	}
+	timeout := c.effectiveMediaTimeout()
 	jitterDepth := c.jitterDepth
 	if jitterDepth == 0 {
 		jitterDepth = defaultJitterDepth
@@ -135,6 +133,7 @@ func (c *call) startMedia() {
 	}
 	codec := c.codec
 	c.mediaDone = make(chan struct{})
+	c.mediaTimerReset = make(chan time.Duration, 1)
 	c.mediaActive = true
 	done := c.mediaDone
 	conn := c.rtpConn
@@ -222,14 +221,14 @@ func (c *call) startMedia() {
 			defer rtcpTicker.Stop()
 		}
 
-		resetTimer := func() {
+		resetTimer := func(d time.Duration) {
 			if !mediaTimer.Stop() {
 				select {
 				case <-mediaTimer.C:
 				default:
 				}
 			}
-			mediaTimer.Reset(timeout)
+			mediaTimer.Reset(d)
 		}
 
 		for {
@@ -262,13 +261,13 @@ func (c *call) startMedia() {
 							go fn(ev.Digit)
 						}
 					}
-					resetTimer()
+					resetTimer(timeout)
 					continue
 				}
 
 				rtcpStats.RecordRTPReceived(pkt.SequenceNumber, pkt.Timestamp, pkt.SSRC, rtpClockRate)
 				jb.Push(pkt)
-				resetTimer()
+				resetTimer(timeout)
 				c.drainJB(jb, cp)
 
 			case <-jitterTick.C:
@@ -355,13 +354,11 @@ func (c *call) startMedia() {
 					rtcpStats.ProcessIncomingSR(pkt.NTPSec, pkt.NTPFrac)
 				}
 
+			case d := <-c.mediaTimerReset:
+				resetTimer(d)
+
 			case <-mediaTimer.C:
 				c.mu.Lock()
-				if c.state == StateOnHold {
-					c.mu.Unlock()
-					mediaTimer.Reset(timeout)
-					continue
-				}
 				c.state = StateEnded
 				c.fireOnState(StateEnded)
 				c.logger.Warn("media timeout", "id", c.id)
@@ -388,7 +385,25 @@ func (c *call) stopMedia() {
 	c.mediaActive = false
 }
 
-// resetMediaTimer resets the media timeout timer. Called on each received
-// RTP packet. Timer is managed inside the media goroutine.
-func (c *call) resetMediaTimer() {
+// effectiveMediaTimeout returns the configured media timeout or the default.
+func (c *call) effectiveMediaTimeout() time.Duration {
+	if c.mediaTimeout > 0 {
+		return c.mediaTimeout
+	}
+	return defaultMediaTimeout
+}
+
+// signalMediaTimerReset sends a timer reset request to the media goroutine.
+// Non-blocking: drops the signal if the channel is full (media goroutine will
+// pick it up on the next iteration).
+func (c *call) signalMediaTimerReset(d time.Duration) {
+	if c.mediaTimerReset == nil {
+		return
+	}
+	// Drain any pending signal so the latest value always wins.
+	select {
+	case <-c.mediaTimerReset:
+	default:
+	}
+	c.mediaTimerReset <- d
 }


### PR DESCRIPTION
## Summary
- Previously the media timer was fully suspended during hold, resetting indefinitely — a network drop while on hold would leave the call stuck in OnHold forever
- Now Hold/Resume signal the media goroutine via a `mediaTimerReset` channel to switch between a 5-minute hold timeout and the normal active timeout
- Timer fires end the call unconditionally (no more special hold-state check)

## Details
- `defaultHoldMediaTimeout = 5 * time.Minute` constant for hold-specific timeout
- `signalMediaTimerReset()` uses drain-then-send to ensure the latest value always wins
- `effectiveMediaTimeout()` helper replaces duplicated inline defaulting logic
- Parameterized `resetTimer(d)` closure eliminates duplicated timer stop/drain pattern

## Test plan
- [x] `make check` passes (build, test, vet, race)
- [x] Existing `TestMediaPipeline_MediaTimeoutSuspendedOnHold` passes — verifies timeout doesn't fire during hold, fires after resume