### PR TITLE
Add SIP INFO DTMF support (RFC 2976)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,5 +2,5 @@
 
 ## Other
 
-- [ ] SIP INFO DTMF
+- [x] SIP INFO DTMF
 - [ ] Attended transfer

--- a/call.go
+++ b/call.go
@@ -69,6 +69,8 @@ type dialog interface {
 	SendReInvite(sdp []byte) error
 	// SendRefer sends a REFER for blind transfer.
 	SendRefer(target string) error
+	// SendInfoDTMF sends a SIP INFO request with application/dtmf-relay body.
+	SendInfoDTMF(digit string, duration int) error
 	// OnNotify registers a callback for NOTIFY events (REFER progress).
 	OnNotify(fn func(code int))
 	// FireNotify fires the on_notify callback with the given status code.
@@ -151,7 +153,8 @@ type call struct {
 	onMuteFn       func()
 	onUnmuteFn     func()
 
-	muted bool
+	muted    bool
+	dtmfMode DtmfMode
 
 	codecPrefs  []int          // codec preference order (payload types)
 	jitterDepth time.Duration  // jitter buffer depth (0 = default)
@@ -590,6 +593,21 @@ func (c *call) dispatch(fn func()) {
 	}
 }
 
+// fireOnDTMF dispatches both the phone-level and public OnDTMF callbacks.
+// Acquires c.mu internally to snapshot function pointers.
+func (c *call) fireOnDTMF(digit string) {
+	c.mu.Lock()
+	fn := c.onDTMFFn
+	fnPhone := c.onDTMFPhone
+	c.mu.Unlock()
+	if fnPhone != nil {
+		c.dispatch(func() { fnPhone(digit) })
+	}
+	if fn != nil {
+		c.dispatch(func() { fn(digit) })
+	}
+}
+
 // fireOnState dispatches both the phone-level and public OnState callbacks.
 // Must be called with c.mu held. Copies function pointers and dispatches via
 // the callback goroutine.
@@ -840,12 +858,18 @@ func (c *call) SendDTMF(digit string) error {
 		c.mu.Unlock()
 		return ErrInvalidDTMFDigit
 	}
+	mode := c.dtmfMode
 	sentRTP := c.sentRTP
 	conn := c.rtpConn
 	addr := c.remoteAddr
 	srtpOut := c.srtpOut
 	c.mu.Unlock()
 
+	if mode == DtmfSipInfo {
+		return c.dlg.SendInfoDTMF(digit, defaultInfoDTMFDuration)
+	}
+
+	// DtmfRfc4733 and DtmfBoth both send via RTP.
 	pkts, err := EncodeDTMF(digit, 0, 0, 0)
 	if err != nil {
 		return err
@@ -868,6 +892,9 @@ func (c *call) SendDTMF(digit string) error {
 	}
 	return nil
 }
+
+// defaultInfoDTMFDuration is the duration in milliseconds sent in SIP INFO DTMF bodies.
+const defaultInfoDTMFDuration = 160
 
 func (c *call) BlindTransfer(target string) error {
 	c.mu.Lock()

--- a/call_test.go
+++ b/call_test.go
@@ -656,6 +656,57 @@ func TestCall_OnDTMF_NilCallbackNoPanic(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
+// --- SIP INFO DTMF ---
+
+func TestCall_SendDTMF_SipInfoMode_SendsInfoRequest(t *testing.T) {
+	dlg := testutil.NewMockDialog()
+	c := testInboundCall(t, dlg)
+	c.dtmfMode = DtmfSipInfo
+	c.Accept()
+
+	err := c.SendDTMF("5")
+	require.NoError(t, err)
+	assert.True(t, dlg.InfoSent())
+	assert.Equal(t, "5", dlg.LastInfoDigit())
+	assert.Equal(t, 160, dlg.LastInfoDuration())
+}
+
+func TestCall_SendDTMF_BothMode_SendsRTP(t *testing.T) {
+	c := activeCall(t)
+	defer c.stopMedia()
+	c.dtmfMode = DtmfBoth
+
+	err := c.SendDTMF("5")
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	pkts := drainPackets(c.sentRTP)
+	var dtmfPkts int
+	for _, pkt := range pkts {
+		if pkt.PayloadType == DTMFPayloadType {
+			dtmfPkts++
+		}
+	}
+	assert.Greater(t, dtmfPkts, 0, "Both mode should send via RTP")
+}
+
+func TestCall_SendDTMF_Rfc4733Mode_DoesNotSendInfo(t *testing.T) {
+	dlg := testutil.NewMockDialog()
+	c := testInboundCall(t, dlg)
+	c.dtmfMode = DtmfRfc4733
+	c.Accept()
+
+	c.SendDTMF("5")
+	assert.False(t, dlg.InfoSent())
+}
+
+func TestCall_SendDTMF_SipInfoMode_InvalidDigitReturnsError(t *testing.T) {
+	c := testInboundCall(t)
+	c.dtmfMode = DtmfSipInfo
+	c.Accept()
+	assert.ErrorIs(t, c.SendDTMF("X"), ErrInvalidDTMFDigit)
+}
+
 // --- Session timers ---
 
 func TestCall_SessionTimer_SendsRefreshReInvite(t *testing.T) {

--- a/dtmf.go
+++ b/dtmf.go
@@ -2,6 +2,8 @@ package xphone
 
 import (
 	"encoding/binary"
+	"fmt"
+	"strings"
 
 	"github.com/pion/rtp"
 )
@@ -100,4 +102,37 @@ func DecodeDTMF(payload []byte) *DTMFEvent {
 		Volume:   payload[1] & 0x3F,
 		Duration: binary.BigEndian.Uint16(payload[2:4]),
 	}
+}
+
+// EncodeInfoDTMF creates a SIP INFO application/dtmf-relay body.
+// Format: "Signal=<digit>\r\nDuration=<ms>\r\n"
+func EncodeInfoDTMF(digit string, durationMs int) (string, error) {
+	if DTMFDigitCode(digit) < 0 {
+		return "", ErrInvalidDTMFDigit
+	}
+	return fmt.Sprintf("Signal=%s\r\nDuration=%d\r\n", digit, durationMs), nil
+}
+
+// ParseInfoDTMF parses a SIP INFO application/dtmf-relay body and returns the digit.
+// Parsing is case-insensitive for the "Signal" key and tolerates whitespace.
+// Returns "" if no valid digit is found.
+func ParseInfoDTMF(body string) string {
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		if !strings.EqualFold(key, "signal") {
+			continue
+		}
+		val := strings.TrimSpace(line[eq+1:])
+		// Normalize a-d to A-D.
+		val = strings.ToUpper(val)
+		if val != "" && DTMFDigitCode(val) >= 0 {
+			return val
+		}
+	}
+	return ""
 }

--- a/dtmf_test.go
+++ b/dtmf_test.go
@@ -93,3 +93,57 @@ func TestEncodeDTMF_InvalidDigitReturnsError(t *testing.T) {
 	_, err := EncodeDTMF("X", 0, 0, 0x12345678)
 	assert.ErrorIs(t, err, ErrInvalidDTMFDigit)
 }
+
+// --- SIP INFO DTMF ---
+
+func TestEncodeInfoDTMF_ValidDigit(t *testing.T) {
+	body, err := EncodeInfoDTMF("5", 160)
+	require.NoError(t, err)
+	assert.Equal(t, "Signal=5\r\nDuration=160\r\n", body)
+}
+
+func TestEncodeInfoDTMF_Star(t *testing.T) {
+	body, err := EncodeInfoDTMF("*", 200)
+	require.NoError(t, err)
+	assert.Equal(t, "Signal=*\r\nDuration=200\r\n", body)
+}
+
+func TestEncodeInfoDTMF_InvalidDigitReturnsError(t *testing.T) {
+	_, err := EncodeInfoDTMF("X", 160)
+	assert.ErrorIs(t, err, ErrInvalidDTMFDigit)
+}
+
+func TestParseInfoDTMF_BasicSignal(t *testing.T) {
+	assert.Equal(t, "5", ParseInfoDTMF("Signal=5\r\nDuration=160\r\n"))
+}
+
+func TestParseInfoDTMF_StarAndHash(t *testing.T) {
+	assert.Equal(t, "*", ParseInfoDTMF("Signal=*\r\nDuration=160\r\n"))
+	assert.Equal(t, "#", ParseInfoDTMF("Signal=#\r\nDuration=160\r\n"))
+}
+
+func TestParseInfoDTMF_CaseInsensitiveKey(t *testing.T) {
+	assert.Equal(t, "5", ParseInfoDTMF("SIGNAL=5\r\nDuration=160\r\n"))
+	assert.Equal(t, "5", ParseInfoDTMF("signal=5\r\nDuration=160\r\n"))
+}
+
+func TestParseInfoDTMF_LowercaseDigitNormalized(t *testing.T) {
+	assert.Equal(t, "A", ParseInfoDTMF("Signal=a\r\nDuration=160\r\n"))
+	assert.Equal(t, "D", ParseInfoDTMF("Signal=d\r\n"))
+}
+
+func TestParseInfoDTMF_WithSpaces(t *testing.T) {
+	assert.Equal(t, "5", ParseInfoDTMF("Signal = 5 \r\nDuration = 160\r\n"))
+}
+
+func TestParseInfoDTMF_EmptyBody(t *testing.T) {
+	assert.Equal(t, "", ParseInfoDTMF(""))
+}
+
+func TestParseInfoDTMF_NoSignalLine(t *testing.T) {
+	assert.Equal(t, "", ParseInfoDTMF("Duration=160\r\n"))
+}
+
+func TestParseInfoDTMF_InvalidDigit(t *testing.T) {
+	assert.Equal(t, "", ParseInfoDTMF("Signal=X\r\n"))
+}

--- a/media.go
+++ b/media.go
@@ -250,17 +250,12 @@ func (c *call) startMedia() {
 					if ev := DecodeDTMF(pkt.Payload); ev != nil && ev.End && !(lastDTMFSeen && pkt.Timestamp == lastDTMFTimestamp) {
 						lastDTMFTimestamp = pkt.Timestamp
 						lastDTMFSeen = true
+						// Skip RTP DTMF callbacks in SipInfo-only mode.
 						c.mu.Lock()
-						fn := c.onDTMFFn
-						fnPhone := c.onDTMFPhone
+						mode := c.dtmfMode
 						c.mu.Unlock()
-						if fnPhone != nil {
-							digit := ev.Digit
-							c.dispatch(func() { fnPhone(digit) })
-						}
-						if fn != nil {
-							digit := ev.Digit
-							c.dispatch(func() { fn(digit) })
+						if mode != DtmfSipInfo {
+							c.fireOnDTMF(ev.Digit)
 						}
 					}
 					resetTimer(timeout)

--- a/options.go
+++ b/options.go
@@ -31,9 +31,22 @@ type Config struct {
 	MediaTimeout time.Duration
 	PCMFrameSize int
 	PCMRate      int
+	DtmfMode     DtmfMode
 
 	Logger *slog.Logger
 }
+
+// DtmfMode controls how DTMF digits are sent and received.
+type DtmfMode int
+
+const (
+	// DtmfRfc4733 sends and receives DTMF via RFC 4733 RTP telephone-event packets (default).
+	DtmfRfc4733 DtmfMode = iota
+	// DtmfSipInfo sends and receives DTMF via SIP INFO with application/dtmf-relay body (RFC 2976).
+	DtmfSipInfo
+	// DtmfBoth sends DTMF via RFC 4733 RTP; also accepts incoming SIP INFO DTMF.
+	DtmfBoth
+)
 
 // Codec represents an audio codec.
 type Codec int
@@ -219,6 +232,14 @@ func WithSRTP() PhoneOption {
 func WithPCMRate(rate int) PhoneOption {
 	return func(c *Config) {
 		c.PCMRate = rate
+	}
+}
+
+// WithDtmfMode sets the DTMF signaling mode.
+// Default is DtmfRfc4733 (RTP telephone-event packets).
+func WithDtmfMode(mode DtmfMode) PhoneOption {
+	return func(c *Config) {
+		c.DtmfMode = mode
 	}
 }
 

--- a/phone_test.go
+++ b/phone_test.go
@@ -514,3 +514,122 @@ func TestPhone_FindCallReturnsNilForUnknown(t *testing.T) {
 
 	assert.Nil(t, p.FindCall("nonexistent"))
 }
+
+// --- DtmfMode ---
+
+func TestPhone_DtmfModePropagatedToCalls(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	cfg := testConfig()
+	cfg.DtmfMode = DtmfSipInfo
+	p := newPhone(cfg)
+	p.connectWithTransport(tr)
+
+	incoming := make(chan Call, 1)
+	p.OnIncoming(func(c Call) { incoming <- c })
+	tr.SimulateInvite("sip:1001@pbx", "sip:1002@pbx")
+
+	c := <-incoming
+	// Access the concrete call to check dtmfMode.
+	cc := c.(*call)
+	cc.mu.Lock()
+	mode := cc.dtmfMode
+	cc.mu.Unlock()
+	assert.Equal(t, DtmfSipInfo, mode)
+}
+
+func TestPhone_InfoDTMFFiresCallDTMFCallback(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	cfg := testConfig()
+	cfg.DtmfMode = DtmfSipInfo
+	p := newPhone(cfg)
+	p.connectWithTransport(tr)
+
+	got := make(chan string, 1)
+	incoming := make(chan Call, 1)
+	p.OnIncoming(func(c Call) { incoming <- c })
+	tr.SimulateInvite("sip:1001@pbx", "sip:1002@pbx")
+
+	c := <-incoming
+	c.OnDTMF(func(digit string) { got <- digit })
+	c.Accept()
+
+	// Simulate SIP INFO DTMF via the phone handler.
+	p.handleDialogInfo(c.CallID(), "5")
+
+	select {
+	case digit := <-got:
+		assert.Equal(t, "5", digit)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("OnDTMF callback never fired for INFO DTMF")
+	}
+}
+
+func TestPhone_InfoDTMFIgnoredInRfc4733Mode(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	cfg := testConfig()
+	cfg.DtmfMode = DtmfRfc4733
+	p := newPhone(cfg)
+	p.connectWithTransport(tr)
+
+	got := make(chan string, 1)
+	incoming := make(chan Call, 1)
+	p.OnIncoming(func(c Call) { incoming <- c })
+	tr.SimulateInvite("sip:1001@pbx", "sip:1002@pbx")
+
+	c := <-incoming
+	c.OnDTMF(func(digit string) { got <- digit })
+	c.Accept()
+
+	p.handleDialogInfo(c.CallID(), "5")
+
+	select {
+	case <-got:
+		t.Fatal("INFO DTMF should be ignored in Rfc4733 mode")
+	case <-time.After(100 * time.Millisecond):
+		// Expected — no callback fired.
+	}
+}
+
+func TestPhone_InfoDTMFAcceptedInBothMode(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	cfg := testConfig()
+	cfg.DtmfMode = DtmfBoth
+	p := newPhone(cfg)
+	p.connectWithTransport(tr)
+
+	got := make(chan string, 1)
+	incoming := make(chan Call, 1)
+	p.OnIncoming(func(c Call) { incoming <- c })
+	tr.SimulateInvite("sip:1001@pbx", "sip:1002@pbx")
+
+	c := <-incoming
+	c.OnDTMF(func(digit string) { got <- digit })
+	c.Accept()
+
+	p.handleDialogInfo(c.CallID(), "9")
+
+	select {
+	case digit := <-got:
+		assert.Equal(t, "9", digit)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("OnDTMF callback never fired for INFO DTMF in Both mode")
+	}
+}
+
+func TestWithDtmfMode(t *testing.T) {
+	p := New(WithDtmfMode(DtmfSipInfo)).(*phone)
+	assert.Equal(t, DtmfSipInfo, p.cfg.DtmfMode)
+}
+
+func TestDtmfModeDefaultIsRfc4733(t *testing.T) {
+	p := New().(*phone)
+	assert.Equal(t, DtmfRfc4733, p.cfg.DtmfMode)
+}

--- a/sipgo_dialog.go
+++ b/sipgo_dialog.go
@@ -10,6 +10,7 @@ import (
 )
 
 const contentTypeSDP = "application/sdp"
+const contentTypeDTMFRelay = "application/dtmf-relay"
 
 // sipRequestTimeout is the deadline for SIP dialog operations (BYE, re-INVITE, REFER).
 const sipRequestTimeout = 5 * time.Second
@@ -54,6 +55,20 @@ func (d *dialogBase) SendRefer(target string) error {
 	req := sip.NewRequest(sip.REFER, d.invite.Recipient)
 	req.AppendHeader(sip.NewHeader("Refer-To", target))
 	_, err := d.sess.Do(ctx, req)
+	return err
+}
+
+func (d *dialogBase) SendInfoDTMF(digit string, duration int) error {
+	body, err := EncodeInfoDTMF(digit, duration)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sipRequestTimeout)
+	defer cancel()
+	req := sip.NewRequest(sip.INFO, d.invite.Recipient)
+	req.AppendHeader(sip.NewHeader("Content-Type", contentTypeDTMFRelay))
+	req.SetBody([]byte(body))
+	_, err = d.sess.Do(ctx, req)
 	return err
 }
 

--- a/sipua.go
+++ b/sipua.go
@@ -81,6 +81,10 @@ type sipUA struct {
 	// onDialogNotify is called when an inbound NOTIFY is received (REFER progress).
 	// The phone uses this to fire the dialog's OnNotify callback.
 	onDialogNotify func(callID string, code int)
+
+	// onDialogInfo is called when an inbound INFO with application/dtmf-relay is received.
+	// The phone uses this to fire DTMF callbacks on the call.
+	onDialogInfo func(callID string, digit string)
 }
 
 // newSipUA creates a sipgo-backed SIP transport.
@@ -367,6 +371,38 @@ func (s *sipUA) startServer() {
 	s.server.OnOptions(func(req *sip.Request, tx sip.ServerTransaction) {
 		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
 		tx.Respond(res)
+	})
+
+	s.server.OnInfo(func(req *sip.Request, tx sip.ServerTransaction) {
+		// Always respond 200 OK to INFO.
+		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
+		tx.Respond(res)
+
+		// Only process application/dtmf-relay bodies.
+		ct := ""
+		if h := req.ContentType(); h != nil {
+			ct = strings.ToLower(h.Value())
+		}
+		if !strings.Contains(ct, "application/dtmf-relay") {
+			return
+		}
+
+		digit := ParseInfoDTMF(string(req.Body()))
+		if digit == "" {
+			return
+		}
+
+		callID := ""
+		if h := req.CallID(); h != nil {
+			callID = h.Value()
+		}
+
+		s.mu.Lock()
+		fn := s.onDialogInfo
+		s.mu.Unlock()
+		if fn != nil && callID != "" {
+			go fn(callID, digit)
+		}
 	})
 
 	s.server.OnNotify(func(req *sip.Request, tx sip.ServerTransaction) {

--- a/testutil/mock_dialog.go
+++ b/testutil/mock_dialog.go
@@ -20,6 +20,9 @@ type MockDialog struct {
 	lastReInviteSDP    []byte
 	referSent          bool
 	lastReferTarget    string
+	infoSent           bool
+	lastInfoDigit      string
+	lastInfoDuration   int
 	callID             string
 	headers            map[string][]string
 	onNotify           func(code int)
@@ -96,6 +99,16 @@ func (d *MockDialog) SendRefer(target string) error {
 	defer d.mu.Unlock()
 	d.referSent = true
 	d.lastReferTarget = target
+	return nil
+}
+
+// SendInfoDTMF records a SIP INFO DTMF request.
+func (d *MockDialog) SendInfoDTMF(digit string, duration int) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.infoSent = true
+	d.lastInfoDigit = digit
+	d.lastInfoDuration = duration
 	return nil
 }
 
@@ -207,6 +220,27 @@ func (d *MockDialog) LastReInviteSDP() string {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return string(d.lastReInviteSDP)
+}
+
+// InfoSent returns whether a SIP INFO DTMF was sent.
+func (d *MockDialog) InfoSent() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.infoSent
+}
+
+// LastInfoDigit returns the digit from the last SIP INFO DTMF.
+func (d *MockDialog) LastInfoDigit() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.lastInfoDigit
+}
+
+// LastInfoDuration returns the duration from the last SIP INFO DTMF.
+func (d *MockDialog) LastInfoDuration() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.lastInfoDuration
 }
 
 // SimulateNotify simulates a NOTIFY with the given response code.

--- a/xphone.go
+++ b/xphone.go
@@ -132,6 +132,7 @@ func (p *phone) applyCallConfig(c *call) {
 	c.jitterDepth = p.cfg.JitterBuffer
 	c.pcmRate = p.cfg.PCMRate
 	c.codecPrefs = p.codecPrefs
+	c.dtmfMode = p.cfg.DtmfMode
 }
 
 // transportDial implements dialFn using the sipTransport interface.
@@ -244,6 +245,7 @@ func (p *phone) Connect(ctx context.Context) error {
 	tr.onDialogBye = p.handleDialogBye
 	tr.onDialogCancel = p.handleDialogCancel
 	tr.onDialogNotify = p.handleDialogNotify
+	tr.onDialogInfo = p.handleDialogInfo
 	tr.mu.Unlock()
 	tr.startServer()
 
@@ -511,6 +513,22 @@ func (p *phone) handleDialogNotify(callID string, code int) {
 	}
 }
 
+// handleDialogInfo is called by sipUA's OnInfo handler when a SIP INFO with
+// application/dtmf-relay is received. It fires the call's DTMF callbacks.
+func (p *phone) handleDialogInfo(callID string, digit string) {
+	c := p.findCall(callID)
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	mode := c.dtmfMode
+	c.mu.Unlock()
+	if mode != DtmfSipInfo && mode != DtmfBoth {
+		return
+	}
+	c.fireOnDTMF(digit)
+}
+
 // handleIncoming is called by the mock transport when an incoming INVITE arrives.
 // It auto-sends 100 Trying via the transport, creates an inbound call, fires
 // OnIncoming, and auto-sends 180 Ringing via the transport.
@@ -523,6 +541,7 @@ func (p *phone) handleIncoming(from, to string) {
 	dlg := newPhoneDialog()
 	c := newInboundCall(dlg)
 	c.logger = p.logger
+	p.applyCallConfig(c)
 	p.registerCall(c)
 
 	p.mu.Lock()
@@ -607,14 +626,17 @@ type phoneDialog struct {
 	onNotify func(int)
 
 	// State tracking (for test inspection via concrete type, not interface).
-	byeSent         bool
-	cancelSent      bool
-	referSent       bool
-	lastRespCode    int
-	lastRespReason  string
-	lastRespBody    []byte
-	lastReInviteSDP []byte
-	lastReferTarget string
+	byeSent          bool
+	cancelSent       bool
+	referSent        bool
+	infoSent         bool
+	lastInfoDigit    string
+	lastInfoDuration int
+	lastRespCode     int
+	lastRespReason   string
+	lastRespBody     []byte
+	lastReInviteSDP  []byte
+	lastReferTarget  string
 }
 
 func newPhoneDialog() *phoneDialog {
@@ -659,6 +681,15 @@ func (d *phoneDialog) SendRefer(target string) error {
 	defer d.mu.Unlock()
 	d.referSent = true
 	d.lastReferTarget = target
+	return nil
+}
+
+func (d *phoneDialog) SendInfoDTMF(digit string, duration int) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.infoSent = true
+	d.lastInfoDigit = digit
+	d.lastInfoDuration = duration
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Add `DtmfMode` config (`Rfc4733`, `SipInfo`, `Both`) controlling how DTMF digits are sent and received
- `SipInfo` mode sends DTMF via SIP INFO with `application/dtmf-relay` body (RFC 2976); `Both` mode sends via RTP but also accepts incoming SIP INFO
- RTP DTMF callbacks suppressed in `SipInfo`-only mode to prevent duplicate events
- Extract `fireOnDTMF` helper to unify callback dispatch between RTP and INFO paths
- Fix `handleIncoming` missing `applyCallConfig` call for mock-transport path

## Test plan
- [ ] `TestEncodeInfoDTMF_*` / `TestParseInfoDTMF_*` — encode/parse round-trip, edge cases (10 tests)
- [ ] `TestCall_SendDTMF_SipInfoMode_*` — SipInfo sends INFO, Both sends RTP, Rfc4733 skips INFO (4 tests)
- [ ] `TestPhone_DtmfModePropagatedToCalls` — config flows to calls
- [ ] `TestPhone_InfoDTMF*` — callback fires in SipInfo/Both, ignored in Rfc4733 (3 tests)
- [ ] `TestWithDtmfMode` / `TestDtmfModeDefaultIsRfc4733` — option and default
- [ ] `make check` passes (fmt, build, test, vet, race)