### PR TITLE
Add call waiting support with Phone.Calls() API

### DIFF
--- a/mock_call.go
+++ b/mock_call.go
@@ -33,17 +33,18 @@ type MockCall struct {
 	transferTo  string
 	headers     map[string][]string
 
-	onDTMFFn     func(string)
-	onHoldFn     func()
-	onResumeFn   func()
-	onMuteFn     func()
-	onUnmuteFn   func()
-	onMediaFn    func()
-	onStateFn    func(CallState)
-	onEndedFn    func(EndReason)
-	onStatePhone func(CallState) // internal: phone-level OnCallState
-	onEndedPhone func(EndReason) // internal: phone-level OnCallEnded
-	onDTMFPhone  func(string)    // internal: phone-level OnCallDTMF
+	onDTMFFn       func(string)
+	onHoldFn       func()
+	onResumeFn     func()
+	onMuteFn       func()
+	onUnmuteFn     func()
+	onMediaFn      func()
+	onStateFn      func(CallState)
+	onEndedFn      func(EndReason)
+	onEndedCleanup func(EndReason) // internal: call tracking cleanup
+	onStatePhone   func(CallState) // internal: phone-level OnCallState
+	onEndedPhone   func(EndReason) // internal: phone-level OnCallEnded
+	onDTMFPhone    func(string)    // internal: phone-level OnCallDTMF
 
 	rtpRawReader chan *rtp.Packet
 	rtpReader    chan *rtp.Packet
@@ -56,7 +57,7 @@ type MockCall struct {
 func NewMockCall() *MockCall {
 	return &MockCall{
 		id:           newCallID(),
-		callID:       "mock-call-id",
+		callID:       newCallID(),
 		state:        StateRinging,
 		direction:    DirectionInbound,
 		headers:      make(map[string][]string),
@@ -223,11 +224,15 @@ func (c *MockCall) Reject(code int, reason string) error {
 		return ErrInvalidState
 	}
 	c.state = StateEnded
+	cleanupFn := c.onEndedCleanup
 	statePhoneFn := c.onStatePhone
 	stateFn := c.onStateFn
 	endPhoneFn := c.onEndedPhone
 	endFn := c.onEndedFn
 	c.mu.Unlock()
+	if cleanupFn != nil {
+		cleanupFn(EndedByRejected)
+	}
 	if statePhoneFn != nil {
 		statePhoneFn(StateEnded)
 	}
@@ -256,11 +261,15 @@ func (c *MockCall) End() error {
 		return ErrInvalidState
 	}
 	c.state = StateEnded
+	cleanupFn := c.onEndedCleanup
 	statePhoneFn := c.onStatePhone
 	stateFn := c.onStateFn
 	endPhoneFn := c.onEndedPhone
 	endFn := c.onEndedFn
 	c.mu.Unlock()
+	if cleanupFn != nil {
+		cleanupFn(reason)
+	}
 	if statePhoneFn != nil {
 		statePhoneFn(StateEnded)
 	}

--- a/mock_phone.go
+++ b/mock_phone.go
@@ -53,7 +53,15 @@ func (p *MockPhone) Disconnect() error {
 	}
 	p.state = PhoneStateDisconnected
 	fn := p.onUnregFn
+	activeCalls := make([]*MockCall, 0, len(p.calls))
+	for _, c := range p.calls {
+		activeCalls = append(activeCalls, c.(*MockCall))
+	}
+	p.calls = make(map[string]Call)
 	p.mu.Unlock()
+	for _, c := range activeCalls {
+		c.End()
+	}
 	if fn != nil {
 		fn()
 	}
@@ -74,6 +82,8 @@ func (p *MockPhone) Dial(_ context.Context, target string, opts ...DialOption) (
 	p.lastCall = c
 	p.calls[c.CallID()] = c
 	p.wireCallCallbacks(c)
+	callID := c.CallID()
+	c.onEndedCleanup = func(_ EndReason) { p.untrackCall(callID) }
 	p.mu.Unlock()
 
 	return c, nil
@@ -139,6 +149,16 @@ func (p *MockPhone) wireCallCallbacks(c *MockCall) {
 	}
 }
 
+func (p *MockPhone) Calls() []Call {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	result := make([]Call, 0, len(p.calls))
+	for _, c := range p.calls {
+		result = append(result, c)
+	}
+	return result
+}
+
 func (p *MockPhone) FindCall(callID string) Call {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -155,6 +175,13 @@ func (p *MockPhone) State() PhoneState {
 	return p.state
 }
 
+// untrackCall removes a call from the active calls map.
+func (p *MockPhone) untrackCall(callID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.calls, callID)
+}
+
 // --- Test simulation methods ---
 
 // SimulateIncoming creates an incoming MockCall and fires the OnIncoming callback.
@@ -166,6 +193,8 @@ func (p *MockPhone) SimulateIncoming(from string) {
 	p.lastCall = c
 	p.calls[c.CallID()] = c
 	p.wireCallCallbacks(c)
+	callID := c.CallID()
+	c.onEndedCleanup = func(_ EndReason) { p.untrackCall(callID) }
 	fn := p.onIncomingFn
 	p.mu.Unlock()
 

--- a/mock_phone_test.go
+++ b/mock_phone_test.go
@@ -217,3 +217,38 @@ func TestMockPhone_FindCallReturnsNilForUnknown(t *testing.T) {
 	p := NewMockPhone()
 	assert.Nil(t, p.FindCall("nonexistent"))
 }
+
+// --- Calls() ---
+
+func TestMockPhone_CallsReturnsEmpty(t *testing.T) {
+	p := NewMockPhone()
+	p.Connect(context.Background())
+	assert.Empty(t, p.Calls())
+}
+
+func TestMockPhone_CallsReturnsConcurrentCalls(t *testing.T) {
+	p := NewMockPhone()
+	p.Connect(context.Background())
+
+	c1, _ := p.Dial(context.Background(), "sip:1001@pbx")
+	c2, _ := p.Dial(context.Background(), "sip:1002@pbx")
+
+	calls := p.Calls()
+	assert.Len(t, calls, 2)
+
+	ids := map[string]bool{c1.ID(): true, c2.ID(): true}
+	for _, c := range calls {
+		assert.True(t, ids[c.ID()])
+	}
+}
+
+func TestMockPhone_CallsIncludesIncoming(t *testing.T) {
+	p := NewMockPhone()
+	p.Connect(context.Background())
+
+	p.OnIncoming(func(Call) {})
+	p.SimulateIncoming("sip:1001@pbx")
+	p.SimulateIncoming("sip:1003@pbx")
+
+	assert.Len(t, p.Calls(), 2)
+}

--- a/phone_test.go
+++ b/phone_test.go
@@ -633,3 +633,135 @@ func TestDtmfModeDefaultIsRfc4733(t *testing.T) {
 	p := New().(*phone)
 	assert.Equal(t, DtmfRfc4733, p.cfg.DtmfMode)
 }
+
+// --- Calls() ---
+
+func TestPhone_CallsReturnsEmpty(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	assert.Empty(t, p.Calls())
+}
+
+func TestPhone_CallsReturnsSingleCall(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	incoming := make(chan Call, 1)
+	p.OnIncoming(func(c Call) { incoming <- c })
+	tr.SimulateInvite("sip:1001@pbx", "sip:1002@pbx")
+
+	c := <-incoming
+	calls := p.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, c.ID(), calls[0].ID())
+}
+
+func TestPhone_ConcurrentIncomingCalls(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	var received []Call
+	p.OnIncoming(func(c Call) { received = append(received, c) })
+
+	tr.SimulateInvite("sip:1001@pbx", "sip:1002@pbx")
+	tr.SimulateInvite("sip:1003@pbx", "sip:1002@pbx")
+
+	require.Len(t, received, 2)
+	calls := p.Calls()
+	assert.Len(t, calls, 2)
+
+	// Both calls should have unique Call-IDs.
+	assert.NotEqual(t, received[0].CallID(), received[1].CallID())
+}
+
+func TestPhone_ByeOneCallLeavesOtherActive(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	p := newPhone(testConfig())
+
+	// Set OnCallEnded before calls are created so it gets wired via registerCall.
+	ended := make(chan struct{}, 2)
+	p.OnCallEnded(func(_ Call, _ EndReason) { ended <- struct{}{} })
+
+	p.connectWithTransport(tr)
+
+	var received []Call
+	p.OnIncoming(func(c Call) { received = append(received, c) })
+
+	tr.SimulateInvite("sip:1001@pbx", "sip:1002@pbx")
+	tr.SimulateInvite("sip:1003@pbx", "sip:1002@pbx")
+
+	require.Len(t, received, 2)
+	require.NoError(t, received[0].Accept())
+	require.NoError(t, received[1].Accept())
+
+	// End call 1.
+	require.NoError(t, received[0].End())
+
+	// Wait for call end cleanup to propagate (dispatched via callback goroutine).
+	select {
+	case <-ended:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("OnCallEnded never fired")
+	}
+
+	// Call 2 should still be active, call 1 removed from tracking.
+	calls := p.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, received[1].ID(), calls[0].ID())
+	assert.Equal(t, StateActive, received[1].State())
+	assert.Equal(t, StateEnded, received[0].State())
+}
+
+func TestPhone_DisconnectEndsAllCalls(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	var received []Call
+	p.OnIncoming(func(c Call) { received = append(received, c) })
+
+	tr.SimulateInvite("sip:1001@pbx", "sip:1002@pbx")
+	tr.SimulateInvite("sip:1003@pbx", "sip:1002@pbx")
+
+	require.Len(t, received, 2)
+	require.NoError(t, received[0].Accept())
+	require.NoError(t, received[1].Accept())
+
+	require.NoError(t, p.Disconnect())
+
+	assert.Equal(t, StateEnded, received[0].State())
+	assert.Equal(t, StateEnded, received[1].State())
+}
+
+func TestPhone_CallsUpdatedAfterDial(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+	tr.OnInvite(func() {
+		tr.RespondWith(180, "Ringing")
+		tr.RespondWith(200, "OK")
+	})
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	c, err := p.Dial(context.Background(), "sip:1002@pbx")
+	require.NoError(t, err)
+
+	calls := p.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, c.ID(), calls[0].ID())
+}

--- a/testutil/mock_dialog.go
+++ b/testutil/mock_dialog.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"crypto/rand"
 	"fmt"
 	"strings"
 	"sync"
@@ -31,9 +32,15 @@ type MockDialog struct {
 // NewMockDialog creates a new MockDialog with defaults.
 func NewMockDialog() *MockDialog {
 	return &MockDialog{
-		callID:  "mock-call-id",
+		callID:  mockCallID(),
 		headers: make(map[string][]string),
 	}
+}
+
+func mockCallID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return fmt.Sprintf("mock-%x", b)
 }
 
 // NewMockDialogWithCallID creates a MockDialog with a specific Call-ID.

--- a/xphone.go
+++ b/xphone.go
@@ -29,6 +29,7 @@ type Phone interface {
 	OnCallEnded(func(call Call, reason EndReason))
 	OnCallDTMF(func(call Call, digit string))
 	FindCall(callID string) Call
+	Calls() []Call
 	State() PhoneState
 }
 
@@ -431,6 +432,17 @@ func (p *phone) findCall(callID string) *call {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.calls[callID]
+}
+
+// Calls returns a snapshot of all active calls.
+func (p *phone) Calls() []Call {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	result := make([]Call, 0, len(p.calls))
+	for _, c := range p.calls {
+		result = append(result, c)
+	}
+	return result
 }
 
 // FindCall returns an active call by its SIP Call-ID, or nil if not found.


### PR DESCRIPTION
## Summary
- Add `Phone.Calls() []Call` method to enumerate all active calls (snapshot semantics under lock)
- Generate unique Call-IDs for `MockCall` and `MockDialog` (previously hardcoded `"mock-call-id"`, breaking multi-call tests)
- Add `MockPhone` call lifecycle parity: `untrackCall` on end, clear calls on `Disconnect()`
- Add 9 multi-call tests covering concurrent incoming, BYE-one-leaves-other-active, disconnect-ends-all, and `Calls()` after dial

## Test plan
- [x] `make check` passes (fmt, build, test, vet, race)
- [x] `/simplify` review completed — replaced `time.Sleep` with channel-based sync, added MockPhone cleanup parity
- [x] New tests: `TestPhone_ConcurrentIncomingCalls`, `TestPhone_ByeOneCallLeavesOtherActive`, `TestPhone_DisconnectEndsAllCalls`, `TestPhone_CallsUpdatedAfterDial`, `TestMockPhone_CallsReturnsConcurrentCalls`, etc.