### PR TITLE
Add MWI (voicemail) support (RFC 3842)

### DIFF
--- a/events.go
+++ b/events.go
@@ -45,3 +45,15 @@ const (
 	DirectionInbound Direction = iota
 	DirectionOutbound
 )
+
+// VoicemailStatus represents the state of a voicemail mailbox (RFC 3842 MWI).
+type VoicemailStatus struct {
+	// MessagesWaiting indicates whether new messages are waiting.
+	MessagesWaiting bool
+	// Account is the optional message account URI (e.g. "sip:*97@pbx.local").
+	Account string
+	// NewMessages is the count of new (unheard) voice messages.
+	NewMessages int
+	// OldMessages is the count of old (heard) voice messages.
+	OldMessages int
+}

--- a/mock_phone.go
+++ b/mock_phone.go
@@ -18,6 +18,7 @@ type MockPhone struct {
 	onCallStateFn  func(Call, CallState)
 	onCallEndedFn  func(Call, EndReason)
 	onCallDTMFFn   func(Call, string)
+	onVoicemailFn  func(VoicemailStatus)
 	lastCall       Call
 	calls          map[string]Call
 }
@@ -131,6 +132,12 @@ func (p *MockPhone) OnCallDTMF(fn func(Call, string)) {
 	p.onCallDTMFFn = fn
 }
 
+func (p *MockPhone) OnVoicemail(fn func(VoicemailStatus)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.onVoicemailFn = fn
+}
+
 // wireCallCallbacks hooks phone-level call callbacks onto a MockCall's
 // internal fields so they coexist with user-set per-call callbacks.
 // Must be called with p.mu held.
@@ -220,6 +227,16 @@ func (p *MockPhone) SimulateError(err error) {
 	p.mu.Unlock()
 	if fn != nil {
 		fn(err)
+	}
+}
+
+// SimulateMWI fires the OnVoicemail callback with the given status.
+func (p *MockPhone) SimulateMWI(status VoicemailStatus) {
+	p.mu.Lock()
+	fn := p.onVoicemailFn
+	p.mu.Unlock()
+	if fn != nil {
+		fn(status)
 	}
 }
 

--- a/mwi.go
+++ b/mwi.go
@@ -1,0 +1,209 @@
+package xphone
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultMWIExpires is the Expires value sent in SUBSCRIBE requests (RFC 3842).
+const defaultMWIExpires = 600
+
+// mwiSubscriber manages a SIP SUBSCRIBE dialog for Message Waiting Indication.
+// It sends an initial SUBSCRIBE, refreshes periodically, and dispatches
+// incoming NOTIFY bodies to the registered callback.
+type mwiSubscriber struct {
+	mu sync.Mutex
+
+	tr           sipTransport
+	voicemailURI string
+	logger       *slog.Logger
+
+	onVoicemailFn func(VoicemailStatus)
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newMWISubscriber(tr sipTransport, voicemailURI string, logger *slog.Logger) *mwiSubscriber {
+	return &mwiSubscriber{
+		tr:           tr,
+		voicemailURI: voicemailURI,
+		logger:       logger,
+	}
+}
+
+// start wires the NOTIFY handler and launches the background subscribe/refresh loop.
+func (m *mwiSubscriber) start() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	m.mu.Lock()
+	m.ctx = ctx
+	m.cancel = cancel
+	m.mu.Unlock()
+
+	// Wire incoming MWI NOTIFY handler on transport.
+	m.tr.OnMWINotify(m.handleNotify)
+
+	// Launch background loop (initial subscribe + periodic refresh).
+	go m.loop(ctx)
+}
+
+// stop cancels the background loop and sends a best-effort unsubscribe (Expires: 0).
+func (m *mwiSubscriber) stop() {
+	m.mu.Lock()
+	cancel := m.cancel
+	m.mu.Unlock()
+
+	// Cancel the background loop first.
+	if cancel != nil {
+		cancel()
+	}
+
+	// Best-effort unsubscribe with a short timeout.
+	m.unsubscribe()
+}
+
+// setOnVoicemail sets the callback for voicemail status changes.
+func (m *mwiSubscriber) setOnVoicemail(fn func(VoicemailStatus)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onVoicemailFn = fn
+}
+
+// mwiHeaders builds the common headers for MWI SUBSCRIBE requests.
+func mwiHeaders(expires string) map[string]string {
+	return map[string]string{
+		"Event":   eventMWI,
+		"Accept":  contentTypeMWI,
+		"Expires": expires,
+	}
+}
+
+// subscribe sends a SUBSCRIBE request with the configured Expires.
+func (m *mwiSubscriber) subscribe(ctx context.Context) {
+	code, _, err := m.tr.SendSubscribe(ctx, m.voicemailURI, mwiHeaders(strconv.Itoa(defaultMWIExpires)))
+	if err != nil {
+		m.logger.Warn("MWI SUBSCRIBE failed", "err", err)
+		return
+	}
+	if code < 200 || code >= 300 {
+		m.logger.Warn("MWI SUBSCRIBE rejected", "code", code)
+		return
+	}
+	m.logger.Info("MWI subscribed", "uri", m.voicemailURI)
+}
+
+// unsubscribe sends a SUBSCRIBE with Expires: 0 to end the subscription.
+func (m *mwiSubscriber) unsubscribe() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, _, err := m.tr.SendSubscribe(ctx, m.voicemailURI, mwiHeaders("0"))
+	if err != nil {
+		m.logger.Warn("MWI unsubscribe failed", "err", err)
+	}
+}
+
+// loop sends the initial SUBSCRIBE and refreshes at half the Expires interval.
+func (m *mwiSubscriber) loop(ctx context.Context) {
+	// Initial SUBSCRIBE (best-effort).
+	m.subscribe(ctx)
+
+	refreshInterval := time.Duration(defaultMWIExpires/2) * time.Second
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.subscribe(ctx)
+		}
+	}
+}
+
+// handleNotify processes an incoming MWI NOTIFY body.
+// Called from the transport's NOTIFY dispatch goroutine, so no extra go needed.
+func (m *mwiSubscriber) handleNotify(body string) {
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		m.logger.Warn("MWI NOTIFY: failed to parse message-summary body")
+		return
+	}
+
+	m.mu.Lock()
+	fn := m.onVoicemailFn
+	m.mu.Unlock()
+
+	m.logger.Info("MWI status update",
+		"waiting", status.MessagesWaiting,
+		"new", status.NewMessages,
+		"old", status.OldMessages,
+	)
+
+	if fn != nil {
+		fn(status)
+	}
+}
+
+// parseMessageSummary parses an application/simple-message-summary body (RFC 3842).
+// Returns the parsed status and true, or zero-value and false if Messages-Waiting
+// is not found.
+func parseMessageSummary(body string) (VoicemailStatus, bool) {
+	var status VoicemailStatus
+	foundWaiting := false
+
+	lines := strings.Split(body, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:colon])
+		val := strings.TrimSpace(line[colon+1:])
+
+		if strings.EqualFold(key, "Messages-Waiting") {
+			foundWaiting = true
+			status.MessagesWaiting = strings.EqualFold(val, "yes")
+		} else if strings.EqualFold(key, "Message-Account") {
+			status.Account = val
+		} else if strings.EqualFold(key, "Voice-Message") {
+			status.NewMessages, status.OldMessages = parseMessageCounts(val)
+		}
+	}
+
+	return status, foundWaiting
+}
+
+// parseMessageCounts parses "new/old" or "new/old (urgent_new/urgent_old)" counts.
+func parseMessageCounts(s string) (int, int) {
+	// Strip optional urgent counts: "2/8 (1/0)" → "2/8"
+	if paren := strings.IndexByte(s, '('); paren >= 0 {
+		s = strings.TrimSpace(s[:paren])
+	}
+
+	parts := strings.SplitN(s, "/", 2)
+	if len(parts) != 2 {
+		return 0, 0
+	}
+
+	newCount, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0
+	}
+	oldCount, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0
+	}
+
+	return newCount, oldCount
+}

--- a/mwi_test.go
+++ b/mwi_test.go
@@ -1,0 +1,368 @@
+package xphone
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/x-phone/xphone-go/testutil"
+)
+
+// --- Parser tests ---
+
+func TestParseMessageSummary_Basic(t *testing.T) {
+	body := "Messages-Waiting: yes\r\nVoice-Message: 2/8\r\n"
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if !status.MessagesWaiting {
+		t.Error("expected MessagesWaiting=true")
+	}
+	if status.NewMessages != 2 || status.OldMessages != 8 {
+		t.Errorf("expected 2/8, got %d/%d", status.NewMessages, status.OldMessages)
+	}
+}
+
+func TestParseMessageSummary_No(t *testing.T) {
+	body := "Messages-Waiting: no\r\n"
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if status.MessagesWaiting {
+		t.Error("expected MessagesWaiting=false")
+	}
+	if status.NewMessages != 0 || status.OldMessages != 0 {
+		t.Errorf("expected 0/0, got %d/%d", status.NewMessages, status.OldMessages)
+	}
+}
+
+func TestParseMessageSummary_WithAccount(t *testing.T) {
+	body := "Messages-Waiting: yes\r\nMessage-Account: sip:*97@pbx.local\r\nVoice-Message: 1/3\r\n"
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if status.Account != "sip:*97@pbx.local" {
+		t.Errorf("expected account sip:*97@pbx.local, got %q", status.Account)
+	}
+	if status.NewMessages != 1 || status.OldMessages != 3 {
+		t.Errorf("expected 1/3, got %d/%d", status.NewMessages, status.OldMessages)
+	}
+}
+
+func TestParseMessageSummary_WithUrgent(t *testing.T) {
+	body := "Messages-Waiting: yes\r\nVoice-Message: 2/8 (1/0)\r\n"
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if status.NewMessages != 2 || status.OldMessages != 8 {
+		t.Errorf("expected 2/8, got %d/%d", status.NewMessages, status.OldMessages)
+	}
+}
+
+func TestParseMessageSummary_CaseInsensitive(t *testing.T) {
+	body := "messages-waiting: YES\r\nvoice-message: 5/10\r\n"
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if !status.MessagesWaiting {
+		t.Error("expected MessagesWaiting=true")
+	}
+	if status.NewMessages != 5 || status.OldMessages != 10 {
+		t.Errorf("expected 5/10, got %d/%d", status.NewMessages, status.OldMessages)
+	}
+}
+
+func TestParseMessageSummary_MissingWaiting(t *testing.T) {
+	body := "Voice-Message: 2/8\r\n"
+	_, ok := parseMessageSummary(body)
+	if ok {
+		t.Error("expected not ok when Messages-Waiting missing")
+	}
+}
+
+func TestParseMessageSummary_EmptyBody(t *testing.T) {
+	_, ok := parseMessageSummary("")
+	if ok {
+		t.Error("expected not ok for empty body")
+	}
+}
+
+func TestParseMessageSummary_UnixLineEndings(t *testing.T) {
+	body := "Messages-Waiting: yes\nVoice-Message: 3/7\n"
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if status.NewMessages != 3 || status.OldMessages != 7 {
+		t.Errorf("expected 3/7, got %d/%d", status.NewMessages, status.OldMessages)
+	}
+}
+
+func TestParseMessageSummary_ExtraWhitespace(t *testing.T) {
+	body := "  Messages-Waiting :  yes  \r\n  Voice-Message :  4 / 6  \r\n"
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if !status.MessagesWaiting {
+		t.Error("expected MessagesWaiting=true")
+	}
+	if status.NewMessages != 4 || status.OldMessages != 6 {
+		t.Errorf("expected 4/6, got %d/%d", status.NewMessages, status.OldMessages)
+	}
+}
+
+func TestParseMessageSummary_DefaultCounts(t *testing.T) {
+	body := "Messages-Waiting: yes\r\n"
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if status.NewMessages != 0 || status.OldMessages != 0 {
+		t.Errorf("expected 0/0 when Voice-Message absent, got %d/%d", status.NewMessages, status.OldMessages)
+	}
+}
+
+func TestParseMessageSummary_InvalidCounts(t *testing.T) {
+	body := "Messages-Waiting: yes\r\nVoice-Message: abc/def\r\n"
+	status, ok := parseMessageSummary(body)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if status.NewMessages != 0 || status.OldMessages != 0 {
+		t.Errorf("expected 0/0 for invalid counts, got %d/%d", status.NewMessages, status.OldMessages)
+	}
+}
+
+func TestParseMessageCounts(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantNew int
+		wantOld int
+	}{
+		{"2/8", 2, 8},
+		{"0/0", 0, 0},
+		{"2/8 (1/0)", 2, 8},
+		{"abc", 0, 0},
+		{"", 0, 0},
+		{"1/", 0, 0},
+	}
+	for _, tt := range tests {
+		n, o := parseMessageCounts(tt.input)
+		if n != tt.wantNew || o != tt.wantOld {
+			t.Errorf("parseMessageCounts(%q) = %d/%d, want %d/%d", tt.input, n, o, tt.wantNew, tt.wantOld)
+		}
+	}
+}
+
+// --- Integration tests ---
+
+func TestMWI_SubscribesOnConnect(t *testing.T) {
+	p := newPhone(Config{
+		VoicemailURI: "sip:*97@pbx.local",
+	})
+	applyDefaults(&p.cfg)
+
+	tr := testutil.NewMockTransport()
+	// Queue: REGISTER 200, SUBSCRIBE 200, unsubscribe 200.
+	tr.RespondSequence(
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+	)
+
+	p.connectWithTransport(tr)
+	defer p.Disconnect()
+
+	// Wait for the background goroutine to send the initial SUBSCRIBE.
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify SUBSCRIBE was sent.
+	if count := tr.CountSent("SUBSCRIBE"); count < 1 {
+		t.Errorf("expected at least 1 SUBSCRIBE sent, got %d", count)
+	}
+
+	sub := tr.LastSent("SUBSCRIBE")
+	if sub == nil {
+		t.Fatal("no SUBSCRIBE message sent")
+	}
+	if sub.Header("Event") != "message-summary" {
+		t.Errorf("expected Event: message-summary, got %q", sub.Header("Event"))
+	}
+}
+
+func TestMWI_NoSubscribeWithoutURI(t *testing.T) {
+	p := newPhone(Config{})
+	applyDefaults(&p.cfg)
+
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	p.connectWithTransport(tr)
+	defer p.Disconnect()
+
+	if count := tr.CountSent("SUBSCRIBE"); count != 0 {
+		t.Errorf("expected 0 SUBSCRIBE without VoicemailURI, got %d", count)
+	}
+}
+
+func TestMWI_FiresOnVoicemailCallback(t *testing.T) {
+	p := newPhone(Config{
+		VoicemailURI: "sip:*97@pbx.local",
+	})
+	applyDefaults(&p.cfg)
+
+	var mu sync.Mutex
+	var got VoicemailStatus
+	done := make(chan struct{})
+
+	p.OnVoicemail(func(status VoicemailStatus) {
+		mu.Lock()
+		got = status
+		mu.Unlock()
+		close(done)
+	})
+
+	tr := testutil.NewMockTransport()
+	// Queue: REGISTER 200, SUBSCRIBE 200, unsubscribe 200.
+	tr.RespondSequence(
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+	)
+
+	p.connectWithTransport(tr)
+	defer p.Disconnect()
+
+	// Wait for background SUBSCRIBE to complete before simulating NOTIFY.
+	time.Sleep(50 * time.Millisecond)
+
+	// Simulate MWI NOTIFY.
+	tr.SimulateMWINotify("Messages-Waiting: yes\r\nVoice-Message: 2/8\r\n")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for OnVoicemail callback")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !got.MessagesWaiting {
+		t.Error("expected MessagesWaiting=true")
+	}
+	if got.NewMessages != 2 || got.OldMessages != 8 {
+		t.Errorf("expected 2/8, got %d/%d", got.NewMessages, got.OldMessages)
+	}
+}
+
+func TestMWI_CallbackSetAfterConnect(t *testing.T) {
+	p := newPhone(Config{
+		VoicemailURI: "sip:*97@pbx.local",
+	})
+	applyDefaults(&p.cfg)
+
+	tr := testutil.NewMockTransport()
+	// Queue: REGISTER 200, SUBSCRIBE 200, unsubscribe 200.
+	tr.RespondSequence(
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+	)
+
+	p.connectWithTransport(tr)
+	defer p.Disconnect()
+
+	// Wait for background SUBSCRIBE to complete before setting callback.
+	time.Sleep(50 * time.Millisecond)
+
+	// Set callback after connect.
+	var mu sync.Mutex
+	var got VoicemailStatus
+	done := make(chan struct{})
+	p.OnVoicemail(func(status VoicemailStatus) {
+		mu.Lock()
+		got = status
+		mu.Unlock()
+		close(done)
+	})
+
+	// Simulate MWI NOTIFY.
+	tr.SimulateMWINotify("Messages-Waiting: yes\r\nVoice-Message: 1/5\r\n")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for OnVoicemail callback")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got.NewMessages != 1 || got.OldMessages != 5 {
+		t.Errorf("expected 1/5, got %d/%d", got.NewMessages, got.OldMessages)
+	}
+}
+
+func TestMWI_DisconnectStopsSubscription(t *testing.T) {
+	p := newPhone(Config{
+		VoicemailURI: "sip:*97@pbx.local",
+	})
+	applyDefaults(&p.cfg)
+
+	tr := testutil.NewMockTransport()
+	// Queue: REGISTER 200, initial SUBSCRIBE 200, unsubscribe SUBSCRIBE 200.
+	tr.RespondSequence(
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+	)
+
+	p.connectWithTransport(tr)
+
+	// Wait for the background goroutine to send the initial SUBSCRIBE.
+	time.Sleep(50 * time.Millisecond)
+
+	p.Disconnect()
+
+	// Should see at least 2 SUBSCRIBEs: initial + unsubscribe (Expires: 0).
+	if count := tr.CountSent("SUBSCRIBE"); count < 2 {
+		t.Errorf("expected at least 2 SUBSCRIBEs (subscribe + unsubscribe), got %d", count)
+	}
+
+	last := tr.LastSent("SUBSCRIBE")
+	if last.Header("Expires") != "0" {
+		t.Errorf("expected last SUBSCRIBE Expires: 0, got %q", last.Header("Expires"))
+	}
+}
+
+func TestMockPhone_SimulateMWI(t *testing.T) {
+	p := NewMockPhone()
+
+	var got VoicemailStatus
+	done := make(chan struct{})
+	p.OnVoicemail(func(status VoicemailStatus) {
+		got = status
+		close(done)
+	})
+
+	p.SimulateMWI(VoicemailStatus{
+		MessagesWaiting: true,
+		NewMessages:     3,
+		OldMessages:     10,
+	})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for MockPhone OnVoicemail callback")
+	}
+
+	if !got.MessagesWaiting || got.NewMessages != 3 || got.OldMessages != 10 {
+		t.Errorf("unexpected status: %+v", got)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -33,6 +33,10 @@ type Config struct {
 	PCMRate      int
 	DtmfMode     DtmfMode
 
+	// VoicemailURI is the SIP URI to subscribe for MWI (RFC 3842).
+	// Example: "sip:*97@pbx.local". When set, the phone auto-subscribes on connect.
+	VoicemailURI string
+
 	Logger *slog.Logger
 }
 
@@ -240,6 +244,16 @@ func WithPCMRate(rate int) PhoneOption {
 func WithDtmfMode(mode DtmfMode) PhoneOption {
 	return func(c *Config) {
 		c.DtmfMode = mode
+	}
+}
+
+// WithVoicemailURI sets the voicemail server URI for MWI SUBSCRIBE (RFC 3842).
+// When set, the phone subscribes to voicemail notifications on Connect()
+// and fires the OnVoicemail callback when the mailbox status changes.
+// Example: "sip:*97@pbx.local"
+func WithVoicemailURI(uri string) PhoneOption {
+	return func(c *Config) {
+		c.VoicemailURI = uri
 	}
 }
 

--- a/sipgo_dialog.go
+++ b/sipgo_dialog.go
@@ -11,6 +11,8 @@ import (
 
 const contentTypeSDP = "application/sdp"
 const contentTypeDTMFRelay = "application/dtmf-relay"
+const contentTypeMWI = "application/simple-message-summary"
+const eventMWI = "message-summary"
 
 // sipRequestTimeout is the deadline for SIP dialog operations (BYE, re-INVITE, REFER).
 const sipRequestTimeout = 5 * time.Second

--- a/sipua.go
+++ b/sipua.go
@@ -85,6 +85,10 @@ type sipUA struct {
 	// onDialogInfo is called when an inbound INFO with application/dtmf-relay is received.
 	// The phone uses this to fire DTMF callbacks on the call.
 	onDialogInfo func(callID string, digit string)
+
+	// onMWINotify is called when an inbound NOTIFY with application/simple-message-summary
+	// Content-Type is received (MWI). The callback receives the raw body string.
+	onMWINotify func(body string)
 }
 
 // newSipUA creates a sipgo-backed SIP transport.
@@ -410,7 +414,29 @@ func (s *sipUA) startServer() {
 		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
 		tx.Respond(res)
 
-		// Parse status code from sipfrag body (e.g. "SIP/2.0 200 OK").
+		// Dispatch by Content-Type: MWI vs REFER progress (sipfrag).
+		ct := ""
+		if h := req.ContentType(); h != nil {
+			ct = h.Value()
+		}
+		mediaType := ct
+		if semi := strings.IndexByte(ct, ';'); semi >= 0 {
+			mediaType = ct[:semi]
+		}
+		mediaType = strings.TrimSpace(mediaType)
+
+		if strings.EqualFold(mediaType, contentTypeMWI) {
+			// MWI NOTIFY — dispatch to MWI handler.
+			s.mu.Lock()
+			fn := s.onMWINotify
+			s.mu.Unlock()
+			if fn != nil {
+				go fn(string(req.Body()))
+			}
+			return
+		}
+
+		// REFER progress (message/sipfrag) — parse status code and dispatch.
 		code := parseSipfragStatus(string(req.Body()))
 		if code <= 0 {
 			return
@@ -431,6 +457,25 @@ func (s *sipUA) startServer() {
 }
 
 // --- sipTransport interface ---
+
+// doWithAuth sends a SIP request and handles 401/407 digest auth challenges.
+func (s *sipUA) doWithAuth(ctx context.Context, req *sip.Request, opts ...sipgo.ClientRequestOption) (int, string, error) {
+	res, err := s.client.Do(ctx, req, opts...)
+	if err != nil {
+		return 0, "", err
+	}
+	if res.StatusCode == 401 || res.StatusCode == 407 {
+		authRes, err := s.client.DoDigestAuth(ctx, req, res, sipgo.DigestAuth{
+			Username: s.cfg.Username,
+			Password: s.cfg.Password,
+		})
+		if err != nil {
+			return 0, "", err
+		}
+		return authRes.StatusCode, authRes.Reason, nil
+	}
+	return res.StatusCode, res.Reason, nil
+}
 
 func (s *sipUA) SendRequest(ctx context.Context, method string, headers map[string]string) (int, string, error) {
 	recipientUri := sip.Uri{
@@ -472,25 +517,7 @@ func (s *sipUA) SendRequest(ctx context.Context, method string, headers map[stri
 		opts = append(opts, sipgo.ClientRequestRegisterBuild)
 	}
 
-	// Send and wait for final response (skips provisional 1xx).
-	res, err := s.client.Do(ctx, req, opts...)
-	if err != nil {
-		return 0, "", err
-	}
-
-	// Handle 401/407 with digest authentication automatically.
-	if res.StatusCode == 401 || res.StatusCode == 407 {
-		authRes, err := s.client.DoDigestAuth(ctx, req, res, sipgo.DigestAuth{
-			Username: s.cfg.Username,
-			Password: s.cfg.Password,
-		})
-		if err != nil {
-			return 0, "", err
-		}
-		return authRes.StatusCode, authRes.Reason, nil
-	}
-
-	return res.StatusCode, res.Reason, nil
+	return s.doWithAuth(ctx, req, opts...)
 }
 
 // ReadResponse is unused in the production sipgo path (dialogs handle responses
@@ -520,6 +547,37 @@ func (s *sipUA) OnIncoming(fn func(from, to string)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.incomingHandler = fn
+}
+
+func (s *sipUA) SendSubscribe(ctx context.Context, uri string, headers map[string]string) (int, string, error) {
+	recipient := parseSIPTarget(uri, s.cfg.Host, s.cfg.Port)
+	req := sip.NewRequest(sip.SUBSCRIBE, recipient)
+
+	from := sip.FromHeader{
+		Address: sip.Uri{Scheme: "sip", User: s.cfg.Username, Host: s.cfg.Host},
+	}
+	from.Params.Add("tag", sip.GenerateTagN(16))
+	req.AppendHeader(&from)
+
+	to := sip.ToHeader{Address: recipient}
+	req.AppendHeader(&to)
+
+	contact := sip.ContactHeader{
+		Address: sip.Uri{Scheme: "sip", User: s.cfg.Username, Host: s.localIP},
+	}
+	req.AppendHeader(&contact)
+
+	for k, v := range headers {
+		req.AppendHeader(sip.NewHeader(k, v))
+	}
+
+	return s.doWithAuth(ctx, req)
+}
+
+func (s *sipUA) OnMWINotify(fn func(body string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onMWINotify = fn
 }
 
 func (s *sipUA) Close() error {

--- a/testutil/mock_transport.go
+++ b/testutil/mock_transport.go
@@ -10,6 +10,7 @@ import (
 // SentMessage represents a sent SIP message for inspection.
 type SentMessage struct {
 	Method  string
+	URI     string
 	headers map[string]string
 }
 
@@ -40,6 +41,7 @@ type MockTransport struct {
 	inviteFunc      func()
 	dropHandler     func()
 	incomingHandler func(from, to string)
+	mwiNotifyFn     func(body string)
 	responseCh      map[int][]chan bool
 
 	// responseReady is signaled when a new response is queued,
@@ -227,6 +229,48 @@ func (m *MockTransport) OnIncoming(fn func(from, to string)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.incomingHandler = fn
+}
+
+// SendSubscribe records a SUBSCRIBE request and returns the next queued response.
+func (m *MockTransport) SendSubscribe(ctx context.Context, uri string, headers map[string]string) (int, string, error) {
+	m.mu.Lock()
+
+	// Copy headers to avoid the caller mutating our stored reference.
+	var hdrCopy map[string]string
+	if headers != nil {
+		hdrCopy = make(map[string]string, len(headers))
+		for k, v := range headers {
+			hdrCopy[k] = v
+		}
+	}
+
+	m.sent = append(m.sent, SentMessage{Method: "SUBSCRIBE", URI: uri, headers: hdrCopy})
+
+	if m.failRemain > 0 {
+		m.failRemain--
+		m.mu.Unlock()
+		return 0, "", errors.New("transport error")
+	}
+	m.mu.Unlock()
+
+	return m.awaitResponse(ctx)
+}
+
+// OnMWINotify registers a handler for incoming MWI NOTIFY bodies.
+func (m *MockTransport) OnMWINotify(fn func(body string)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mwiNotifyFn = fn
+}
+
+// SimulateMWINotify simulates an incoming MWI NOTIFY with the given body.
+func (m *MockTransport) SimulateMWINotify(body string) {
+	m.mu.Lock()
+	fn := m.mwiNotifyFn
+	m.mu.Unlock()
+	if fn != nil {
+		fn(body)
+	}
 }
 
 // --- Test simulation methods ---

--- a/transport.go
+++ b/transport.go
@@ -16,6 +16,14 @@ type sipTransport interface {
 	// Returns (response code, response header/reason, error).
 	ReadResponse(ctx context.Context) (int, string, error)
 
+	// SendSubscribe sends a SIP SUBSCRIBE to the given URI with the specified headers.
+	// Used for MWI (RFC 3842). Returns (response code, reason, error).
+	SendSubscribe(ctx context.Context, uri string, headers map[string]string) (int, string, error)
+
+	// OnMWINotify registers a callback for incoming MWI NOTIFY bodies.
+	// The callback receives the raw application/simple-message-summary body.
+	OnMWINotify(fn func(body string))
+
 	// SendKeepalive sends a NAT keepalive packet.
 	SendKeepalive() error
 

--- a/xphone.go
+++ b/xphone.go
@@ -29,6 +29,7 @@ type Phone interface {
 	OnCallState(func(call Call, state CallState))
 	OnCallEnded(func(call Call, reason EndReason))
 	OnCallDTMF(func(call Call, digit string))
+	OnVoicemail(func(status VoicemailStatus))
 	AttendedTransfer(callA Call, callB Call) error
 	FindCall(callID string) Call
 	Calls() []Call
@@ -64,6 +65,10 @@ type phone struct {
 	onCallStateFn func(Call, CallState)
 	onCallEndedFn func(Call, EndReason)
 	onCallDTMFFn  func(Call, string)
+
+	// MWI (voicemail) state.
+	onVoicemailFn func(VoicemailStatus)
+	mwi           *mwiSubscriber
 }
 
 // codecPrefsToInts converts []Codec to []int for SDP/negotiation.
@@ -200,7 +205,21 @@ func (p *phone) connectWithTransport(tr sipTransport) {
 	} else {
 		p.state = PhoneStateRegistrationFailed
 	}
+	voicemailURI := p.cfg.VoicemailURI
+	voicemailFn := p.onVoicemailFn
 	p.mu.Unlock()
+
+	// Auto-start MWI subscription if configured and registration succeeded.
+	if err == nil && voicemailURI != "" {
+		sub := newMWISubscriber(tr, voicemailURI, p.logger)
+		if voicemailFn != nil {
+			sub.setOnVoicemail(voicemailFn)
+		}
+		sub.start()
+		p.mu.Lock()
+		p.mwi = sub
+		p.mu.Unlock()
+	}
 
 	p.logger.Info("phone connected")
 }
@@ -264,9 +283,11 @@ func (p *phone) Disconnect() error {
 	}
 	reg := p.reg
 	tr := p.tr
+	mwi := p.mwi
 	p.state = PhoneStateDisconnected
 	p.reg = nil
 	p.tr = nil
+	p.mwi = nil
 	fn := p.onUnregisteredFn
 
 	// Snapshot and clear active calls so we can end them outside the lock.
@@ -280,6 +301,11 @@ func (p *phone) Disconnect() error {
 	// End all active calls.
 	for _, c := range activeCalls {
 		c.End()
+	}
+
+	// Stop MWI subscription (sends Expires: 0 unsubscribe).
+	if mwi != nil {
+		mwi.stop()
 	}
 
 	// Stop the registry (cancels refresh loop and re-registration goroutines).
@@ -687,6 +713,17 @@ func (p *phone) OnCallDTMF(fn func(Call, string)) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.onCallDTMFFn = fn
+}
+
+func (p *phone) OnVoicemail(fn func(VoicemailStatus)) {
+	p.mu.Lock()
+	p.onVoicemailFn = fn
+	mwi := p.mwi
+	p.mu.Unlock()
+	// If already subscribed, apply the callback immediately.
+	if mwi != nil {
+		mwi.setOnVoicemail(fn)
+	}
 }
 
 func (p *phone) State() PhoneState {


### PR DESCRIPTION
## Summary
- Subscribe to `message-summary` events via SIP SUBSCRIBE when `VoicemailURI` is configured
- Parse `application/simple-message-summary` NOTIFY bodies (Messages-Waiting, Voice-Message counts, Message-Account)
- Fire `OnVoicemail` callback with `VoicemailStatus` (waiting flag, new/old counts, account URI)
- Auto-refresh subscription at `Expires/2`, clean unsubscribe (Expires: 0) on disconnect
- Extract `doWithAuth()` helper for shared 401/407 digest-auth challenge handling
- NOTIFY dispatch by Content-Type: MWI vs REFER progress (sipfrag)
- Full test coverage: 11 parser tests, 5 integration tests, 1 MockPhone test

## Test plan
- [x] `make check` passes (fmt, build, test, vet, race)
- [x] Parser handles: basic, no-waiting, account URI, urgent counts, case-insensitive, missing headers, empty body, unix line endings, extra whitespace, default counts, invalid counts
- [x] Integration: subscribes on connect, no subscribe without URI, fires callback, callback set after connect, disconnect unsubscribes
- [x] MockPhone SimulateMWI fires callback