### PR TITLE
Add SIP SUBSCRIBE/NOTIFY support with BLF monitoring (RFC 6665)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,6 @@
 
 - [x] SIP INFO DTMF
 - [x] Attended transfer
+- [ ] O(n) findMatch — fine for <100 subs, index map adds complexity
+- [ ] MWI consolidation into subscription manager — good future refactoring but too large for this PR
+- [ ] Per-goroutine refresh vs shared ticker — acceptable for expected workloads

--- a/dialog_info.go
+++ b/dialog_info.go
@@ -1,0 +1,69 @@
+package xphone
+
+import "encoding/xml"
+
+// dialogInfo represents the root <dialog-info> element of RFC 4235.
+type dialogInfo struct {
+	XMLName xml.Name      `xml:"dialog-info"`
+	Dialogs []dialogEntry `xml:"dialog"`
+}
+
+// dialogEntry represents a single <dialog> element.
+type dialogEntry struct {
+	State string `xml:"state"`
+}
+
+// RFC 4235 dialog state values.
+const (
+	dialogStateConfirmed  = "confirmed"
+	dialogStateEarly      = "early"
+	dialogStateProceeding = "proceeding"
+	dialogStateTerminated = "terminated"
+)
+
+// parseDialogInfo parses a dialog-info+xml body and derives an ExtensionState.
+//
+// Mapping:
+//   - No dialogs or all terminated → ExtensionAvailable
+//   - Any confirmed               → ExtensionOnThePhone
+//   - Any early/proceeding        → ExtensionRinging
+//   - Otherwise                   → ExtensionUnknown
+func parseDialogInfo(body string) (ExtensionState, error) {
+	var info dialogInfo
+	if err := xml.Unmarshal([]byte(body), &info); err != nil {
+		return ExtensionUnknown, err
+	}
+	if len(info.Dialogs) == 0 {
+		return ExtensionAvailable, nil
+	}
+
+	hasConfirmed := false
+	hasEarly := false
+	allTerminated := true
+
+	for _, d := range info.Dialogs {
+		switch d.State {
+		case dialogStateConfirmed:
+			hasConfirmed = true
+			allTerminated = false
+		case dialogStateEarly, dialogStateProceeding:
+			hasEarly = true
+			allTerminated = false
+		case dialogStateTerminated:
+			// still terminated
+		default:
+			allTerminated = false
+		}
+	}
+
+	switch {
+	case hasConfirmed:
+		return ExtensionOnThePhone, nil
+	case hasEarly:
+		return ExtensionRinging, nil
+	case allTerminated:
+		return ExtensionAvailable, nil
+	default:
+		return ExtensionUnknown, nil
+	}
+}

--- a/dialog_info_test.go
+++ b/dialog_info_test.go
@@ -1,0 +1,126 @@
+package xphone
+
+import "testing"
+
+func TestParseDialogInfo_NoDialogs(t *testing.T) {
+	body := `<?xml version="1.0"?><dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="0" state="full" entity="sip:1001@pbx.local"></dialog-info>`
+	state, err := parseDialogInfo(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != ExtensionAvailable {
+		t.Errorf("expected ExtensionAvailable, got %d", state)
+	}
+}
+
+func TestParseDialogInfo_Confirmed(t *testing.T) {
+	body := `<?xml version="1.0"?>
+<dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="1" state="full" entity="sip:1001@pbx.local">
+  <dialog id="abc123">
+    <state>confirmed</state>
+  </dialog>
+</dialog-info>`
+	state, err := parseDialogInfo(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != ExtensionOnThePhone {
+		t.Errorf("expected ExtensionOnThePhone, got %d", state)
+	}
+}
+
+func TestParseDialogInfo_Early(t *testing.T) {
+	body := `<?xml version="1.0"?>
+<dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="1" state="full" entity="sip:1001@pbx.local">
+  <dialog id="abc123">
+    <state>early</state>
+  </dialog>
+</dialog-info>`
+	state, err := parseDialogInfo(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != ExtensionRinging {
+		t.Errorf("expected ExtensionRinging, got %d", state)
+	}
+}
+
+func TestParseDialogInfo_Proceeding(t *testing.T) {
+	body := `<?xml version="1.0"?>
+<dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="1" state="full" entity="sip:1001@pbx.local">
+  <dialog id="abc123">
+    <state>proceeding</state>
+  </dialog>
+</dialog-info>`
+	state, err := parseDialogInfo(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != ExtensionRinging {
+		t.Errorf("expected ExtensionRinging, got %d", state)
+	}
+}
+
+func TestParseDialogInfo_AllTerminated(t *testing.T) {
+	body := `<?xml version="1.0"?>
+<dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="2" state="full" entity="sip:1001@pbx.local">
+  <dialog id="abc123">
+    <state>terminated</state>
+  </dialog>
+  <dialog id="def456">
+    <state>terminated</state>
+  </dialog>
+</dialog-info>`
+	state, err := parseDialogInfo(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != ExtensionAvailable {
+		t.Errorf("expected ExtensionAvailable, got %d", state)
+	}
+}
+
+func TestParseDialogInfo_MixedConfirmedTerminated(t *testing.T) {
+	body := `<?xml version="1.0"?>
+<dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="3" state="full" entity="sip:1001@pbx.local">
+  <dialog id="abc123">
+    <state>terminated</state>
+  </dialog>
+  <dialog id="def456">
+    <state>confirmed</state>
+  </dialog>
+</dialog-info>`
+	state, err := parseDialogInfo(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != ExtensionOnThePhone {
+		t.Errorf("expected ExtensionOnThePhone, got %d", state)
+	}
+}
+
+func TestParseDialogInfo_InvalidXML(t *testing.T) {
+	_, err := parseDialogInfo("not xml at all")
+	if err == nil {
+		t.Error("expected error for invalid XML")
+	}
+}
+
+func TestParseDialogInfo_ConfirmedBeatsEarly(t *testing.T) {
+	body := `<?xml version="1.0"?>
+<dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="1" state="full" entity="sip:1001@pbx.local">
+  <dialog id="abc123">
+    <state>early</state>
+  </dialog>
+  <dialog id="def456">
+    <state>confirmed</state>
+  </dialog>
+</dialog-info>`
+	state, err := parseDialogInfo(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != ExtensionOnThePhone {
+		t.Errorf("expected ExtensionOnThePhone (confirmed beats early), got %d", state)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -34,4 +34,8 @@ var (
 	ErrNotConnected = errors.New("xphone: not connected")
 	// ErrHostRequired is returned when Connect is called without a Host configured.
 	ErrHostRequired = errors.New("xphone: Host is required")
+	// ErrSubscriptionRejected is returned when the server permanently rejects a SUBSCRIBE.
+	ErrSubscriptionRejected = errors.New("xphone: subscription rejected")
+	// ErrSubscriptionNotFound is returned when UnsubscribeEvent is called with an unknown ID.
+	ErrSubscriptionNotFound = errors.New("xphone: subscription not found")
 )

--- a/events.go
+++ b/events.go
@@ -54,6 +54,36 @@ type SipMessage struct {
 	Body        string
 }
 
+// ExtensionState represents the monitoring state of a remote extension (BLF).
+type ExtensionState int
+
+const (
+	ExtensionAvailable  ExtensionState = iota // idle, no active dialogs
+	ExtensionRinging                          // early/proceeding dialog
+	ExtensionOnThePhone                       // confirmed dialog
+	ExtensionOffline                          // not registered or subscription failed
+	ExtensionUnknown                          // subscription pending or parse error
+)
+
+// SubState represents the state of a SIP event subscription (RFC 6665).
+type SubState int
+
+const (
+	SubStatePending    SubState = iota // awaiting authorization
+	SubStateActive                     // subscription is active
+	SubStateTerminated                 // subscription ended
+)
+
+// NotifyEvent is delivered by SubscribeEvent callbacks for each incoming NOTIFY.
+type NotifyEvent struct {
+	Event             string   // Event header (e.g. "dialog", "presence")
+	ContentType       string   // Content-Type of the NOTIFY body
+	Body              string   // raw NOTIFY body
+	SubscriptionState SubState // parsed Subscription-State
+	Expires           int      // expires parameter from Subscription-State header
+	Reason            string   // reason parameter (e.g. "deactivated", "rejected")
+}
+
 // VoicemailStatus represents the state of a voicemail mailbox (RFC 3842 MWI).
 type VoicemailStatus struct {
 	// MessagesWaiting indicates whether new messages are waiting.

--- a/examples/sipcli/main.go
+++ b/examples/sipcli/main.go
@@ -64,6 +64,12 @@ type trackedCall struct {
 	status string
 }
 
+// blfEntry tracks one watched extension in the BLF panel.
+type blfEntry struct {
+	extension string
+	state     xphone.ExtensionState
+}
+
 // prog is the running bubbletea program. Used by xphone callbacks and the
 // custom slog handler to send messages into the TUI from any goroutine.
 var prog *tea.Program
@@ -79,6 +85,14 @@ type msgCallState struct {
 }
 type msgCallEnded struct{ callID string }
 type msgCallRef struct{ call xphone.Call }
+type msgWatchAdded struct {
+	ext string
+	id  string
+}
+type msgBLFUpdate struct {
+	ext   string
+	state xphone.ExtensionState
+}
 
 // ---------------------------------------------------------------------------
 // Custom slog handler that feeds into the TUI debug panel
@@ -221,6 +235,10 @@ type model struct {
 	// Audio handler for speaker/mic/echo (nil if no active call)
 	audio *audioHandler
 
+	// BLF state
+	blf     []blfEntry        // watched extensions for BLF panel
+	watches map[string]string // subscription IDs keyed by extension
+
 	// Command history
 	history      []string
 	historyPos   int // -1 = not browsing
@@ -233,6 +251,7 @@ func initialModel(phone xphone.Phone) model {
 		regStatus:  "disconnected",
 		width:      80,
 		height:     24,
+		watches:    make(map[string]string),
 		history:    loadHistory(),
 		historyPos: -1,
 	}
@@ -283,6 +302,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.selected >= len(m.calls) && m.selected > 0 {
 					m.selected = len(m.calls) - 1
 				}
+				break
+			}
+		}
+	case msgWatchAdded:
+		m.watches[msg.ext] = msg.id
+		// Add to BLF list with Unknown state (will be updated by first NOTIFY).
+		m.blf = append(m.blf, blfEntry{extension: msg.ext, state: xphone.ExtensionUnknown})
+	case msgBLFUpdate:
+		for i := range m.blf {
+			if m.blf[i].extension == msg.ext {
+				m.blf[i].state = msg.state
 				break
 			}
 		}
@@ -452,16 +482,32 @@ func (m model) View() string {
 		callsInnerH = 6
 	}
 	callsPanelH := callsInnerH + 2 // +2 for border
-	eventsPanelH := panelH - callsPanelH
+
+	// BLF panel height: conditional, only when watching extensions
+	blfPanelH := 0
+	if len(m.blf) > 0 {
+		blfInnerH := len(m.blf)
+		if blfInnerH > 4 {
+			blfInnerH = 4
+		}
+		blfPanelH = blfInnerH + 2 // +2 for border
+	}
+
+	eventsPanelH := panelH - callsPanelH - blfPanelH
 	if eventsPanelH < 4 {
 		eventsPanelH = 4
-		callsPanelH = panelH - eventsPanelH
+		callsPanelH = panelH - eventsPanelH - blfPanelH
 	}
 
 	callsPanel := m.renderCallsPanel(leftW, callsPanelH)
-	eventsPanel := m.renderEventsPanel(leftW, eventsPanelH)
+	var leftPanels []string
+	leftPanels = append(leftPanels, callsPanel)
+	if blfPanelH > 0 {
+		leftPanels = append(leftPanels, m.renderBLFPanel(leftW, blfPanelH))
+	}
+	leftPanels = append(leftPanels, m.renderEventsPanel(leftW, eventsPanelH))
 	leftColumn := lipgloss.NewStyle().Height(panelH).Render(
-		lipgloss.JoinVertical(lipgloss.Left, callsPanel, eventsPanel),
+		lipgloss.JoinVertical(lipgloss.Left, leftPanels...),
 	)
 
 	// --- Right panel (60%) ---
@@ -554,6 +600,51 @@ func (m model) renderCallsPanel(w, h int) string {
 		Render(titleStyle.Render(" Calls ") + "\n" + content)
 }
 
+func (m model) renderBLFPanel(w, h int) string {
+	innerW := w - 2
+	innerH := h - 2
+	if innerH < 1 {
+		innerH = 1
+	}
+
+	var lines []string
+	for _, b := range m.blf {
+		indicator, style := blfIndicator(b.state)
+		line := "  " + style.Render(indicator) + " " + whiteStyle.Render(b.extension) +
+			"  " + style.Render(extStateName(b.state))
+		lines = append(lines, truncate(line, innerW))
+	}
+
+	for len(lines) < innerH {
+		lines = append(lines, "")
+	}
+	if len(lines) > innerH {
+		lines = lines[:innerH]
+	}
+
+	content := strings.Join(lines, "\n")
+	return borderStyle.
+		Width(innerW).
+		Height(innerH).
+		Background(surface).
+		Render(titleStyle.Render(" BLF ") + "\n" + content)
+}
+
+func blfIndicator(state xphone.ExtensionState) (string, lipgloss.Style) {
+	switch state {
+	case xphone.ExtensionAvailable:
+		return "●", greenStyle
+	case xphone.ExtensionRinging:
+		return "◌", yellowStyle
+	case xphone.ExtensionOnThePhone:
+		return "●", redStyle
+	case xphone.ExtensionOffline:
+		return "○", dimStyle
+	default:
+		return "○", dimStyle
+	}
+}
+
 func (m model) renderEventsPanel(w, h int) string {
 	return renderLogPanel(" Events ", m.events, w, h, styleEvent)
 }
@@ -642,7 +733,7 @@ func (m model) renderCommandArea(w int) string {
 
 	inputLine := promptStyle.Render(" > ") + m.input + cursorStyle.Render("_")
 
-	helpText := "dial(d) accept(a) reject hangup(h) hold resume mute unmute dtmf transfer(xfer) msg echo speaker mic 1/2/3 quit(q)"
+	helpText := "dial(d) accept(a) reject hangup(h) hold resume mute unmute dtmf transfer(xfer) msg watch(w) unwatch(uw) echo speaker mic quit(q)"
 	helpLine := "   " + dimStyle.Render(helpText)
 
 	cmdTitle := titleStyle.Render(" Command ")
@@ -697,6 +788,12 @@ func styleEvent(line string) string {
 		return magentaStyle.Render(line)
 	case strings.HasPrefix(content, "MSG from"):
 		return incomingStyle.Render(line)
+	case strings.HasPrefix(content, "BLF"):
+		return magentaStyle.Render(line)
+	case strings.HasPrefix(content, "watching"):
+		return accentStyle.Render(line)
+	case strings.HasPrefix(content, "unwatched"):
+		return accentStyle.Render(line)
 	case strings.HasPrefix(content, "dialing"),
 		strings.HasPrefix(content, "ringing"),
 		strings.HasPrefix(content, "early media"):
@@ -853,6 +950,57 @@ func (m model) execCommand(input string) (model, tea.Cmd) {
 				return msgLog(fmt.Sprintf("ERROR msg: %s", err))
 			}
 			return msgLog(fmt.Sprintf("message sent to %s", target))
+		}
+
+	case "watch", "w":
+		if arg == "" {
+			m.err = "usage: watch <extension>"
+			return m, nil
+		}
+		ext := arg
+		if _, ok := m.watches[ext]; ok {
+			m.err = fmt.Sprintf("already watching %s", ext)
+			return m, nil
+		}
+		m.pushEvent(fmt.Sprintf("watching %s...", ext))
+		ph := m.phone
+		return m, func() tea.Msg {
+			id, err := ph.Watch(context.Background(), ext, func(extension string, state, prev xphone.ExtensionState) {
+				prog.Send(msgBLFUpdate{ext: extension, state: state})
+				prog.Send(msgLog(fmt.Sprintf("BLF %s: %s (was %s)", extension, extStateName(state), extStateName(prev))))
+			})
+			if err != nil {
+				return msgLog(fmt.Sprintf("ERROR watch %s: %s", ext, err))
+			}
+			prog.Send(msgLog(fmt.Sprintf("watching %s", ext)))
+			return msgWatchAdded{ext: ext, id: id}
+		}
+
+	case "unwatch", "uw":
+		if arg == "" {
+			m.err = "usage: unwatch <extension>"
+			return m, nil
+		}
+		ext := arg
+		id, ok := m.watches[ext]
+		if !ok {
+			m.err = fmt.Sprintf("not watching %s", ext)
+			return m, nil
+		}
+		delete(m.watches, ext)
+		// Remove from BLF list.
+		for i := range m.blf {
+			if m.blf[i].extension == ext {
+				m.blf = append(m.blf[:i], m.blf[i+1:]...)
+				break
+			}
+		}
+		ph := m.phone
+		return m, func() tea.Msg {
+			if err := ph.Unwatch(id); err != nil {
+				return msgLog(fmt.Sprintf("ERROR unwatch %s: %s", ext, err))
+			}
+			return msgLog(fmt.Sprintf("unwatched %s", ext))
 		}
 
 	case "echo":
@@ -1094,6 +1242,23 @@ func callStateName(s xphone.CallState) string {
 		return "ended"
 	default:
 		return fmt.Sprintf("unknown(%d)", s)
+	}
+}
+
+func extStateName(s xphone.ExtensionState) string {
+	switch s {
+	case xphone.ExtensionAvailable:
+		return "available"
+	case xphone.ExtensionRinging:
+		return "ringing"
+	case xphone.ExtensionOnThePhone:
+		return "on the phone"
+	case xphone.ExtensionOffline:
+		return "offline"
+	case xphone.ExtensionUnknown:
+		return "unknown"
+	default:
+		return fmt.Sprintf("state(%d)", s)
 	}
 }
 

--- a/mock_phone.go
+++ b/mock_phone.go
@@ -153,6 +153,22 @@ func (p *MockPhone) SendMessageWithType(_ context.Context, _ string, _ string, _
 	return nil
 }
 
+func (p *MockPhone) Watch(_ context.Context, _ string, _ func(string, ExtensionState, ExtensionState)) (string, error) {
+	return newCallID(), nil
+}
+
+func (p *MockPhone) Unwatch(_ string) error {
+	return nil
+}
+
+func (p *MockPhone) SubscribeEvent(_ context.Context, _ string, _ string, _ int, _ func(NotifyEvent)) (string, error) {
+	return newCallID(), nil
+}
+
+func (p *MockPhone) UnsubscribeEvent(_ string) error {
+	return nil
+}
+
 // wireCallCallbacks hooks phone-level call callbacks onto a MockCall's
 // internal fields so they coexist with user-set per-call callbacks.
 // Must be called with p.mu held.

--- a/sipgo_dialog.go
+++ b/sipgo_dialog.go
@@ -13,7 +13,9 @@ const contentTypeSDP = "application/sdp"
 const contentTypeDTMFRelay = "application/dtmf-relay"
 const contentTypeMWI = "application/simple-message-summary"
 const contentTypeTextPlain = "text/plain"
+const contentTypeDialogInfo = "application/dialog-info+xml"
 const eventMWI = "message-summary"
+const eventDialog = "dialog"
 
 // sipRequestTimeout is the deadline for SIP dialog operations (BYE, re-INVITE, REFER).
 const sipRequestTimeout = 5 * time.Second

--- a/sipua.go
+++ b/sipua.go
@@ -86,6 +86,10 @@ type sipUA struct {
 	// The phone uses this to fire DTMF callbacks on the call.
 	onDialogInfo func(callID string, digit string)
 
+	// onNotify is the general NOTIFY callback for SUBSCRIBE/NOTIFY (RFC 6665).
+	// Receives event, from, contentType, body, subscriptionState.
+	onNotify func(event, from, contentType, body, subscriptionState string)
+
 	// onMWINotify is called when an inbound NOTIFY with application/simple-message-summary
 	// Content-Type is received (MWI). The callback receives the raw body string.
 	onMWINotify func(body string)
@@ -417,7 +421,7 @@ func (s *sipUA) startServer() {
 		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
 		tx.Respond(res)
 
-		// Dispatch by Content-Type: MWI vs REFER progress (sipfrag).
+		// Extract common headers for dispatch.
 		ct := ""
 		if h := req.ContentType(); h != nil {
 			ct = h.Value()
@@ -428,8 +432,13 @@ func (s *sipUA) startServer() {
 		}
 		mediaType = strings.TrimSpace(mediaType)
 
+		event := ""
+		if h := req.GetHeader("Event"); h != nil {
+			event = h.Value()
+		}
+
+		// MWI dispatch (legacy dedicated handler).
 		if strings.EqualFold(mediaType, contentTypeMWI) {
-			// MWI NOTIFY — dispatch to MWI handler.
 			s.mu.Lock()
 			fn := s.onMWINotify
 			s.mu.Unlock()
@@ -441,20 +450,35 @@ func (s *sipUA) startServer() {
 
 		// REFER progress (message/sipfrag) — parse status code and dispatch.
 		code := parseSipfragStatus(string(req.Body()))
-		if code <= 0 {
+		if code > 0 {
+			callID := ""
+			if h := req.CallID(); h != nil {
+				callID = h.Value()
+			}
+			s.mu.Lock()
+			fn := s.onDialogNotify
+			s.mu.Unlock()
+			if fn != nil && callID != "" {
+				go fn(callID, code)
+			}
 			return
 		}
 
-		callID := ""
-		if h := req.CallID(); h != nil {
-			callID = h.Value()
-		}
-
+		// General NOTIFY dispatch (for SubscriptionManager).
+		// Only reached for non-MWI, non-REFER NOTIFYs.
 		s.mu.Lock()
-		fn := s.onDialogNotify
+		generalFn := s.onNotify
 		s.mu.Unlock()
-		if fn != nil && callID != "" {
-			go fn(callID, code)
+		if generalFn != nil {
+			from := ""
+			if f := req.From(); f != nil {
+				from = f.Address.String()
+			}
+			subState := ""
+			if h := req.GetHeader("Subscription-State"); h != nil {
+				subState = h.Value()
+			}
+			go generalFn(event, from, ct, string(req.Body()), subState)
 		}
 	})
 
@@ -607,6 +631,12 @@ func (s *sipUA) SendSubscribe(ctx context.Context, uri string, headers map[strin
 	req.AppendHeader(&contact)
 
 	return s.doWithAuth(ctx, req)
+}
+
+func (s *sipUA) OnNotify(fn func(event, from, contentType, body, subscriptionState string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onNotify = fn
 }
 
 func (s *sipUA) OnMWINotify(fn func(body string)) {

--- a/subscribe.go
+++ b/subscribe.go
@@ -1,0 +1,417 @@
+package xphone
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultSubscribeExpires is the default Expires value for SUBSCRIBE requests.
+const defaultSubscribeExpires = 600
+
+// RFC 6665 §4.1.3 Subscription-State reason values that trigger auto-resubscribe.
+const (
+	reasonDeactivated = "deactivated"
+	reasonTimeout     = "timeout"
+)
+
+// subscription represents a single SIP SUBSCRIBE dialog.
+type subscription struct {
+	id      string
+	uri     string
+	event   string
+	expires int
+
+	// Watch-specific fields.
+	isWatch   bool
+	extension string
+	watchFn   func(ext string, state ExtensionState, prev ExtensionState)
+	prevState ExtensionState
+
+	// SubscribeEvent-specific fields.
+	notifyFn func(NotifyEvent)
+
+	// Refresh goroutine cancel.
+	refreshCancel context.CancelFunc
+}
+
+// subscriptionManager manages SUBSCRIBE/NOTIFY dialogs.
+// It handles BLF Watch subscriptions (dialog-info) and generic SubscribeEvent.
+type subscriptionManager struct {
+	mu     sync.Mutex
+	tr     sipTransport
+	host   string
+	logger *slog.Logger
+	subs   map[string]*subscription
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newSubscriptionManager(tr sipTransport, host string, logger *slog.Logger) *subscriptionManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &subscriptionManager{
+		tr:     tr,
+		host:   host,
+		logger: logger,
+		subs:   make(map[string]*subscription),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// start wires the general NOTIFY handler on the transport.
+func (m *subscriptionManager) start() {
+	m.tr.OnNotify(m.handleNotify)
+}
+
+// stop cancels all refresh goroutines and sends best-effort unsubscribes.
+func (m *subscriptionManager) stop() {
+	m.cancel()
+
+	m.mu.Lock()
+	subs := make([]*subscription, 0, len(m.subs))
+	for _, s := range m.subs {
+		subs = append(subs, s)
+	}
+	m.subs = make(map[string]*subscription)
+	m.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, s := range subs {
+		if s.refreshCancel != nil {
+			s.refreshCancel()
+		}
+		wg.Add(1)
+		go func(sub *subscription) {
+			defer wg.Done()
+			m.sendUnsubscribe(sub)
+		}(s)
+	}
+	wg.Wait()
+}
+
+// watch creates a BLF subscription for an extension using dialog event (RFC 4235).
+// Returns a subscription ID that can be passed to unwatch.
+func (m *subscriptionManager) watch(ctx context.Context, extension string, fn func(string, ExtensionState, ExtensionState)) (string, error) {
+	sub := &subscription{
+		id:        newCallID(),
+		uri:       "sip:" + extension + "@" + m.host,
+		event:     eventDialog,
+		expires:   defaultSubscribeExpires,
+		isWatch:   true,
+		extension: extension,
+		watchFn:   fn,
+		prevState: ExtensionUnknown,
+	}
+	return m.doSubscribe(ctx, sub)
+}
+
+// unwatch removes a BLF Watch subscription.
+func (m *subscriptionManager) unwatch(id string) error {
+	return m.remove(id)
+}
+
+// subscribeEvent creates a generic SIP event subscription.
+// Returns a subscription ID that can be passed to unsubscribeEvent.
+func (m *subscriptionManager) subscribeEvent(ctx context.Context, uri, event string, expires int, fn func(NotifyEvent)) (string, error) {
+	if expires <= 0 {
+		expires = defaultSubscribeExpires
+	}
+	sub := &subscription{
+		id:       newCallID(),
+		uri:      uri,
+		event:    event,
+		expires:  expires,
+		notifyFn: fn,
+	}
+	return m.doSubscribe(ctx, sub)
+}
+
+// doSubscribe registers a subscription and sends the initial SUBSCRIBE request.
+// On failure, the subscription is removed from the map.
+func (m *subscriptionManager) doSubscribe(ctx context.Context, sub *subscription) (string, error) {
+	// Register before sending so the initial NOTIFY can be dispatched.
+	m.mu.Lock()
+	m.subs[sub.id] = sub
+	m.mu.Unlock()
+
+	headers := m.subscribeHeaders(sub)
+	code, _, err := m.tr.SendSubscribe(ctx, sub.uri, headers)
+	if err != nil || code >= 400 {
+		m.mu.Lock()
+		delete(m.subs, sub.id)
+		m.mu.Unlock()
+		if err != nil {
+			return "", err
+		}
+		return "", ErrSubscriptionRejected
+	}
+
+	m.startRefresh(sub)
+	return sub.id, nil
+}
+
+// unsubscribeEvent removes a generic event subscription.
+func (m *subscriptionManager) unsubscribeEvent(id string) error {
+	return m.remove(id)
+}
+
+// remove cancels a subscription by ID: stops refresh and sends Expires: 0.
+func (m *subscriptionManager) remove(id string) error {
+	m.mu.Lock()
+	sub, ok := m.subs[id]
+	if !ok {
+		m.mu.Unlock()
+		return ErrSubscriptionNotFound
+	}
+	delete(m.subs, id)
+	m.mu.Unlock()
+
+	if sub.refreshCancel != nil {
+		sub.refreshCancel()
+	}
+	m.sendUnsubscribe(sub)
+	return nil
+}
+
+// subscribeHeaders builds the common headers for a SUBSCRIBE request.
+func (m *subscriptionManager) subscribeHeaders(sub *subscription) map[string]string {
+	headers := map[string]string{
+		"Event":   sub.event,
+		"Expires": strconv.Itoa(sub.expires),
+	}
+	if sub.isWatch {
+		headers["Accept"] = contentTypeDialogInfo
+	}
+	return headers
+}
+
+// sendUnsubscribe sends a SUBSCRIBE with Expires: 0 (best-effort).
+func (m *subscriptionManager) sendUnsubscribe(sub *subscription) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	headers := map[string]string{
+		"Event":   sub.event,
+		"Expires": "0",
+	}
+	m.tr.SendSubscribe(ctx, sub.uri, headers)
+}
+
+// startRefresh launches a goroutine that refreshes the subscription at half the Expires interval.
+func (m *subscriptionManager) startRefresh(sub *subscription) {
+	refreshCtx, refreshCancel := context.WithCancel(m.ctx)
+
+	m.mu.Lock()
+	sub.refreshCancel = refreshCancel
+	m.mu.Unlock()
+
+	interval := time.Duration(sub.expires/2) * time.Second
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-refreshCtx.Done():
+				return
+			case <-ticker.C:
+				m.refresh(refreshCtx, sub)
+			}
+		}
+	}()
+}
+
+// refresh sends a SUBSCRIBE refresh for the given subscription.
+func (m *subscriptionManager) refresh(ctx context.Context, sub *subscription) {
+	headers := m.subscribeHeaders(sub)
+	code, _, err := m.tr.SendSubscribe(ctx, sub.uri, headers)
+	if err != nil {
+		m.logger.Warn("subscription refresh failed", "id", sub.id, "err", err)
+		return
+	}
+	if code >= 400 {
+		m.logger.Warn("subscription refresh rejected", "id", sub.id, "code", code)
+		m.mu.Lock()
+		delete(m.subs, sub.id)
+		m.mu.Unlock()
+		if sub.refreshCancel != nil {
+			sub.refreshCancel()
+		}
+	}
+}
+
+// handleNotify processes incoming NOTIFY requests from the transport.
+func (m *subscriptionManager) handleNotify(event, from, contentType, body, subscriptionState string) {
+	subState, stateExpires, reason := parseSubscriptionState(subscriptionState)
+
+	m.mu.Lock()
+	match := m.findMatch(event, from)
+	if match == nil {
+		m.mu.Unlock()
+		return
+	}
+
+	// Snapshot callback fields under lock.
+	watchFn := match.watchFn
+	notifyFn := match.notifyFn
+	isWatch := match.isWatch
+	extension := match.extension
+	prev := match.prevState
+
+	// Handle terminated subscriptions under lock.
+	var cancelFn context.CancelFunc
+	if subState == SubStateTerminated {
+		if reason == reasonDeactivated || reason == reasonTimeout {
+			// Will resubscribe after unlock.
+		} else {
+			delete(m.subs, match.id)
+			cancelFn = match.refreshCancel
+		}
+	}
+
+	// Update refresh interval if server changed expires.
+	restartRefresh := false
+	if stateExpires > 0 && stateExpires != match.expires {
+		match.expires = stateExpires
+		cancelFn = match.refreshCancel
+		restartRefresh = true
+	}
+	m.mu.Unlock()
+
+	if cancelFn != nil {
+		cancelFn()
+	}
+	if subState == SubStateTerminated && (reason == reasonDeactivated || reason == reasonTimeout) {
+		go m.resubscribe(match)
+	}
+	if restartRefresh {
+		m.startRefresh(match)
+	}
+
+	// Dispatch to callback.
+	if isWatch && watchFn != nil {
+		state, err := parseDialogInfo(body)
+		if err != nil {
+			m.logger.Warn("watch: failed to parse dialog-info", "ext", extension, "err", err)
+			return
+		}
+		m.mu.Lock()
+		match.prevState = state
+		m.mu.Unlock()
+		watchFn(extension, state, prev)
+	} else if notifyFn != nil {
+		notifyFn(NotifyEvent{
+			Event:             event,
+			ContentType:       contentType,
+			Body:              body,
+			SubscriptionState: subState,
+			Expires:           stateExpires,
+			Reason:            reason,
+		})
+	}
+}
+
+// findMatch finds a subscription matching the given event and from URI.
+// Must be called with m.mu held.
+func (m *subscriptionManager) findMatch(event, from string) *subscription {
+	fromUser := extractSIPUser(from)
+	for _, s := range m.subs {
+		if s.event != event {
+			continue
+		}
+		if s.isWatch {
+			if fromUser == s.extension {
+				return s
+			}
+		} else {
+			if extractSIPUser(s.uri) == fromUser {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+// resubscribe sends a fresh SUBSCRIBE after a deactivated/timeout termination.
+func (m *subscriptionManager) resubscribe(sub *subscription) {
+	if sub.refreshCancel != nil {
+		sub.refreshCancel()
+	}
+
+	// Check that the subscription is still active (not unwatched by user).
+	m.mu.Lock()
+	if _, ok := m.subs[sub.id]; !ok {
+		m.mu.Unlock()
+		return
+	}
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	defer cancel()
+
+	headers := m.subscribeHeaders(sub)
+	code, _, err := m.tr.SendSubscribe(ctx, sub.uri, headers)
+	if err != nil || code >= 400 {
+		m.logger.Warn("resubscribe failed, removing subscription", "id", sub.id)
+		m.mu.Lock()
+		delete(m.subs, sub.id)
+		m.mu.Unlock()
+		return
+	}
+
+	m.startRefresh(sub)
+}
+
+// parseSubscriptionState parses a Subscription-State header value.
+// Examples: "active;expires=600", "terminated;reason=deactivated"
+func parseSubscriptionState(header string) (SubState, int, string) {
+	if header == "" {
+		return SubStateActive, 0, ""
+	}
+
+	parts := strings.Split(header, ";")
+	stateStr := strings.TrimSpace(parts[0])
+
+	var state SubState
+	switch strings.ToLower(stateStr) {
+	case "active":
+		state = SubStateActive
+	case "pending":
+		state = SubStatePending
+	case "terminated":
+		state = SubStateTerminated
+	default:
+		state = SubStateActive
+	}
+
+	var expires int
+	var reason string
+	for _, param := range parts[1:] {
+		param = strings.TrimSpace(param)
+		if strings.HasPrefix(param, "expires=") {
+			expires, _ = strconv.Atoi(param[8:])
+		} else if strings.HasPrefix(param, "reason=") {
+			reason = param[7:]
+		}
+	}
+
+	return state, expires, reason
+}
+
+// extractSIPUser extracts the user part from a SIP URI.
+// "sip:1001@pbx.local" → "1001", "1001" → "1001"
+func extractSIPUser(uri string) string {
+	s := uri
+	if strings.HasPrefix(s, "sip:") {
+		s = s[4:]
+	} else if strings.HasPrefix(s, "sips:") {
+		s = s[5:]
+	}
+	if at := strings.Index(s, "@"); at >= 0 {
+		return s[:at]
+	}
+	return s
+}

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -1,0 +1,409 @@
+package xphone
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/x-phone/xphone-go/testutil"
+)
+
+// --- parseSubscriptionState ---
+
+func TestParseSubscriptionState_Active(t *testing.T) {
+	state, expires, reason := parseSubscriptionState("active;expires=600")
+	if state != SubStateActive {
+		t.Errorf("expected SubStateActive, got %d", state)
+	}
+	if expires != 600 {
+		t.Errorf("expected expires 600, got %d", expires)
+	}
+	if reason != "" {
+		t.Errorf("expected empty reason, got %q", reason)
+	}
+}
+
+func TestParseSubscriptionState_Pending(t *testing.T) {
+	state, _, _ := parseSubscriptionState("pending;expires=3600")
+	if state != SubStatePending {
+		t.Errorf("expected SubStatePending, got %d", state)
+	}
+}
+
+func TestParseSubscriptionState_Terminated(t *testing.T) {
+	state, _, reason := parseSubscriptionState("terminated;reason=deactivated")
+	if state != SubStateTerminated {
+		t.Errorf("expected SubStateTerminated, got %d", state)
+	}
+	if reason != "deactivated" {
+		t.Errorf("expected reason deactivated, got %q", reason)
+	}
+}
+
+func TestParseSubscriptionState_Empty(t *testing.T) {
+	state, expires, reason := parseSubscriptionState("")
+	if state != SubStateActive {
+		t.Errorf("expected SubStateActive for empty header, got %d", state)
+	}
+	if expires != 0 {
+		t.Errorf("expected 0 expires, got %d", expires)
+	}
+	if reason != "" {
+		t.Errorf("expected empty reason, got %q", reason)
+	}
+}
+
+// --- extractSIPUser ---
+
+func TestExtractSIPUser(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"sip:1001@pbx.local", "1001"},
+		{"sips:1001@pbx.local", "1001"},
+		{"1001@pbx.local", "1001"},
+		{"1001", "1001"},
+		{"sip:alice@example.com", "alice"},
+	}
+	for _, tt := range tests {
+		got := extractSIPUser(tt.input)
+		if got != tt.want {
+			t.Errorf("extractSIPUser(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// --- Watch ---
+
+func TestWatch_Success(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+	tr.RespondWith(200, "OK") // SUBSCRIBE
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	var gotExt string
+	var gotState, gotPrev ExtensionState
+	done := make(chan struct{})
+
+	id, err := p.Watch(context.Background(), "1002", func(ext string, state, prev ExtensionState) {
+		gotExt = ext
+		gotState = state
+		gotPrev = prev
+		close(done)
+	})
+	if err != nil {
+		t.Fatalf("Watch failed: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected non-empty subscription ID")
+	}
+
+	// Verify SUBSCRIBE was sent.
+	sub := tr.LastSent("SUBSCRIBE")
+	if sub == nil {
+		t.Fatal("expected SUBSCRIBE to be sent")
+	}
+	if sub.URI != "sip:1002@127.0.0.1" {
+		t.Errorf("expected URI sip:1002@127.0.0.1, got %q", sub.URI)
+	}
+	if sub.Header("Event") != "dialog" {
+		t.Errorf("expected Event: dialog, got %q", sub.Header("Event"))
+	}
+	if sub.Header("Accept") != "application/dialog-info+xml" {
+		t.Errorf("expected Accept: application/dialog-info+xml, got %q", sub.Header("Accept"))
+	}
+
+	// Simulate a NOTIFY with dialog-info.
+	dialogInfoBody := `<?xml version="1.0"?><dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="0" state="full" entity="sip:1002@127.0.0.1"><dialog id="abc"><state>confirmed</state></dialog></dialog-info>`
+	tr.SimulateNotify("dialog", "sip:1002@127.0.0.1", "application/dialog-info+xml", dialogInfoBody, "active;expires=600")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for watch callback")
+	}
+
+	if gotExt != "1002" {
+		t.Errorf("expected ext 1002, got %q", gotExt)
+	}
+	if gotState != ExtensionOnThePhone {
+		t.Errorf("expected ExtensionOnThePhone, got %d", gotState)
+	}
+	if gotPrev != ExtensionUnknown {
+		t.Errorf("expected prev ExtensionUnknown, got %d", gotPrev)
+	}
+}
+
+func TestWatch_Rejected(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+	tr.RespondWith(403, "Forbidden")
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	_, err := p.Watch(context.Background(), "1002", func(string, ExtensionState, ExtensionState) {})
+	if err != ErrSubscriptionRejected {
+		t.Errorf("expected ErrSubscriptionRejected, got %v", err)
+	}
+}
+
+func TestWatch_NotConnected(t *testing.T) {
+	p := newPhone(testConfig())
+	_, err := p.Watch(context.Background(), "1002", func(string, ExtensionState, ExtensionState) {})
+	if err != ErrNotConnected {
+		t.Errorf("expected ErrNotConnected, got %v", err)
+	}
+}
+
+func TestUnwatch_Success(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+	tr.RespondWith(200, "OK") // SUBSCRIBE
+	tr.RespondWith(200, "OK") // unsubscribe (Expires: 0)
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	id, err := p.Watch(context.Background(), "1002", func(string, ExtensionState, ExtensionState) {})
+	if err != nil {
+		t.Fatalf("Watch failed: %v", err)
+	}
+
+	err = p.Unwatch(id)
+	if err != nil {
+		t.Fatalf("Unwatch failed: %v", err)
+	}
+
+	// Verify unsubscribe SUBSCRIBE with Expires: 0 was sent.
+	if tr.CountSent("SUBSCRIBE") != 2 {
+		t.Errorf("expected 2 SUBSCRIBEs (subscribe + unsubscribe), got %d", tr.CountSent("SUBSCRIBE"))
+	}
+}
+
+func TestUnwatch_NotFound(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	err := p.Unwatch("nonexistent-id")
+	if err != ErrSubscriptionNotFound {
+		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
+	}
+}
+
+// --- Watch prev state tracking ---
+
+func TestWatch_PrevStateTracking(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+	tr.RespondWith(200, "OK") // SUBSCRIBE
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	var states []ExtensionState
+	var prevs []ExtensionState
+	notify := make(chan struct{}, 5)
+
+	_, err := p.Watch(context.Background(), "1002", func(_ string, state, prev ExtensionState) {
+		states = append(states, state)
+		prevs = append(prevs, prev)
+		notify <- struct{}{}
+	})
+	if err != nil {
+		t.Fatalf("Watch failed: %v", err)
+	}
+
+	// First NOTIFY: idle (no dialogs).
+	bodyAvailable := `<?xml version="1.0"?><dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="0" state="full" entity="sip:1002@127.0.0.1"></dialog-info>`
+	tr.SimulateNotify("dialog", "sip:1002@127.0.0.1", "application/dialog-info+xml", bodyAvailable, "active;expires=600")
+	<-notify
+
+	// Second NOTIFY: ringing.
+	bodyRinging := `<?xml version="1.0"?><dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="1" state="full" entity="sip:1002@127.0.0.1"><dialog id="1"><state>early</state></dialog></dialog-info>`
+	tr.SimulateNotify("dialog", "sip:1002@127.0.0.1", "application/dialog-info+xml", bodyRinging, "active;expires=600")
+	<-notify
+
+	// Third NOTIFY: confirmed.
+	bodyConfirmed := `<?xml version="1.0"?><dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="2" state="full" entity="sip:1002@127.0.0.1"><dialog id="1"><state>confirmed</state></dialog></dialog-info>`
+	tr.SimulateNotify("dialog", "sip:1002@127.0.0.1", "application/dialog-info+xml", bodyConfirmed, "active;expires=600")
+	<-notify
+
+	// Verify state transitions: Unknown→Available→Ringing→OnThePhone.
+	if len(states) != 3 {
+		t.Fatalf("expected 3 callbacks, got %d", len(states))
+	}
+	if prevs[0] != ExtensionUnknown || states[0] != ExtensionAvailable {
+		t.Errorf("first: expected Unknown→Available, got %d→%d", prevs[0], states[0])
+	}
+	if prevs[1] != ExtensionAvailable || states[1] != ExtensionRinging {
+		t.Errorf("second: expected Available→Ringing, got %d→%d", prevs[1], states[1])
+	}
+	if prevs[2] != ExtensionRinging || states[2] != ExtensionOnThePhone {
+		t.Errorf("third: expected Ringing→OnThePhone, got %d→%d", prevs[2], states[2])
+	}
+}
+
+// --- SubscribeEvent ---
+
+func TestSubscribeEvent_Success(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+	tr.RespondWith(200, "OK") // SUBSCRIBE
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	var gotEvent NotifyEvent
+	done := make(chan struct{})
+
+	id, err := p.SubscribeEvent(context.Background(), "sip:1002@127.0.0.1", "presence", 300, func(ev NotifyEvent) {
+		gotEvent = ev
+		close(done)
+	})
+	if err != nil {
+		t.Fatalf("SubscribeEvent failed: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected non-empty subscription ID")
+	}
+
+	// Simulate a NOTIFY.
+	tr.SimulateNotify("presence", "sip:1002@127.0.0.1", "application/pidf+xml", "<presence/>", "active;expires=300")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for subscribe event callback")
+	}
+
+	if gotEvent.Event != "presence" {
+		t.Errorf("expected event presence, got %q", gotEvent.Event)
+	}
+	if gotEvent.Body != "<presence/>" {
+		t.Errorf("expected body <presence/>, got %q", gotEvent.Body)
+	}
+	if gotEvent.SubscriptionState != SubStateActive {
+		t.Errorf("expected SubStateActive, got %d", gotEvent.SubscriptionState)
+	}
+	if gotEvent.Expires != 300 {
+		t.Errorf("expected expires 300, got %d", gotEvent.Expires)
+	}
+}
+
+func TestSubscribeEvent_Rejected(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+	tr.RespondWith(489, "Bad Event")
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	_, err := p.SubscribeEvent(context.Background(), "sip:1002@127.0.0.1", "badEvent", 0, func(NotifyEvent) {})
+	if err != ErrSubscriptionRejected {
+		t.Errorf("expected ErrSubscriptionRejected, got %v", err)
+	}
+}
+
+func TestUnsubscribeEvent_Success(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+	tr.RespondWith(200, "OK") // SUBSCRIBE
+	tr.RespondWith(200, "OK") // unsubscribe
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	id, err := p.SubscribeEvent(context.Background(), "sip:1002@127.0.0.1", "dialog", 300, func(NotifyEvent) {})
+	if err != nil {
+		t.Fatalf("SubscribeEvent failed: %v", err)
+	}
+
+	err = p.UnsubscribeEvent(id)
+	if err != nil {
+		t.Fatalf("UnsubscribeEvent failed: %v", err)
+	}
+
+	// Check Expires: 0 was sent.
+	last := tr.LastSent("SUBSCRIBE")
+	if last == nil {
+		t.Fatal("expected SUBSCRIBE")
+	}
+	if last.Header("Expires") != "0" {
+		t.Errorf("expected Expires: 0 for unsubscribe, got %q", last.Header("Expires"))
+	}
+}
+
+func TestUnsubscribeEvent_NotFound(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	err := p.UnsubscribeEvent("nonexistent")
+	if err != ErrSubscriptionNotFound {
+		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
+	}
+}
+
+// --- Auto-resubscribe on deactivated ---
+
+func TestWatch_ResubscribeOnDeactivated(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+	tr.RespondWith(200, "OK") // initial SUBSCRIBE
+	tr.RespondWith(200, "OK") // resubscribe SUBSCRIBE
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	_, err := p.Watch(context.Background(), "1002", func(string, ExtensionState, ExtensionState) {})
+	if err != nil {
+		t.Fatalf("Watch failed: %v", err)
+	}
+
+	initialCount := tr.CountSent("SUBSCRIBE")
+
+	// Simulate terminated;reason=deactivated — should auto-resubscribe.
+	tr.SimulateNotify("dialog", "sip:1002@127.0.0.1", "application/dialog-info+xml",
+		`<?xml version="1.0"?><dialog-info xmlns="urn:ietf:params:xml:ns:dialog-info" version="0" state="full" entity="sip:1002@127.0.0.1"></dialog-info>`,
+		"terminated;reason=deactivated")
+
+	// Wait for the resubscribe goroutine to send the SUBSCRIBE.
+	time.Sleep(200 * time.Millisecond)
+
+	if tr.CountSent("SUBSCRIBE") <= initialCount {
+		t.Error("expected resubscribe SUBSCRIBE after terminated;reason=deactivated")
+	}
+}
+
+// --- Disconnect stops subscriptions ---
+
+func TestDisconnect_StopsSubscriptions(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondWith(200, "OK") // registration
+	tr.RespondWith(200, "OK") // SUBSCRIBE
+	tr.RespondWith(200, "OK") // unsubscribe on Disconnect
+
+	p := newPhone(testConfig())
+	p.connectWithTransport(tr)
+
+	_, err := p.Watch(context.Background(), "1002", func(string, ExtensionState, ExtensionState) {})
+	if err != nil {
+		t.Fatalf("Watch failed: %v", err)
+	}
+
+	p.Disconnect()
+
+	// Should have sent unsubscribe (Expires: 0).
+	if tr.CountSent("SUBSCRIBE") < 2 {
+		t.Error("expected at least 2 SUBSCRIBEs (initial + unsubscribe on disconnect)")
+	}
+}

--- a/testutil/mock_transport.go
+++ b/testutil/mock_transport.go
@@ -41,6 +41,7 @@ type MockTransport struct {
 	inviteFunc      func()
 	dropHandler     func()
 	incomingHandler func(from, to string)
+	notifyFn        func(event, from, contentType, body, subscriptionState string)
 	mwiNotifyFn     func(body string)
 	messageFn       func(from, to, contentType, body string)
 	responseCh      map[int][]chan bool
@@ -251,6 +252,13 @@ func (m *MockTransport) SendSubscribe(ctx context.Context, uri string, headers m
 	return m.awaitResponse(ctx)
 }
 
+// OnNotify registers a handler for incoming NOTIFY requests (general).
+func (m *MockTransport) OnNotify(fn func(event, from, contentType, body, subscriptionState string)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.notifyFn = fn
+}
+
 // OnMWINotify registers a handler for incoming MWI NOTIFY bodies.
 func (m *MockTransport) OnMWINotify(fn func(body string)) {
 	m.mu.Lock()
@@ -294,6 +302,16 @@ func (m *MockTransport) SimulateMessage(from, to, contentType, body string) {
 	m.mu.Unlock()
 	if fn != nil {
 		fn(from, to, contentType, body)
+	}
+}
+
+// SimulateNotify simulates an incoming NOTIFY request.
+func (m *MockTransport) SimulateNotify(event, from, contentType, body, subscriptionState string) {
+	m.mu.Lock()
+	fn := m.notifyFn
+	m.mu.Unlock()
+	if fn != nil {
+		fn(event, from, contentType, body, subscriptionState)
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -28,6 +28,10 @@ type sipTransport interface {
 	// Parameters: from, to, contentType, body.
 	OnMessage(fn func(from, to, contentType, body string))
 
+	// OnNotify registers a callback for incoming NOTIFY requests (general).
+	// Parameters: event, from, contentType, body, subscriptionState.
+	OnNotify(fn func(event, from, contentType, body, subscriptionState string))
+
 	// OnMWINotify registers a callback for incoming MWI NOTIFY bodies.
 	// The callback receives the raw application/simple-message-summary body.
 	OnMWINotify(fn func(body string))

--- a/xphone.go
+++ b/xphone.go
@@ -34,6 +34,10 @@ type Phone interface {
 	OnMessage(func(msg SipMessage))
 	SendMessage(ctx context.Context, target string, body string) error
 	SendMessageWithType(ctx context.Context, target string, contentType string, body string) error
+	Watch(ctx context.Context, extension string, fn func(ext string, state ExtensionState, prev ExtensionState)) (string, error)
+	Unwatch(subscriptionID string) error
+	SubscribeEvent(ctx context.Context, uri string, event string, expires int, fn func(NotifyEvent)) (string, error)
+	UnsubscribeEvent(subscriptionID string) error
 	AttendedTransfer(callA Call, callB Call) error
 	FindCall(callID string) Call
 	Calls() []Call
@@ -77,6 +81,9 @@ type phone struct {
 	// MWI (voicemail) state.
 	onVoicemailFn func(VoicemailStatus)
 	mwi           *mwiSubscriber
+
+	// Subscription manager for Watch/SubscribeEvent.
+	subMgr *subscriptionManager
 }
 
 // codecPrefsToInts converts []Codec to []int for SDP/negotiation.
@@ -234,6 +241,15 @@ func (p *phone) connectWithTransport(tr sipTransport) {
 		p.mu.Unlock()
 	}
 
+	// Start subscription manager for Watch/SubscribeEvent.
+	if err == nil {
+		sm := newSubscriptionManager(tr, p.cfg.Host, p.logger)
+		sm.start()
+		p.mu.Lock()
+		p.subMgr = sm
+		p.mu.Unlock()
+	}
+
 	p.logger.Info("phone connected")
 }
 
@@ -297,10 +313,12 @@ func (p *phone) Disconnect() error {
 	reg := p.reg
 	tr := p.tr
 	mwi := p.mwi
+	sm := p.subMgr
 	p.state = PhoneStateDisconnected
 	p.reg = nil
 	p.tr = nil
 	p.mwi = nil
+	p.subMgr = nil
 	fn := p.onUnregisteredFn
 
 	// Snapshot and clear active calls so we can end them outside the lock.
@@ -314,6 +332,11 @@ func (p *phone) Disconnect() error {
 	// End all active calls.
 	for _, c := range activeCalls {
 		c.End()
+	}
+
+	// Stop subscription manager (sends Expires: 0 unsubscribes).
+	if sm != nil {
+		sm.stop()
 	}
 
 	// Stop MWI subscription (sends Expires: 0 unsubscribe).
@@ -769,6 +792,46 @@ func (p *phone) SendMessageWithType(ctx context.Context, target string, contentT
 		return fmt.Errorf("MESSAGE %d %s", code, reason)
 	}
 	return nil
+}
+
+func (p *phone) Watch(ctx context.Context, extension string, fn func(string, ExtensionState, ExtensionState)) (string, error) {
+	p.mu.Lock()
+	sm := p.subMgr
+	p.mu.Unlock()
+	if sm == nil {
+		return "", ErrNotConnected
+	}
+	return sm.watch(ctx, extension, fn)
+}
+
+func (p *phone) Unwatch(subscriptionID string) error {
+	p.mu.Lock()
+	sm := p.subMgr
+	p.mu.Unlock()
+	if sm == nil {
+		return ErrNotConnected
+	}
+	return sm.unwatch(subscriptionID)
+}
+
+func (p *phone) SubscribeEvent(ctx context.Context, uri string, event string, expires int, fn func(NotifyEvent)) (string, error) {
+	p.mu.Lock()
+	sm := p.subMgr
+	p.mu.Unlock()
+	if sm == nil {
+		return "", ErrNotConnected
+	}
+	return sm.subscribeEvent(ctx, uri, event, expires, fn)
+}
+
+func (p *phone) UnsubscribeEvent(subscriptionID string) error {
+	p.mu.Lock()
+	sm := p.subMgr
+	p.mu.Unlock()
+	if sm == nil {
+		return ErrNotConnected
+	}
+	return sm.unsubscribeEvent(subscriptionID)
 }
 
 func (p *phone) handleMessage(from, to, contentType, body string) {


### PR DESCRIPTION
## Summary

- Add general-purpose subscription manager for SIP event subscriptions (RFC 6665) with auto-refresh and auto-resubscribe on deactivated/timeout terminations
- Add BLF (Busy Lamp Field) convenience API: `Watch`/`Unwatch` for monitoring extension state via dialog-info+xml (RFC 4235)
- Add generic event API: `SubscribeEvent`/`UnsubscribeEvent` for arbitrary SIP event packages
- Add BLF presence panel to sipcli TUI with colored state indicators (matching Rust sipcli)

## Test plan

- [x] `make check` passes (fmt, build, test, vet, race)
- [x] 16 subscription tests: watch/unwatch, subscribe/unsubscribe, NOTIFY dispatch, prev state tracking, auto-resubscribe, disconnect cleanup
- [x] 8 dialog-info parser tests: empty, confirmed, early, proceeding, terminated, mixed states
- [x] 4 parseSubscriptionState tests: active, pending, terminated, empty
- [x] extractSIPUser table tests
- [x] sipcli builds and installs