### PR TITLE
Add G.729 codec support via bcg729

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt vet build test test-race test-opus lint tidy check install-sipcli
+.PHONY: fmt vet build test test-race test-opus test-g729 lint tidy check install-sipcli
 
 fmt:
 	gofmt -s -w .
@@ -17,6 +17,9 @@ test-race:
 
 test-opus:
 	go test -tags opus ./... -count=1
+
+test-g729:
+	go test -tags g729 ./... -count=1
 
 lint:
 	golangci-lint run ./...

--- a/internal/media/codec.go
+++ b/internal/media/codec.go
@@ -19,6 +19,8 @@ func NewCodecProcessor(payloadType int, pcmRate int) CodecProcessor {
 		return &pcmaProcessor{}
 	case 9:
 		return newG722Processor(pcmRate)
+	case 18:
+		return newG729Processor()
 	case 111:
 		return newOpusProcessor()
 	default:

--- a/internal/media/g729_codec.go
+++ b/internal/media/g729_codec.go
@@ -1,0 +1,89 @@
+//go:build g729
+
+package media
+
+/*
+#cgo pkg-config: libbcg729
+#include <bcg729/decoder.h>
+#include <bcg729/encoder.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"runtime"
+	"unsafe"
+)
+
+// g729Processor wraps bcg729 for G.729 Annex A encoding/decoding.
+// G.729 operates on 10ms frames (80 samples → 10 bytes). Since the
+// media pipeline uses 20ms frames (160 samples), each Encode/Decode
+// call processes two consecutive G.729 frames.
+type g729Processor struct {
+	enc *C.bcg729EncoderChannelContextStruct
+	dec *C.bcg729DecoderChannelContextStruct
+}
+
+const (
+	g729FrameSamples = 80 // 10ms at 8kHz
+	g729FrameBytes   = 10 // compressed frame size
+)
+
+func newG729Processor() CodecProcessor {
+	enc := C.initBcg729EncoderChannel(0) // VAD disabled
+	if enc == nil {
+		return nil
+	}
+	dec := C.initBcg729DecoderChannel()
+	if dec == nil {
+		C.closeBcg729EncoderChannel(enc)
+		return nil
+	}
+	p := &g729Processor{enc: enc, dec: dec}
+	runtime.SetFinalizer(p, func(p *g729Processor) {
+		C.closeBcg729DecoderChannel(p.dec)
+		C.closeBcg729EncoderChannel(p.enc)
+	})
+	return p
+}
+
+func (p *g729Processor) Decode(payload []byte) []int16 {
+	nFrames := len(payload) / g729FrameBytes
+	if nFrames == 0 {
+		return make([]int16, g729FrameSamples*2) // silence
+	}
+	out := make([]int16, nFrames*g729FrameSamples)
+	for i := 0; i < nFrames; i++ {
+		C.bcg729Decoder(
+			p.dec,
+			(*C.uint8_t)(unsafe.Pointer(&payload[i*g729FrameBytes])),
+			C.uint8_t(g729FrameBytes), // bitStreamLength
+			0,                         // frameErasureFlag
+			0,                         // SIDFrameFlag
+			0,                         // rfc3389PayloadFlag
+			(*C.int16_t)(unsafe.Pointer(&out[i*g729FrameSamples])),
+		)
+	}
+	return out
+}
+
+func (p *g729Processor) Encode(samples []int16) []byte {
+	nFrames := len(samples) / g729FrameSamples
+	if nFrames == 0 {
+		return []byte{}
+	}
+	out := make([]byte, nFrames*g729FrameBytes)
+	for i := 0; i < nFrames; i++ {
+		var bsLen C.uint8_t
+		C.bcg729Encoder(
+			p.enc,
+			(*C.int16_t)(unsafe.Pointer(&samples[i*g729FrameSamples])),
+			(*C.uint8_t)(unsafe.Pointer(&out[i*g729FrameBytes])),
+			&bsLen,
+		)
+	}
+	return out
+}
+
+func (p *g729Processor) PayloadType() uint8      { return 18 }
+func (p *g729Processor) ClockRate() uint32       { return 8000 }
+func (p *g729Processor) SamplesPerFrame() uint32 { return 160 }

--- a/internal/media/g729_codec_test.go
+++ b/internal/media/g729_codec_test.go
@@ -1,0 +1,147 @@
+//go:build g729
+
+package media
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestG729_Interface(t *testing.T) {
+	cp := NewCodecProcessor(18, 8000)
+	require.NotNil(t, cp, "PT=18 should return g729Processor with g729 tag")
+	assert.Equal(t, uint8(18), cp.PayloadType())
+	assert.Equal(t, uint32(8000), cp.ClockRate())
+	assert.Equal(t, uint32(160), cp.SamplesPerFrame())
+}
+
+func TestG729_RoundTripSilence(t *testing.T) {
+	cp := newG729Processor()
+	require.NotNil(t, cp)
+
+	silence := make([]int16, 160)
+	encoded := cp.Encode(silence)
+	require.Len(t, encoded, 20, "160 samples → 2 G.729 frames → 20 bytes")
+
+	decoded := cp.Decode(encoded)
+	require.Len(t, decoded, 160)
+	for i, s := range decoded {
+		assert.InDelta(t, 0, int(s), 200, "sample %d not near zero: %d", i, s)
+	}
+}
+
+func TestG729_RoundTripTone(t *testing.T) {
+	cp := newG729Processor()
+	require.NotNil(t, cp)
+
+	// Generate 400Hz tone at 8kHz.
+	input := make([]int16, 160)
+	for i := range input {
+		input[i] = int16(8000 * math.Sin(2*math.Pi*400*float64(i)/8000))
+	}
+
+	// Feed a few frames to let the codec settle.
+	for range 3 {
+		encoded := cp.Encode(input)
+		cp.Decode(encoded)
+	}
+
+	encoded := cp.Encode(input)
+	require.NotEmpty(t, encoded)
+
+	decoded := cp.Decode(encoded)
+	require.Len(t, decoded, 160)
+
+	// Check that decoded signal has non-trivial amplitude.
+	var maxAbs int16
+	for _, s := range decoded {
+		if s < 0 {
+			s = -s
+		}
+		if s > maxAbs {
+			maxAbs = s
+		}
+	}
+	assert.Greater(t, maxAbs, int16(500), "decoded tone should have significant amplitude")
+}
+
+func TestG729_Compression(t *testing.T) {
+	cp := newG729Processor()
+	require.NotNil(t, cp)
+
+	// 160 samples × 2 bytes = 320 bytes PCM → 20 bytes G.729.
+	silence := make([]int16, 160)
+	encoded := cp.Encode(silence)
+	assert.Len(t, encoded, 20, "G.729 always produces 10 bytes per 10ms frame")
+}
+
+func TestG729_SingleFrame(t *testing.T) {
+	cp := newG729Processor()
+	require.NotNil(t, cp)
+
+	// 80 samples = one 10ms frame → 10 bytes.
+	samples := make([]int16, 80)
+	encoded := cp.Encode(samples)
+	assert.Len(t, encoded, 10)
+
+	decoded := cp.Decode(encoded)
+	assert.Len(t, decoded, 80)
+}
+
+func TestG729_MultiFrame(t *testing.T) {
+	cp := newG729Processor()
+	require.NotNil(t, cp)
+
+	for frame := 0; frame < 5; frame++ {
+		input := make([]int16, 160)
+		for i := range input {
+			input[i] = int16(3000 * math.Sin(2*math.Pi*float64(i+frame*160)/20.0))
+		}
+		encoded := cp.Encode(input)
+		require.Len(t, encoded, 20, "frame %d: encode failed", frame)
+
+		decoded := cp.Decode(encoded)
+		require.Len(t, decoded, 160, "frame %d: decode should produce 160 samples", frame)
+	}
+}
+
+func TestG729_DecodeShortPayload(t *testing.T) {
+	cp := newG729Processor()
+	require.NotNil(t, cp)
+
+	// Payload shorter than one frame → silence.
+	decoded := cp.Decode([]byte{1, 2, 3})
+	require.Len(t, decoded, 160)
+	for i, s := range decoded {
+		assert.Equal(t, int16(0), s, "sample %d should be zero silence", i)
+	}
+}
+
+func TestG729_DecodeEmpty(t *testing.T) {
+	cp := newG729Processor()
+	require.NotNil(t, cp)
+
+	decoded := cp.Decode(nil)
+	assert.Len(t, decoded, 160)
+
+	decoded = cp.Decode([]byte{})
+	assert.Len(t, decoded, 160)
+}
+
+func TestG729_EncodeEmpty(t *testing.T) {
+	cp := newG729Processor()
+	require.NotNil(t, cp)
+
+	encoded := cp.Encode(nil)
+	assert.Empty(t, encoded)
+
+	encoded = cp.Encode([]int16{})
+	assert.Empty(t, encoded)
+
+	// Sub-frame input (< 80 samples) also returns empty.
+	encoded = cp.Encode(make([]int16, 40))
+	assert.Empty(t, encoded)
+}

--- a/internal/media/g729_stub.go
+++ b/internal/media/g729_stub.go
@@ -1,0 +1,5 @@
+//go:build !g729
+
+package media
+
+func newG729Processor() CodecProcessor { return nil }

--- a/internal/media/g729_stub_test.go
+++ b/internal/media/g729_stub_test.go
@@ -1,0 +1,13 @@
+//go:build !g729
+
+package media
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestG729Stub_ReturnsNil(t *testing.T) {
+	assert.Nil(t, NewCodecProcessor(18, 8000), "PT=18 should return nil without g729 build tag")
+}

--- a/internal/sdp/sdp.go
+++ b/internal/sdp/sdp.go
@@ -80,7 +80,7 @@ func (s *Session) FirstCrypto() *CryptoAttr {
 }
 
 var codecNames = map[int]string{
-	0: "PCMU/8000", 8: "PCMA/8000", 9: "G722/8000", 101: "telephone-event/8000", 111: "opus/48000/2",
+	0: "PCMU/8000", 8: "PCMA/8000", 9: "G722/8000", 18: "G729/8000", 101: "telephone-event/8000", 111: "opus/48000/2",
 }
 
 // Parse parses a raw SDP string into a Session.
@@ -267,6 +267,9 @@ func buildSDP(ip string, port int, codecs []int, direction, profile, cryptoInlin
 	for _, c := range codecs {
 		if name, ok := codecNames[c]; ok {
 			b.WriteString(fmt.Sprintf("a=rtpmap:%d %s\r\n", c, name))
+			if c == 18 {
+				b.WriteString("a=fmtp:18 annexb=no\r\n")
+			}
 			if c == 101 {
 				b.WriteString("a=fmtp:101 0-16\r\n")
 			}

--- a/internal/sdp/sdp_test.go
+++ b/internal/sdp/sdp_test.go
@@ -94,11 +94,37 @@ func TestParse_RoundTrip(t *testing.T) {
 	assert.Equal(t, 0, s.FirstCodec())
 }
 
+func TestBuildOffer_G729(t *testing.T) {
+	sdp := BuildOffer("192.168.1.100", 5004, []int{18}, "sendrecv")
+	assert.Contains(t, sdp, "m=audio 5004 RTP/AVP 18")
+	assert.Contains(t, sdp, "a=rtpmap:18 G729/8000")
+	assert.Contains(t, sdp, "a=fmtp:18 annexb=no")
+}
+
+func TestBuildOffer_G729WithOtherCodecs(t *testing.T) {
+	sdp := BuildOffer("192.168.1.100", 5004, []int{0, 18}, "sendrecv")
+	assert.Contains(t, sdp, "m=audio 5004 RTP/AVP 0 18")
+	assert.Contains(t, sdp, "a=rtpmap:18 G729/8000")
+	assert.Contains(t, sdp, "a=fmtp:18 annexb=no")
+	assert.Contains(t, sdp, "a=rtpmap:0 PCMU/8000")
+}
+
+func TestParse_G729RoundTrip(t *testing.T) {
+	raw := BuildOffer("10.0.0.1", 5004, []int{18}, "sendrecv")
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	assert.Equal(t, 18, s.FirstCodec())
+	assert.Equal(t, 5004, s.Media[0].Port)
+}
+
 func TestNegotiateCodec(t *testing.T) {
 	// local prefers [0,8], remote offers [8,0] → first local pref found in remote = 0
 	assert.Equal(t, 0, NegotiateCodec([]int{0, 8}, []int{8, 0}))
 	// no common codec
 	assert.Equal(t, -1, NegotiateCodec([]int{0}, []int{9}))
+	// G.729 negotiation
+	assert.Equal(t, 18, NegotiateCodec([]int{0, 18}, []int{18}))
+	assert.Equal(t, -1, NegotiateCodec([]int{18}, []int{0, 8}))
 }
 
 func TestBuildOfferSRTP(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -69,6 +69,7 @@ const (
 	CodecPCMU Codec = 0
 	CodecPCMA Codec = 8
 	CodecG722 Codec = 9
+	CodecG729 Codec = 18
 	CodecOpus Codec = 111
 )
 


### PR DESCRIPTION
## Summary
- Wrap bcg729 (BSD-licensed ITU-T G.729 Annex A) via CGo behind `g729` build tag
- 8kbps narrowband speech codec: 160 PCM samples (20ms) → 20 bytes (two 10ms frames)
- SDP `a=rtpmap:18 G729/8000` + `a=fmtp:18 annexb=no` for VAD-disabled interop
- `runtime.SetFinalizer` for deterministic C resource cleanup
- `CodecG729` (PT=18) constant, factory routing, codec negotiation

## Test plan
- [x] `make check` passes (fmt, build, test, vet, race)
- [x] `make test-g729` — 9 codec tests (interface, round-trip silence/tone, compression, single/multi frame, empty/short payload edge cases)
- [x] 1 stub test verifies PT=18 returns nil without build tag
- [x] 5 SDP tests (G.729 offer, multi-codec offer, parse round-trip, negotiate with PT=18)

## Dependencies
Requires [bcg729](https://github.com/BelledonneCommunications/bcg729) installed with pkg-config support.