### PR TITLE
Add attended transfer support (RFC 3891)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,4 +3,4 @@
 ## Other
 
 - [x] SIP INFO DTMF
-- [ ] Attended transfer
+- [x] Attended transfer

--- a/call.go
+++ b/call.go
@@ -328,6 +328,58 @@ func sipHeaderDisplayName(val string) string {
 	return name
 }
 
+// sipHeaderTag extracts the tag parameter from a SIP header value.
+// e.g. `<sip:1001@host>;tag=abc123` → `abc123`
+func sipHeaderTag(val string) string {
+	const needle = ";tag="
+	idx := -1
+	for i := 0; i <= len(val)-len(needle); i++ {
+		if strings.EqualFold(val[i:i+len(needle)], needle) {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return ""
+	}
+	rest := val[idx+len(needle):]
+	if end := strings.IndexAny(rest, ";>,"); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}
+
+// uriEncode percent-encodes URI-reserved characters for SIP Replaces headers (RFC 3891).
+func uriEncode(val string) string {
+	var b strings.Builder
+	b.Grow(len(val) * 2)
+	for i := 0; i < len(val); i++ {
+		switch val[i] {
+		case '%':
+			b.WriteString("%25")
+		case '@':
+			b.WriteString("%40")
+		case ' ':
+			b.WriteString("%20")
+		case ';':
+			b.WriteString("%3B")
+		case '?':
+			b.WriteString("%3F")
+		case '&':
+			b.WriteString("%26")
+		case '=':
+			b.WriteString("%3D")
+		case '+':
+			b.WriteString("%2B")
+		case ':':
+			b.WriteString("%3A")
+		default:
+			b.WriteByte(val[i])
+		}
+	}
+	return b.String()
+}
+
 func (c *call) RemoteIP() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -912,14 +964,45 @@ func (c *call) BlindTransfer(target string) error {
 	c.dlg.SendRefer(target)
 	c.dlg.OnNotify(func(code int) {
 		if code == 200 {
-			c.mu.Lock()
-			c.state = StateEnded
-			c.fireOnState(StateEnded)
-			c.fireOnEnded(EndedByTransfer)
-			c.mu.Unlock()
+			c.endWithReason(EndedByTransfer)
 		}
 	})
 	return nil
+}
+
+// dialogID returns the Call-ID, local tag, and remote tag for this call's dialog.
+// For outbound calls: local=From tag, remote=To tag.
+// For inbound calls: local=To tag, remote=From tag.
+func (c *call) dialogID() (callID, localTag, remoteTag string) {
+	callID = c.dlg.CallID()
+	var fromTag, toTag string
+	if vals := c.dlg.Header("From"); len(vals) > 0 {
+		fromTag = sipHeaderTag(vals[0])
+	}
+	if vals := c.dlg.Header("To"); len(vals) > 0 {
+		toTag = sipHeaderTag(vals[0])
+	}
+	c.mu.Lock()
+	dir := c.direction
+	c.mu.Unlock()
+	if dir == DirectionOutbound {
+		return callID, fromTag, toTag
+	}
+	return callID, toTag, fromTag
+}
+
+// endWithReason transitions the call to Ended with the given reason.
+// Safe to call from outside the call's goroutine (e.g., from a NOTIFY handler).
+func (c *call) endWithReason(reason EndReason) {
+	c.mu.Lock()
+	if c.state == StateEnded {
+		c.mu.Unlock()
+		return
+	}
+	c.state = StateEnded
+	c.fireOnState(StateEnded)
+	c.fireOnEnded(reason)
+	c.mu.Unlock()
 }
 
 func (c *call) RTPRawReader() <-chan *rtp.Packet { return c.rtpRawReader }

--- a/call_test.go
+++ b/call_test.go
@@ -465,6 +465,27 @@ func TestCall_BlindTransferWhenNotActiveReturnsInvalidState(t *testing.T) {
 	assert.ErrorIs(t, call.BlindTransfer("sip:1003@pbx"), ErrInvalidState)
 }
 
+// --- sipHeaderTag ---
+
+func TestSipHeaderTag(t *testing.T) {
+	assert.Equal(t, "abc123", sipHeaderTag("<sip:1001@host>;tag=abc123"))
+	assert.Equal(t, "xyz", sipHeaderTag(`"Alice" <sip:1001@host>;tag=xyz`))
+	assert.Equal(t, "t1", sipHeaderTag("<sip:1001@host>;tag=t1;other=val"))
+	assert.Equal(t, "", sipHeaderTag("<sip:1001@host>"))
+	assert.Equal(t, "CaSe", sipHeaderTag("<sip:u@h>;Tag=CaSe")) // case-insensitive param name
+}
+
+// --- uriEncode ---
+
+func TestURIEncode(t *testing.T) {
+	assert.Equal(t, "abc%40host", uriEncode("abc@host"))
+	assert.Equal(t, "hello%20world", uriEncode("hello world"))
+	assert.Equal(t, "100%25done", uriEncode("100%done"))
+	assert.Equal(t, "simple", uriEncode("simple"))
+	assert.Equal(t, "a%3Bb%3Dc%3Fd%26e%2Bf", uriEncode("a;b=c?d&e+f"))
+	assert.Equal(t, "sip%3Auser", uriEncode("sip:user"))
+}
+
 // --- SDP integration ---
 
 // testSDP generates a minimal valid SDP for call-level tests.

--- a/mock_phone.go
+++ b/mock_phone.go
@@ -149,6 +149,16 @@ func (p *MockPhone) wireCallCallbacks(c *MockCall) {
 	}
 }
 
+func (p *MockPhone) AttendedTransfer(callA Call, callB Call) error {
+	if s := callA.State(); s != StateActive && s != StateOnHold {
+		return ErrInvalidState
+	}
+	if s := callB.State(); s != StateActive && s != StateOnHold {
+		return ErrInvalidState
+	}
+	return nil
+}
+
 func (p *MockPhone) Calls() []Call {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/phone_test.go
+++ b/phone_test.go
@@ -3,6 +3,7 @@ package xphone
 import (
 	"context"
 	"crypto/tls"
+	"strings"
 	"testing"
 	"time"
 
@@ -764,4 +765,128 @@ func TestPhone_CallsUpdatedAfterDial(t *testing.T) {
 	calls := p.Calls()
 	require.Len(t, calls, 1)
 	assert.Equal(t, c.ID(), calls[0].ID())
+}
+
+// --- Attended Transfer ---
+
+// mockDlgWithTags creates a MockDialog with From/To headers containing tags.
+func mockDlgWithTags(callID, from, to string) *testutil.MockDialog {
+	return testutil.NewMockDialogWithCallIDAndHeaders(callID, map[string][]string{
+		"From": {from},
+		"To":   {to},
+	})
+}
+
+func TestPhone_AttendedTransferSendsReferWithReplaces(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	// Call A (outbound to Bob).
+	dlgA := mockDlgWithTags("call-a-id", "<sip:1001@pbx>;tag=alice-a", "<sip:bob@pbx>;tag=bob-a")
+	callA := testOutboundCall(t, dlgA)
+	callA.simulateResponse(200, "OK")
+
+	// Call B (outbound to Charlie) — Call-ID contains @ to test encoding.
+	dlgB := mockDlgWithTags("call-b-id@pbx.local", "<sip:1001@pbx>;tag=alice-b", "<sip:charlie@pbx>;tag=charlie-b")
+	callB := testOutboundCall(t, dlgB)
+	callB.simulateResponse(200, "OK")
+	callB.Hold()
+
+	err := p.AttendedTransfer(callA, callB)
+	require.NoError(t, err)
+
+	// Verify REFER sent on Call A's dialog.
+	assert.True(t, dlgA.ReferSent())
+	target := dlgA.LastReferTarget()
+
+	// Refer-To should point to Charlie's URI with Replaces.
+	assert.True(t, strings.HasPrefix(target, "sip:charlie@pbx?Replaces="), "target: %s", target)
+	assert.Contains(t, target, "call-b-id%40pbx.local", "Call-ID @ should be encoded")
+	assert.Contains(t, target, "to-tag%3Dcharlie-b", "remote tag should be in to-tag")
+	assert.Contains(t, target, "from-tag%3Dalice-b", "local tag should be in from-tag")
+}
+
+func TestPhone_AttendedTransferEndsBothOnNotify200(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	dlgA := mockDlgWithTags("call-a", "<sip:1001@pbx>;tag=a1", "<sip:bob@pbx>;tag=b1")
+	callA := testOutboundCall(t, dlgA)
+	callA.simulateResponse(200, "OK")
+
+	dlgB := mockDlgWithTags("call-b", "<sip:1001@pbx>;tag=a2", "<sip:charlie@pbx>;tag=c2")
+	callB := testOutboundCall(t, dlgB)
+	callB.simulateResponse(200, "OK")
+
+	endedA := make(chan EndReason, 1)
+	endedB := make(chan EndReason, 1)
+	callA.OnEnded(func(r EndReason) { endedA <- r })
+	callB.OnEnded(func(r EndReason) { endedB <- r })
+
+	require.NoError(t, p.AttendedTransfer(callA, callB))
+
+	// Simulate NOTIFY 200 on Call A's dialog.
+	dlgA.SimulateNotify(200)
+
+	select {
+	case r := <-endedA:
+		assert.Equal(t, EndedByTransfer, r)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("callA OnEnded never fired")
+	}
+	select {
+	case r := <-endedB:
+		assert.Equal(t, EndedByTransfer, r)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("callB OnEnded never fired")
+	}
+	assert.Equal(t, StateEnded, callA.State())
+	assert.Equal(t, StateEnded, callB.State())
+}
+
+func TestPhone_AttendedTransferRejectsInactiveCallA(t *testing.T) {
+	p := newPhone(testConfig())
+	callA := testInboundCall(t) // Ringing, not Active
+	dlgB := testutil.NewMockDialog()
+	callB := testOutboundCall(t, dlgB)
+	callB.simulateResponse(200, "OK")
+
+	assert.ErrorIs(t, p.AttendedTransfer(callA, callB), ErrInvalidState)
+}
+
+func TestPhone_AttendedTransferRejectsInactiveCallB(t *testing.T) {
+	p := newPhone(testConfig())
+	callA := testInboundCall(t)
+	callA.Accept()
+	callB := testInboundCall(t) // Ringing, not Active
+
+	assert.ErrorIs(t, p.AttendedTransfer(callA, callB), ErrInvalidState)
+}
+
+func TestPhone_AttendedTransferNotifyNon200KeepsCallsAlive(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	dlgA := mockDlgWithTags("call-a", "<sip:1001@pbx>;tag=a1", "<sip:bob@pbx>;tag=b1")
+	callA := testOutboundCall(t, dlgA)
+	callA.simulateResponse(200, "OK")
+
+	dlgB := mockDlgWithTags("call-b", "<sip:1001@pbx>;tag=a2", "<sip:charlie@pbx>;tag=c2")
+	callB := testOutboundCall(t, dlgB)
+	callB.simulateResponse(200, "OK")
+
+	require.NoError(t, p.AttendedTransfer(callA, callB))
+
+	// NOTIFY 100 (Trying) should NOT end the calls.
+	dlgA.SimulateNotify(100)
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, StateActive, callA.State())
+	assert.Equal(t, StateActive, callB.State())
 }

--- a/testutil/mock_dialog.go
+++ b/testutil/mock_dialog.go
@@ -57,6 +57,14 @@ func NewMockDialogWithHeaders(headers map[string][]string) *MockDialog {
 	return d
 }
 
+// NewMockDialogWithCallIDAndHeaders creates a MockDialog with a specific Call-ID and headers.
+func NewMockDialogWithCallIDAndHeaders(callID string, headers map[string][]string) *MockDialog {
+	d := NewMockDialog()
+	d.callID = callID
+	d.headers = headers
+	return d
+}
+
 // NewMockDialogWithSessionExpires creates a MockDialog with a Session-Expires header.
 func NewMockDialogWithSessionExpires(seconds int) *MockDialog {
 	return NewMockDialogWithHeaders(map[string][]string{

--- a/xphone.go
+++ b/xphone.go
@@ -6,6 +6,7 @@ package xphone
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"strings"
@@ -28,6 +29,7 @@ type Phone interface {
 	OnCallState(func(call Call, state CallState))
 	OnCallEnded(func(call Call, reason EndReason))
 	OnCallDTMF(func(call Call, digit string))
+	AttendedTransfer(callA Call, callB Call) error
 	FindCall(callID string) Call
 	Calls() []Call
 	State() PhoneState
@@ -443,6 +445,71 @@ func (p *phone) Calls() []Call {
 		result = append(result, c)
 	}
 	return result
+}
+
+// AttendedTransfer performs an attended (consultative) transfer.
+// Call A's dialog sends a REFER with a Replaces header built from Call B's
+// dialog identifiers. On NOTIFY 200, both calls end with EndedByTransfer.
+// Both calls must be Active or OnHold.
+func (p *phone) AttendedTransfer(callA Call, callB Call) error {
+	// Validate states.
+	if s := callA.State(); s != StateActive && s != StateOnHold {
+		return ErrInvalidState
+	}
+	if s := callB.State(); s != StateActive && s != StateOnHold {
+		return ErrInvalidState
+	}
+
+	a, ok := callA.(*call)
+	if !ok {
+		return fmt.Errorf("xphone: callA is not an *call")
+	}
+	b, ok := callB.(*call)
+	if !ok {
+		return fmt.Errorf("xphone: callB is not an *call")
+	}
+
+	// Extract Call B's dialog identifiers for the Replaces header.
+	bCallID, bLocalTag, bRemoteTag := b.dialogID()
+	if bCallID == "" || bLocalTag == "" || bRemoteTag == "" {
+		return fmt.Errorf("xphone: attended transfer: call B dialog missing call-id or tags")
+	}
+
+	// Build remote party URI from Call B's headers.
+	var remoteURI string
+	if callB.Direction() == DirectionOutbound {
+		if vals := b.dlg.Header("To"); len(vals) > 0 {
+			remoteURI = sipHeaderURI(vals[0])
+		}
+	} else {
+		if vals := b.dlg.Header("From"); len(vals) > 0 {
+			remoteURI = sipHeaderURI(vals[0])
+		}
+	}
+	if remoteURI == "" {
+		return fmt.Errorf("xphone: attended transfer: cannot determine call B remote URI")
+	}
+
+	// Build Refer-To with Replaces parameter (RFC 3891).
+	referTo := remoteURI + "?Replaces=" +
+		uriEncode(bCallID) + "%3Bto-tag%3D" +
+		uriEncode(bRemoteTag) + "%3Bfrom-tag%3D" +
+		uriEncode(bLocalTag)
+
+	// Send REFER, then wire NOTIFY handler on success.
+	if err := a.dlg.SendRefer(referTo); err != nil {
+		return err
+	}
+
+	// Wire NOTIFY handler: on 200, end both calls with Transfer reason.
+	a.dlg.OnNotify(func(code int) {
+		if code == 200 {
+			a.endWithReason(EndedByTransfer)
+			b.endWithReason(EndedByTransfer)
+		}
+	})
+
+	return nil
 }
 
 // FindCall returns an active call by its SIP Call-ID, or nil if not found.


### PR DESCRIPTION
## Summary
- **Attended transfer**: `Phone.AttendedTransfer(callA, callB)` sends a REFER on Call A with a Replaces header built from Call B's dialog identifiers. On NOTIFY 200, both calls end with `EndedByTransfer`.
- **Helpers**: `sipHeaderTag` (case-insensitive tag extraction), `uriEncode` (RFC 3891 percent-encoding), `dialogID` (direction-aware tag swap), `endWithReason` (idempotent call termination).
- **Refactor**: `BlindTransfer` now uses `endWithReason` instead of inline lock/state/fire pattern.

## Test plan
- [x] 5 attended transfer integration tests (REFER with Replaces encoding, both calls end on NOTIFY 200, rejects inactive calls, non-200 NOTIFY keeps calls alive)
- [x] 2 unit tests (sipHeaderTag, uriEncode)
- [x] `make check` passes (fmt, build, test, vet, race)
- [x] All existing tests still pass