### PR TITLE
Add SIP MESSAGE instant messaging (RFC 3428)

### DIFF
--- a/events.go
+++ b/events.go
@@ -46,6 +46,14 @@ const (
 	DirectionOutbound
 )
 
+// SipMessage represents an incoming or outgoing SIP MESSAGE (RFC 3428).
+type SipMessage struct {
+	From        string
+	To          string
+	ContentType string
+	Body        string
+}
+
 // VoicemailStatus represents the state of a voicemail mailbox (RFC 3842 MWI).
 type VoicemailStatus struct {
 	// MessagesWaiting indicates whether new messages are waiting.

--- a/examples/sipcli/main.go
+++ b/examples/sipcli/main.go
@@ -642,7 +642,7 @@ func (m model) renderCommandArea(w int) string {
 
 	inputLine := promptStyle.Render(" > ") + m.input + cursorStyle.Render("_")
 
-	helpText := "dial(d) accept(a) reject hangup(h) hold resume mute unmute dtmf transfer(xfer) echo speaker mic 1/2/3 quit(q)"
+	helpText := "dial(d) accept(a) reject hangup(h) hold resume mute unmute dtmf transfer(xfer) msg echo speaker mic 1/2/3 quit(q)"
 	helpLine := "   " + dimStyle.Render(helpText)
 
 	cmdTitle := titleStyle.Render(" Command ")
@@ -695,6 +695,8 @@ func styleEvent(line string) string {
 		return greenStyle.Render(line)
 	case strings.HasPrefix(content, "DTMF"):
 		return magentaStyle.Render(line)
+	case strings.HasPrefix(content, "MSG from"):
+		return incomingStyle.Render(line)
 	case strings.HasPrefix(content, "dialing"),
 		strings.HasPrefix(content, "ringing"),
 		strings.HasPrefix(content, "early media"):
@@ -835,6 +837,23 @@ func (m model) execCommand(input string) (model, tea.Cmd) {
 		return m, callAction(&m, "transfer to "+arg, -1, func(c xphone.Call) error {
 			return c.BlindTransfer(target)
 		})
+
+	case "msg":
+		// msg <target> <body...>
+		if len(parts) < 3 {
+			m.err = "usage: msg <target> <message>"
+			return m, nil
+		}
+		target := parts[1]
+		body := strings.Join(parts[2:], " ")
+		m.pushEvent(fmt.Sprintf("sending message to %s...", target))
+		ph := m.phone
+		return m, func() tea.Msg {
+			if err := ph.SendMessage(context.Background(), target, body); err != nil {
+				return msgLog(fmt.Sprintf("ERROR msg: %s", err))
+			}
+			return msgLog(fmt.Sprintf("message sent to %s", target))
+		}
 
 	case "echo":
 		m.ensureAudio()
@@ -1021,6 +1040,9 @@ func wirePhoneEvents(phone xphone.Phone) {
 		wireCallEvents(call)
 		prog.Send(msgLog(fmt.Sprintf("incoming from %s — type 'accept' or 'reject'", callLabel(call))))
 		prog.Send(msgCallRef{call: call})
+	})
+	phone.OnMessage(func(msg xphone.SipMessage) {
+		prog.Send(msgLog(fmt.Sprintf("MSG from %s: %s", msg.From, msg.Body)))
 	})
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,240 @@
+package xphone
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/x-phone/xphone-go/testutil"
+)
+
+func TestSendMessage_Success(t *testing.T) {
+	p := newPhone(Config{})
+	applyDefaults(&p.cfg)
+
+	tr := testutil.NewMockTransport()
+	// Queue: REGISTER 200, MESSAGE 200.
+	tr.RespondSequence(
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+	)
+
+	p.connectWithTransport(tr)
+	defer p.Disconnect()
+
+	err := p.SendMessage(context.Background(), "sip:bob@example.com", "Hello")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if count := tr.CountSent("MESSAGE"); count != 1 {
+		t.Errorf("expected 1 MESSAGE sent, got %d", count)
+	}
+
+	msg := tr.LastSent("MESSAGE")
+	if msg == nil {
+		t.Fatal("no MESSAGE sent")
+	}
+	if msg.URI != "sip:bob@example.com" {
+		t.Errorf("expected URI sip:bob@example.com, got %q", msg.URI)
+	}
+	if msg.Header("Content-Type") != "text/plain" {
+		t.Errorf("expected Content-Type text/plain, got %q", msg.Header("Content-Type"))
+	}
+}
+
+func TestSendMessage_Rejected(t *testing.T) {
+	p := newPhone(Config{})
+	applyDefaults(&p.cfg)
+
+	tr := testutil.NewMockTransport()
+	// Queue: REGISTER 200, MESSAGE 403.
+	tr.RespondSequence(
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 403, Header: "Forbidden"},
+	)
+
+	p.connectWithTransport(tr)
+	defer p.Disconnect()
+
+	err := p.SendMessage(context.Background(), "sip:bob@example.com", "Hello")
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if err.Error() != "MESSAGE 403 Forbidden" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSendMessage_NotConnected(t *testing.T) {
+	p := newPhone(Config{})
+	applyDefaults(&p.cfg)
+
+	err := p.SendMessage(context.Background(), "sip:bob@example.com", "Hello")
+	if err != ErrNotConnected {
+		t.Errorf("expected ErrNotConnected, got %v", err)
+	}
+}
+
+func TestSendMessageWithType_CustomContentType(t *testing.T) {
+	p := newPhone(Config{})
+	applyDefaults(&p.cfg)
+
+	tr := testutil.NewMockTransport()
+	// Queue: REGISTER 200, MESSAGE 200.
+	tr.RespondSequence(
+		testutil.Response{Code: 200, Header: "OK"},
+		testutil.Response{Code: 200, Header: "OK"},
+	)
+
+	p.connectWithTransport(tr)
+	defer p.Disconnect()
+
+	err := p.SendMessageWithType(context.Background(), "sip:bob@example.com", "application/json", `{"text":"hi"}`)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	msg := tr.LastSent("MESSAGE")
+	if msg == nil {
+		t.Fatal("no MESSAGE sent")
+	}
+	if msg.Header("Content-Type") != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", msg.Header("Content-Type"))
+	}
+}
+
+func TestOnMessage_IncomingMessage(t *testing.T) {
+	p := newPhone(Config{})
+	applyDefaults(&p.cfg)
+
+	var mu sync.Mutex
+	var got SipMessage
+	done := make(chan struct{})
+
+	p.OnMessage(func(msg SipMessage) {
+		mu.Lock()
+		got = msg
+		mu.Unlock()
+		close(done)
+	})
+
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	p.connectWithTransport(tr)
+	defer p.Disconnect()
+
+	tr.SimulateMessage("sip:alice@example.com", "sip:bob@example.com", "text/plain", "Hello Bob")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for OnMessage callback")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got.From != "sip:alice@example.com" {
+		t.Errorf("expected From sip:alice@example.com, got %q", got.From)
+	}
+	if got.To != "sip:bob@example.com" {
+		t.Errorf("expected To sip:bob@example.com, got %q", got.To)
+	}
+	if got.ContentType != "text/plain" {
+		t.Errorf("expected ContentType text/plain, got %q", got.ContentType)
+	}
+	if got.Body != "Hello Bob" {
+		t.Errorf("expected Body 'Hello Bob', got %q", got.Body)
+	}
+}
+
+func TestOnMessage_CallbackSetAfterConnect(t *testing.T) {
+	p := newPhone(Config{})
+	applyDefaults(&p.cfg)
+
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK")
+
+	p.connectWithTransport(tr)
+	defer p.Disconnect()
+
+	var mu sync.Mutex
+	var got SipMessage
+	done := make(chan struct{})
+	p.OnMessage(func(msg SipMessage) {
+		mu.Lock()
+		got = msg
+		mu.Unlock()
+		close(done)
+	})
+
+	tr.SimulateMessage("sip:alice@example.com", "sip:bob@example.com", "text/plain", "Late callback")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for OnMessage callback")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got.From != "sip:alice@example.com" {
+		t.Errorf("expected From sip:alice@example.com, got %q", got.From)
+	}
+	if got.To != "sip:bob@example.com" {
+		t.Errorf("expected To sip:bob@example.com, got %q", got.To)
+	}
+	if got.ContentType != "text/plain" {
+		t.Errorf("expected ContentType text/plain, got %q", got.ContentType)
+	}
+	if got.Body != "Late callback" {
+		t.Errorf("expected Body 'Late callback', got %q", got.Body)
+	}
+}
+
+func TestMockPhone_SimulateMessage(t *testing.T) {
+	p := NewMockPhone()
+
+	var got SipMessage
+	done := make(chan struct{})
+	p.OnMessage(func(msg SipMessage) {
+		got = msg
+		close(done)
+	})
+
+	p.SimulateMessage(SipMessage{
+		From:        "sip:alice@example.com",
+		To:          "sip:bob@example.com",
+		ContentType: "text/plain",
+		Body:        "Test message",
+	})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for MockPhone OnMessage callback")
+	}
+
+	if got.From != "sip:alice@example.com" {
+		t.Errorf("expected From sip:alice@example.com, got %q", got.From)
+	}
+	if got.Body != "Test message" {
+		t.Errorf("expected Body 'Test message', got %q", got.Body)
+	}
+}
+
+func TestMockPhone_SendMessage(t *testing.T) {
+	p := NewMockPhone()
+	if err := p.Connect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer p.Disconnect()
+
+	// MockPhone.SendMessage always returns nil.
+	err := p.SendMessage(context.Background(), "sip:bob@example.com", "Hello")
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}

--- a/mock_phone.go
+++ b/mock_phone.go
@@ -19,6 +19,7 @@ type MockPhone struct {
 	onCallEndedFn  func(Call, EndReason)
 	onCallDTMFFn   func(Call, string)
 	onVoicemailFn  func(VoicemailStatus)
+	onMessageFn    func(SipMessage)
 	lastCall       Call
 	calls          map[string]Call
 }
@@ -138,6 +139,20 @@ func (p *MockPhone) OnVoicemail(fn func(VoicemailStatus)) {
 	p.onVoicemailFn = fn
 }
 
+func (p *MockPhone) OnMessage(fn func(SipMessage)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.onMessageFn = fn
+}
+
+func (p *MockPhone) SendMessage(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (p *MockPhone) SendMessageWithType(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
+
 // wireCallCallbacks hooks phone-level call callbacks onto a MockCall's
 // internal fields so they coexist with user-set per-call callbacks.
 // Must be called with p.mu held.
@@ -237,6 +252,16 @@ func (p *MockPhone) SimulateMWI(status VoicemailStatus) {
 	p.mu.Unlock()
 	if fn != nil {
 		fn(status)
+	}
+}
+
+// SimulateMessage fires the OnMessage callback with the given message.
+func (p *MockPhone) SimulateMessage(msg SipMessage) {
+	p.mu.Lock()
+	fn := p.onMessageFn
+	p.mu.Unlock()
+	if fn != nil {
+		fn(msg)
 	}
 }
 

--- a/sipgo_dialog.go
+++ b/sipgo_dialog.go
@@ -12,6 +12,7 @@ import (
 const contentTypeSDP = "application/sdp"
 const contentTypeDTMFRelay = "application/dtmf-relay"
 const contentTypeMWI = "application/simple-message-summary"
+const contentTypeTextPlain = "text/plain"
 const eventMWI = "message-summary"
 
 // sipRequestTimeout is the deadline for SIP dialog operations (BYE, re-INVITE, REFER).

--- a/sipua.go
+++ b/sipua.go
@@ -89,6 +89,9 @@ type sipUA struct {
 	// onMWINotify is called when an inbound NOTIFY with application/simple-message-summary
 	// Content-Type is received (MWI). The callback receives the raw body string.
 	onMWINotify func(body string)
+
+	// onMessage is called when an inbound SIP MESSAGE is received (RFC 3428).
+	onMessage func(from, to, contentType, body string)
 }
 
 // newSipUA creates a sipgo-backed SIP transport.
@@ -454,6 +457,31 @@ func (s *sipUA) startServer() {
 			go fn(callID, code)
 		}
 	})
+
+	s.server.OnMessage(func(req *sip.Request, tx sip.ServerTransaction) {
+		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
+		tx.Respond(res)
+
+		from := ""
+		if f := req.From(); f != nil {
+			from = f.Address.String()
+		}
+		to := ""
+		if t := req.To(); t != nil {
+			to = t.Address.String()
+		}
+		ct := contentTypeTextPlain
+		if h := req.ContentType(); h != nil {
+			ct = h.Value()
+		}
+
+		s.mu.Lock()
+		fn := s.onMessage
+		s.mu.Unlock()
+		if fn != nil {
+			go fn(from, to, ct, string(req.Body()))
+		}
+	})
 }
 
 // --- sipTransport interface ---
@@ -549,9 +577,11 @@ func (s *sipUA) OnIncoming(fn func(from, to string)) {
 	s.incomingHandler = fn
 }
 
-func (s *sipUA) SendSubscribe(ctx context.Context, uri string, headers map[string]string) (int, string, error) {
+// buildOutboundRequest constructs a SIP request with From (tagged), To, and
+// caller-provided headers. Shared by SendSubscribe and SendMessage.
+func (s *sipUA) buildOutboundRequest(method sip.RequestMethod, uri string, headers map[string]string) *sip.Request {
 	recipient := parseSIPTarget(uri, s.cfg.Host, s.cfg.Port)
-	req := sip.NewRequest(sip.SUBSCRIBE, recipient)
+	req := sip.NewRequest(method, recipient)
 
 	from := sip.FromHeader{
 		Address: sip.Uri{Scheme: "sip", User: s.cfg.Username, Host: s.cfg.Host},
@@ -562,14 +592,19 @@ func (s *sipUA) SendSubscribe(ctx context.Context, uri string, headers map[strin
 	to := sip.ToHeader{Address: recipient}
 	req.AppendHeader(&to)
 
+	for k, v := range headers {
+		req.AppendHeader(sip.NewHeader(k, v))
+	}
+	return req
+}
+
+func (s *sipUA) SendSubscribe(ctx context.Context, uri string, headers map[string]string) (int, string, error) {
+	req := s.buildOutboundRequest(sip.SUBSCRIBE, uri, headers)
+
 	contact := sip.ContactHeader{
 		Address: sip.Uri{Scheme: "sip", User: s.cfg.Username, Host: s.localIP},
 	}
 	req.AppendHeader(&contact)
-
-	for k, v := range headers {
-		req.AppendHeader(sip.NewHeader(k, v))
-	}
 
 	return s.doWithAuth(ctx, req)
 }
@@ -578,6 +613,19 @@ func (s *sipUA) OnMWINotify(fn func(body string)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onMWINotify = fn
+}
+
+func (s *sipUA) SendMessage(ctx context.Context, uri string, contentType string, body string, headers map[string]string) (int, string, error) {
+	req := s.buildOutboundRequest(sip.MESSAGE, uri, headers)
+	req.AppendHeader(sip.NewHeader("Content-Type", contentType))
+	req.SetBody([]byte(body))
+	return s.doWithAuth(ctx, req)
+}
+
+func (s *sipUA) OnMessage(fn func(from, to, contentType, body string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onMessage = fn
 }
 
 func (s *sipUA) Close() error {

--- a/testutil/mock_transport.go
+++ b/testutil/mock_transport.go
@@ -42,6 +42,7 @@ type MockTransport struct {
 	dropHandler     func()
 	incomingHandler func(from, to string)
 	mwiNotifyFn     func(body string)
+	messageFn       func(from, to, contentType, body string)
 	responseCh      map[int][]chan bool
 
 	// responseReady is signaled when a new response is queued,
@@ -115,6 +116,18 @@ func (m *MockTransport) OnInvite(fn func()) {
 	m.inviteFunc = fn
 }
 
+// copyHeaders returns a shallow copy of the headers map, or nil if headers is nil.
+func copyHeaders(headers map[string]string) map[string]string {
+	if headers == nil {
+		return nil
+	}
+	cp := make(map[string]string, len(headers))
+	for k, v := range headers {
+		cp[k] = v
+	}
+	return cp
+}
+
 // --- sipTransport interface ---
 
 // SendRequest sends a SIP request and waits for a response.
@@ -124,17 +137,8 @@ func (m *MockTransport) OnInvite(fn func()) {
 func (m *MockTransport) SendRequest(ctx context.Context, method string, headers map[string]string) (int, string, error) {
 	m.mu.Lock()
 
-	// Copy headers to avoid the caller mutating our stored reference.
-	var hdrCopy map[string]string
-	if headers != nil {
-		hdrCopy = make(map[string]string, len(headers))
-		for k, v := range headers {
-			hdrCopy[k] = v
-		}
-	}
-
 	// Record the sent message (even for failed attempts, so CountSent is accurate).
-	m.sent = append(m.sent, SentMessage{Method: method, headers: hdrCopy})
+	m.sent = append(m.sent, SentMessage{Method: method, headers: copyHeaders(headers)})
 
 	// Check for simulated transport failures.
 	if m.failRemain > 0 {
@@ -235,16 +239,7 @@ func (m *MockTransport) OnIncoming(fn func(from, to string)) {
 func (m *MockTransport) SendSubscribe(ctx context.Context, uri string, headers map[string]string) (int, string, error) {
 	m.mu.Lock()
 
-	// Copy headers to avoid the caller mutating our stored reference.
-	var hdrCopy map[string]string
-	if headers != nil {
-		hdrCopy = make(map[string]string, len(headers))
-		for k, v := range headers {
-			hdrCopy[k] = v
-		}
-	}
-
-	m.sent = append(m.sent, SentMessage{Method: "SUBSCRIBE", URI: uri, headers: hdrCopy})
+	m.sent = append(m.sent, SentMessage{Method: "SUBSCRIBE", URI: uri, headers: copyHeaders(headers)})
 
 	if m.failRemain > 0 {
 		m.failRemain--
@@ -261,6 +256,45 @@ func (m *MockTransport) OnMWINotify(fn func(body string)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.mwiNotifyFn = fn
+}
+
+// SendMessage records a MESSAGE request and returns the next queued response.
+func (m *MockTransport) SendMessage(ctx context.Context, uri string, contentType string, body string, headers map[string]string) (int, string, error) {
+	m.mu.Lock()
+
+	hdrCopy := make(map[string]string, len(headers)+1)
+	for k, v := range headers {
+		hdrCopy[k] = v
+	}
+	hdrCopy["Content-Type"] = contentType
+
+	m.sent = append(m.sent, SentMessage{Method: "MESSAGE", URI: uri, headers: hdrCopy})
+
+	if m.failRemain > 0 {
+		m.failRemain--
+		m.mu.Unlock()
+		return 0, "", errors.New("transport error")
+	}
+	m.mu.Unlock()
+
+	return m.awaitResponse(ctx)
+}
+
+// OnMessage registers a handler for incoming SIP MESSAGE requests.
+func (m *MockTransport) OnMessage(fn func(from, to, contentType, body string)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messageFn = fn
+}
+
+// SimulateMessage simulates an incoming SIP MESSAGE.
+func (m *MockTransport) SimulateMessage(from, to, contentType, body string) {
+	m.mu.Lock()
+	fn := m.messageFn
+	m.mu.Unlock()
+	if fn != nil {
+		fn(from, to, contentType, body)
+	}
 }
 
 // SimulateMWINotify simulates an incoming MWI NOTIFY with the given body.

--- a/transport.go
+++ b/transport.go
@@ -20,6 +20,14 @@ type sipTransport interface {
 	// Used for MWI (RFC 3842). Returns (response code, reason, error).
 	SendSubscribe(ctx context.Context, uri string, headers map[string]string) (int, string, error)
 
+	// SendMessage sends a SIP MESSAGE to the given URI with optional headers.
+	// Returns (response code, reason, error).
+	SendMessage(ctx context.Context, uri string, contentType string, body string, headers map[string]string) (int, string, error)
+
+	// OnMessage registers a callback for incoming SIP MESSAGE requests.
+	// Parameters: from, to, contentType, body.
+	OnMessage(fn func(from, to, contentType, body string))
+
 	// OnMWINotify registers a callback for incoming MWI NOTIFY bodies.
 	// The callback receives the raw application/simple-message-summary body.
 	OnMWINotify(fn func(body string))

--- a/xphone.go
+++ b/xphone.go
@@ -31,6 +31,9 @@ type Phone interface {
 	OnCallEnded(func(call Call, reason EndReason))
 	OnCallDTMF(func(call Call, digit string))
 	OnVoicemail(func(status VoicemailStatus))
+	OnMessage(func(msg SipMessage))
+	SendMessage(ctx context.Context, target string, body string) error
+	SendMessageWithType(ctx context.Context, target string, contentType string, body string) error
 	AttendedTransfer(callA Call, callB Call) error
 	FindCall(callID string) Call
 	Calls() []Call
@@ -67,6 +70,9 @@ type phone struct {
 	onCallStateFn func(Call, CallState)
 	onCallEndedFn func(Call, EndReason)
 	onCallDTMFFn  func(Call, string)
+
+	// SIP MESSAGE callback.
+	onMessageFn func(SipMessage)
 
 	// MWI (voicemail) state.
 	onVoicemailFn func(VoicemailStatus)
@@ -202,8 +208,9 @@ func (p *phone) connectWithTransport(tr sipTransport) {
 	// Perform registration (consumes the pre-queued 200 OK in tests).
 	err := p.reg.Start(context.Background())
 
-	// Wire up incoming INVITE handling on the transport.
+	// Wire up incoming INVITE and MESSAGE handling on the transport.
 	tr.OnIncoming(p.handleIncoming)
+	tr.OnMessage(p.handleMessage)
 
 	p.mu.Lock()
 	if err == nil {
@@ -734,6 +741,42 @@ func (p *phone) OnVoicemail(fn func(VoicemailStatus)) {
 	// If already subscribed, apply the callback immediately.
 	if mwi != nil {
 		mwi.setOnVoicemail(fn)
+	}
+}
+
+func (p *phone) OnMessage(fn func(SipMessage)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.onMessageFn = fn
+}
+
+func (p *phone) SendMessage(ctx context.Context, target string, body string) error {
+	return p.SendMessageWithType(ctx, target, contentTypeTextPlain, body)
+}
+
+func (p *phone) SendMessageWithType(ctx context.Context, target string, contentType string, body string) error {
+	p.mu.Lock()
+	tr := p.tr
+	p.mu.Unlock()
+	if tr == nil {
+		return ErrNotConnected
+	}
+	code, reason, err := tr.SendMessage(ctx, target, contentType, body, nil)
+	if err != nil {
+		return err
+	}
+	if code < 200 || code >= 300 {
+		return fmt.Errorf("MESSAGE %d %s", code, reason)
+	}
+	return nil
+}
+
+func (p *phone) handleMessage(from, to, contentType, body string) {
+	p.mu.Lock()
+	fn := p.onMessageFn
+	p.mu.Unlock()
+	if fn != nil {
+		fn(SipMessage{From: from, To: to, ContentType: contentType, Body: body})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `SendMessage`, `SendMessageWithType`, and `OnMessage` to the Phone interface for SIP MESSAGE (RFC 3428)
- `SipMessage` struct carries From, To, ContentType, and Body fields
- Production path: sipgo server handler (200 OK + dispatch), outbound via `doWithAuth` with digest auth
- Extract `buildOutboundRequest` helper in sipUA (shared by SendSubscribe/SendMessage)
- Extract `copyHeaders` helper in MockTransport (shared by SendRequest/SendSubscribe/SendMessage)
- Add `msg <target> <body>` command to sipcli with incoming message display in events panel

## Test plan
- [x] `make check` passes (fmt, build, test, vet, race)
- [x] 8 unit tests: send success/rejected/not-connected, custom content type, incoming callback before/after connect, MockPhone send/simulate
- [x] Verified bidirectional messaging between two sipcli instances via Asterisk
- [x] Verified interop with Zoiper (iOS) as sender and receiver