### PR TITLE
Add video SDP support (RFC 3264 multi-media)

### DIFF
--- a/internal/sdp/sdp.go
+++ b/internal/sdp/sdp.go
@@ -40,14 +40,23 @@ type CryptoAttr struct {
 	KeyParams string // inline:<base64key>
 }
 
+// Media type constants.
+const (
+	MediaAudio = "audio"
+	MediaVideo = "video"
+)
+
 // MediaDesc describes a single media line in an SDP session.
 type MediaDesc struct {
+	Type       string // MediaAudio or MediaVideo
 	Port       int
-	Profile    string       // ProfileRTP or ProfileSRTP
-	Codecs     []int        // payload type numbers
-	Direction  string       // DirSendRecv | DirSendOnly | DirRecvOnly | DirInactive
-	Crypto     []CryptoAttr // a=crypto: attributes
-	Candidates []string     // a=candidate: values (raw, without prefix)
+	Profile    string           // ProfileRTP or ProfileSRTP
+	Codecs     []int            // payload type numbers
+	Direction  string           // DirSendRecv | DirSendOnly | DirRecvOnly | DirInactive
+	Crypto     []CryptoAttr     // a=crypto: attributes
+	Candidates []string         // a=candidate: values (raw, without prefix)
+	Fmtp       map[int]string   // a=fmtp:<pt> <params> per payload type
+	RtcpFb     map[int][]string // a=rtcp-fb:<pt> <value> per payload type
 }
 
 // FirstCodec returns the first payload type from the first m= line, or -1 if none.
@@ -81,6 +90,21 @@ func (s *Session) FirstCrypto() *CryptoAttr {
 
 var codecNames = map[int]string{
 	0: "PCMU/8000", 8: "PCMA/8000", 9: "G722/8000", 18: "G729/8000", 101: "telephone-event/8000", 111: "opus/48000/2",
+	96: "H264/90000", 97: "VP8/90000",
+}
+
+// codecFmtp maps payload types to their default fmtp parameters.
+var codecFmtp = map[int]string{
+	18:  "annexb=no",
+	96:  "profile-level-id=42e01f;packetization-mode=1",
+	101: "0-16",
+	111: "minptime=20;useinbandfec=0",
+}
+
+// codecRtcpFb lists the rtcp-fb attributes for payload types that need them.
+var codecRtcpFb = map[int][]string{
+	96: {"nack", "nack pli", "ccm fir"},
+	97: {"nack", "nack pli", "ccm fir"},
 }
 
 // Parse parses a raw SDP string into a Session.
@@ -110,10 +134,12 @@ func Parse(raw string) (*Session, error) {
 				s.Connection = parts[2]
 			}
 		case 'm':
-			// m=audio <port> RTP/AVP <pt...>
+			// m=<type> <port> <profile> <pt...>
 			parts := strings.Fields(val)
 			if len(parts) >= 3 {
-				md := MediaDesc{}
+				md := MediaDesc{
+					Type: parts[0],
+				}
 				md.Port, _ = strconv.Atoi(parts[1])
 				md.Profile = parts[2]
 				for _, ptStr := range parts[3:] {
@@ -142,6 +168,10 @@ func Parse(raw string) (*Session, error) {
 				s.IcePwd = val[8:]
 			case strings.HasPrefix(val, "candidate:") && curMedia != nil:
 				curMedia.Candidates = append(curMedia.Candidates, val[10:])
+			case strings.HasPrefix(val, "fmtp:") && curMedia != nil:
+				parseFmtp(val[5:], curMedia)
+			case strings.HasPrefix(val, "rtcp-fb:") && curMedia != nil:
+				parseRtcpFb(val[8:], curMedia)
 			}
 		}
 	}
@@ -244,22 +274,55 @@ func BuildAnswerSRTP(ip string, port int, localPrefs []int, remoteOffer []int, d
 	return buildSDP(ip, port, common, direction, ProfileSRTP, cryptoInlineKey, nil)
 }
 
-// buildSDP is the shared implementation for building SDP with configurable profile.
+// buildSDP is the shared implementation for building audio-only SDP.
 func buildSDP(ip string, port int, codecs []int, direction, profile, cryptoInlineKey string, ice *ICEParams) string {
-	var b strings.Builder
-	b.WriteString("v=0\r\n")
-	b.WriteString("o=xphone 0 0 IN IP4 ")
-	b.WriteString(ip)
-	b.WriteString("\r\n")
-	b.WriteString("s=xphone\r\n")
-	b.WriteString("c=IN IP4 ")
-	b.WriteString(ip)
-	b.WriteString("\r\n")
-	b.WriteString("t=0 0\r\n")
-	if ice != nil && ice.Lite {
-		b.WriteString("a=ice-lite\r\n")
+	return buildSDPMulti(ip, port, codecs, direction, profile, cryptoInlineKey, ice, 0, nil)
+}
+
+// parseCryptoVal parses the value portion of an a=crypto: attribute.
+// Format: "<tag> <suite> inline:<key>"
+func parseCryptoVal(val string) (CryptoAttr, error) {
+	parts := strings.Fields(val)
+	if len(parts) < 3 {
+		return CryptoAttr{}, fmt.Errorf("sdp: malformed crypto attribute")
 	}
-	b.WriteString(fmt.Sprintf("m=audio %d %s", port, profile))
+	tag, _ := strconv.Atoi(parts[0])
+	suite := parts[1]
+	keyParam := parts[2]
+	return CryptoAttr{Tag: tag, Suite: suite, KeyParams: keyParam}, nil
+}
+
+// InlineKey extracts the base64 key from key params (removes "inline:" prefix).
+func (c *CryptoAttr) InlineKey() string {
+	if strings.HasPrefix(c.KeyParams, "inline:") {
+		return c.KeyParams[7:]
+	}
+	return c.KeyParams
+}
+
+// AudioMedia returns the first audio MediaDesc, or nil if none.
+func (s *Session) AudioMedia() *MediaDesc {
+	for i := range s.Media {
+		if s.Media[i].Type == MediaAudio {
+			return &s.Media[i]
+		}
+	}
+	return nil
+}
+
+// VideoMedia returns the first video MediaDesc, or nil if none.
+func (s *Session) VideoMedia() *MediaDesc {
+	for i := range s.Media {
+		if s.Media[i].Type == MediaVideo {
+			return &s.Media[i]
+		}
+	}
+	return nil
+}
+
+// writeMediaSection writes a single m= section (audio or video) to the builder.
+func writeMediaSection(b *strings.Builder, mediaType string, port int, profile string, codecs []int, direction, cryptoInlineKey string, ice *ICEParams) {
+	b.WriteString(fmt.Sprintf("m=%s %d %s", mediaType, port, profile))
 	for _, c := range codecs {
 		b.WriteString(fmt.Sprintf(" %d", c))
 	}
@@ -267,14 +330,13 @@ func buildSDP(ip string, port int, codecs []int, direction, profile, cryptoInlin
 	for _, c := range codecs {
 		if name, ok := codecNames[c]; ok {
 			b.WriteString(fmt.Sprintf("a=rtpmap:%d %s\r\n", c, name))
-			if c == 18 {
-				b.WriteString("a=fmtp:18 annexb=no\r\n")
+			if fmtp, ok := codecFmtp[c]; ok {
+				b.WriteString(fmt.Sprintf("a=fmtp:%d %s\r\n", c, fmtp))
 			}
-			if c == 101 {
-				b.WriteString("a=fmtp:101 0-16\r\n")
-			}
-			if c == 111 {
-				b.WriteString("a=fmtp:111 minptime=20;useinbandfec=0\r\n")
+			if fbs, ok := codecRtcpFb[c]; ok {
+				for _, fb := range fbs {
+					b.WriteString(fmt.Sprintf("a=rtcp-fb:%d %s\r\n", c, fb))
+				}
 			}
 		}
 	}
@@ -299,26 +361,79 @@ func buildSDP(ip string, port int, codecs []int, direction, profile, cryptoInlin
 	b.WriteString("a=")
 	b.WriteString(direction)
 	b.WriteString("\r\n")
+}
+
+// buildSDPMulti builds an SDP with audio and optional video media sections.
+// If videoCodecs is non-empty, a video m= line is appended at videoPort.
+func buildSDPMulti(ip string, audioPort int, audioCodecs []int, direction, profile, cryptoInlineKey string, ice *ICEParams, videoPort int, videoCodecs []int) string {
+	var b strings.Builder
+	b.WriteString("v=0\r\n")
+	b.WriteString("o=xphone 0 0 IN IP4 ")
+	b.WriteString(ip)
+	b.WriteString("\r\n")
+	b.WriteString("s=xphone\r\n")
+	b.WriteString("c=IN IP4 ")
+	b.WriteString(ip)
+	b.WriteString("\r\n")
+	b.WriteString("t=0 0\r\n")
+	if ice != nil && ice.Lite {
+		b.WriteString("a=ice-lite\r\n")
+	}
+	writeMediaSection(&b, MediaAudio, audioPort, profile, audioCodecs, direction, cryptoInlineKey, ice)
+	if len(videoCodecs) > 0 {
+		writeMediaSection(&b, MediaVideo, videoPort, profile, videoCodecs, direction, cryptoInlineKey, ice)
+	}
 	return b.String()
 }
 
-// parseCryptoVal parses the value portion of an a=crypto: attribute.
-// Format: "<tag> <suite> inline:<key>"
-func parseCryptoVal(val string) (CryptoAttr, error) {
-	parts := strings.Fields(val)
-	if len(parts) < 3 {
-		return CryptoAttr{}, fmt.Errorf("sdp: malformed crypto attribute")
-	}
-	tag, _ := strconv.Atoi(parts[0])
-	suite := parts[1]
-	keyParam := parts[2]
-	return CryptoAttr{Tag: tag, Suite: suite, KeyParams: keyParam}, nil
+// BuildOfferVideo creates an SDP offer with audio and video media lines.
+func BuildOfferVideo(ip string, audioPort int, audioCodecs []int, videoPort int, videoCodecs []int, direction string) string {
+	return buildSDPMulti(ip, audioPort, audioCodecs, direction, ProfileRTP, "", nil, videoPort, videoCodecs)
 }
 
-// InlineKey extracts the base64 key from key params (removes "inline:" prefix).
-func (c *CryptoAttr) InlineKey() string {
-	if strings.HasPrefix(c.KeyParams, "inline:") {
-		return c.KeyParams[7:]
+// BuildOfferVideoICE creates an SDP offer with audio, video, and ICE.
+func BuildOfferVideoICE(ip string, audioPort int, audioCodecs []int, videoPort int, videoCodecs []int, direction string, ice *ICEParams) string {
+	return buildSDPMulti(ip, audioPort, audioCodecs, direction, ProfileRTP, "", ice, videoPort, videoCodecs)
+}
+
+// BuildOfferVideoSRTP creates an SDP offer with audio, video, and SRTP.
+func BuildOfferVideoSRTP(ip string, audioPort int, audioCodecs []int, videoPort int, videoCodecs []int, direction, cryptoInlineKey string) string {
+	return buildSDPMulti(ip, audioPort, audioCodecs, direction, ProfileSRTP, cryptoInlineKey, nil, videoPort, videoCodecs)
+}
+
+// BuildOfferVideoSRTPICE creates an SDP offer with audio, video, SRTP, and ICE.
+func BuildOfferVideoSRTPICE(ip string, audioPort int, audioCodecs []int, videoPort int, videoCodecs []int, direction, cryptoInlineKey string, ice *ICEParams) string {
+	return buildSDPMulti(ip, audioPort, audioCodecs, direction, ProfileSRTP, cryptoInlineKey, ice, videoPort, videoCodecs)
+}
+
+// parseFmtp parses "a=fmtp:<pt> <params>" and stores it in the media desc.
+func parseFmtp(val string, md *MediaDesc) {
+	space := strings.IndexByte(val, ' ')
+	if space < 0 {
+		return
 	}
-	return c.KeyParams
+	pt, err := strconv.Atoi(val[:space])
+	if err != nil {
+		return
+	}
+	if md.Fmtp == nil {
+		md.Fmtp = make(map[int]string)
+	}
+	md.Fmtp[pt] = val[space+1:]
+}
+
+// parseRtcpFb parses "a=rtcp-fb:<pt> <value>" and stores it in the media desc.
+func parseRtcpFb(val string, md *MediaDesc) {
+	space := strings.IndexByte(val, ' ')
+	if space < 0 {
+		return
+	}
+	pt, err := strconv.Atoi(val[:space])
+	if err != nil {
+		return
+	}
+	if md.RtcpFb == nil {
+		md.RtcpFb = make(map[int][]string)
+	}
+	md.RtcpFb[pt] = append(md.RtcpFb[pt], val[space+1:])
 }

--- a/internal/sdp/sdp_test.go
+++ b/internal/sdp/sdp_test.go
@@ -1,6 +1,7 @@
 package sdp
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -239,4 +240,187 @@ func TestParseICE_FromRawSDP(t *testing.T) {
 	assert.Equal(t, "abc123", s.IceUfrag)
 	assert.Equal(t, "password1234567890abcdef", s.IcePwd)
 	require.Len(t, s.Media[0].Candidates, 1)
+}
+
+// --- Video SDP tests ---
+
+func TestBuildOfferVideo_AudioAndVideo(t *testing.T) {
+	s := BuildOfferVideo("10.0.0.1", 5004, []int{0, 8}, 5006, []int{96, 97}, "sendrecv")
+	assert.Contains(t, s, "m=audio 5004 RTP/AVP 0 8")
+	assert.Contains(t, s, "m=video 5006 RTP/AVP 96 97")
+	assert.Contains(t, s, "a=rtpmap:96 H264/90000")
+	assert.Contains(t, s, "a=rtpmap:97 VP8/90000")
+}
+
+func TestBuildOfferVideo_H264Fmtp(t *testing.T) {
+	s := BuildOfferVideo("10.0.0.1", 5004, []int{0}, 5006, []int{96}, "sendrecv")
+	assert.Contains(t, s, "a=fmtp:96 profile-level-id=42e01f;packetization-mode=1")
+}
+
+func TestBuildOfferVideo_RtcpFb(t *testing.T) {
+	s := BuildOfferVideo("10.0.0.1", 5004, []int{0}, 5006, []int{96}, "sendrecv")
+	assert.Contains(t, s, "a=rtcp-fb:96 nack\r\n")
+	assert.Contains(t, s, "a=rtcp-fb:96 nack pli\r\n")
+	assert.Contains(t, s, "a=rtcp-fb:96 ccm fir\r\n")
+}
+
+func TestBuildOfferVideo_VP8RtcpFb(t *testing.T) {
+	s := BuildOfferVideo("10.0.0.1", 5004, []int{0}, 5006, []int{97}, "sendrecv")
+	assert.Contains(t, s, "a=rtcp-fb:97 nack\r\n")
+	assert.Contains(t, s, "a=rtcp-fb:97 nack pli\r\n")
+	assert.Contains(t, s, "a=rtcp-fb:97 ccm fir\r\n")
+}
+
+func TestBuildOfferVideo_SRTP(t *testing.T) {
+	s := BuildOfferVideoSRTP("10.0.0.1", 5004, []int{0}, 5006, []int{96}, "sendrecv", "base64key==")
+	assert.Contains(t, s, "m=audio 5004 RTP/SAVP 0")
+	assert.Contains(t, s, "m=video 5006 RTP/SAVP 96")
+	// Both media sections should have crypto.
+	// Count occurrences of a=crypto:
+	assert.Equal(t, 2, strings.Count(s, "a=crypto:1 AES_CM_128_HMAC_SHA1_80"))
+}
+
+func TestBuildOfferVideo_ICE(t *testing.T) {
+	ice := &ICEParams{Ufrag: "uf", Pwd: "pw", Lite: true}
+	s := BuildOfferVideoICE("10.0.0.1", 5004, []int{0}, 5006, []int{96}, "sendrecv", ice)
+	assert.Contains(t, s, "a=ice-lite")
+	assert.Contains(t, s, "m=audio 5004 RTP/AVP 0")
+	assert.Contains(t, s, "m=video 5006 RTP/AVP 96")
+	// Both media sections should have ICE attributes.
+	assert.Equal(t, 2, strings.Count(s, "a=ice-ufrag:uf"))
+}
+
+func TestParseVideo_TwoMediaLines(t *testing.T) {
+	raw := BuildOfferVideo("10.0.0.1", 5004, []int{0, 8}, 5006, []int{96, 97}, "sendrecv")
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	require.Len(t, s.Media, 2)
+
+	assert.Equal(t, MediaAudio, s.Media[0].Type)
+	assert.Equal(t, 5004, s.Media[0].Port)
+	assert.Equal(t, []int{0, 8}, s.Media[0].Codecs)
+
+	assert.Equal(t, MediaVideo, s.Media[1].Type)
+	assert.Equal(t, 5006, s.Media[1].Port)
+	assert.Equal(t, []int{96, 97}, s.Media[1].Codecs)
+}
+
+func TestParseVideo_AudioMediaHelper(t *testing.T) {
+	raw := BuildOfferVideo("10.0.0.1", 5004, []int{0}, 5006, []int{96}, "sendrecv")
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	audio := s.AudioMedia()
+	require.NotNil(t, audio)
+	assert.Equal(t, 5004, audio.Port)
+	assert.Equal(t, []int{0}, audio.Codecs)
+}
+
+func TestParseVideo_VideoMediaHelper(t *testing.T) {
+	raw := BuildOfferVideo("10.0.0.1", 5004, []int{0}, 5006, []int{96, 97}, "sendrecv")
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	video := s.VideoMedia()
+	require.NotNil(t, video)
+	assert.Equal(t, 5006, video.Port)
+	assert.Equal(t, []int{96, 97}, video.Codecs)
+}
+
+func TestParseVideo_AudioOnly_NoVideoMedia(t *testing.T) {
+	raw := BuildOffer("10.0.0.1", 5004, []int{0}, "sendrecv")
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	assert.NotNil(t, s.AudioMedia())
+	assert.Nil(t, s.VideoMedia())
+}
+
+func TestParseVideo_Fmtp(t *testing.T) {
+	raw := BuildOfferVideo("10.0.0.1", 5004, []int{0}, 5006, []int{96}, "sendrecv")
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	video := s.VideoMedia()
+	require.NotNil(t, video)
+	assert.Equal(t, "profile-level-id=42e01f;packetization-mode=1", video.Fmtp[96])
+}
+
+func TestParseVideo_RtcpFb(t *testing.T) {
+	raw := BuildOfferVideo("10.0.0.1", 5004, []int{0}, 5006, []int{96}, "sendrecv")
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	video := s.VideoMedia()
+	require.NotNil(t, video)
+	require.Len(t, video.RtcpFb[96], 3)
+	assert.Equal(t, "nack", video.RtcpFb[96][0])
+	assert.Equal(t, "nack pli", video.RtcpFb[96][1])
+	assert.Equal(t, "ccm fir", video.RtcpFb[96][2])
+}
+
+func TestParseVideo_Direction(t *testing.T) {
+	raw := BuildOfferVideo("10.0.0.1", 5004, []int{0}, 5006, []int{96}, "sendonly")
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	assert.Equal(t, "sendonly", s.AudioMedia().Direction)
+	assert.Equal(t, "sendonly", s.VideoMedia().Direction)
+}
+
+func TestNegotiateCodec_Video(t *testing.T) {
+	assert.Equal(t, 96, NegotiateCodec([]int{96, 97}, []int{97, 96}))
+	assert.Equal(t, 97, NegotiateCodec([]int{97, 96}, []int{96, 97}))
+	assert.Equal(t, -1, NegotiateCodec([]int{96}, []int{97}))
+}
+
+func TestParseVideo_MediaType(t *testing.T) {
+	// Existing audio-only SDP should parse Type=audio.
+	raw := BuildOffer("10.0.0.1", 5004, []int{0}, "sendrecv")
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	require.NotEmpty(t, s.Media)
+	assert.Equal(t, MediaAudio, s.Media[0].Type)
+}
+
+func TestParseVideo_ExternalSDP(t *testing.T) {
+	// Simulate an external SDP with audio + video from a different UA.
+	raw := "v=0\r\n" +
+		"o=other 123 456 IN IP4 203.0.113.1\r\n" +
+		"s=-\r\n" +
+		"c=IN IP4 203.0.113.1\r\n" +
+		"t=0 0\r\n" +
+		"m=audio 10000 RTP/AVP 0 8\r\n" +
+		"a=rtpmap:0 PCMU/8000\r\n" +
+		"a=rtpmap:8 PCMA/8000\r\n" +
+		"a=sendrecv\r\n" +
+		"m=video 10002 RTP/AVP 96 97\r\n" +
+		"a=rtpmap:96 H264/90000\r\n" +
+		"a=fmtp:96 profile-level-id=42e01f;packetization-mode=1\r\n" +
+		"a=rtcp-fb:96 nack\r\n" +
+		"a=rtcp-fb:96 nack pli\r\n" +
+		"a=rtpmap:97 VP8/90000\r\n" +
+		"a=rtcp-fb:97 nack\r\n" +
+		"a=sendrecv\r\n"
+
+	s, err := Parse(raw)
+	require.NoError(t, err)
+	require.Len(t, s.Media, 2)
+
+	audio := s.AudioMedia()
+	require.NotNil(t, audio)
+	assert.Equal(t, 10000, audio.Port)
+	assert.Equal(t, []int{0, 8}, audio.Codecs)
+
+	video := s.VideoMedia()
+	require.NotNil(t, video)
+	assert.Equal(t, 10002, video.Port)
+	assert.Equal(t, []int{96, 97}, video.Codecs)
+	assert.Equal(t, "profile-level-id=42e01f;packetization-mode=1", video.Fmtp[96])
+	assert.Equal(t, []string{"nack", "nack pli"}, video.RtcpFb[96])
+	assert.Equal(t, []string{"nack"}, video.RtcpFb[97])
+}
+
+func TestBuildOfferVideo_BackwardsCompat(t *testing.T) {
+	// Audio-only BuildOffer should still work exactly as before.
+	s := BuildOffer("10.0.0.1", 5004, []int{0, 8}, "sendrecv")
+	parsed, err := Parse(s)
+	require.NoError(t, err)
+	require.Len(t, parsed.Media, 1)
+	assert.Equal(t, MediaAudio, parsed.Media[0].Type)
+	assert.Nil(t, parsed.VideoMedia())
 }

--- a/options.go
+++ b/options.go
@@ -73,6 +73,14 @@ const (
 	CodecOpus Codec = 111
 )
 
+// VideoCodec represents a video codec.
+type VideoCodec int
+
+const (
+	VideoCodecH264 VideoCodec = 96
+	VideoCodecVP8  VideoCodec = 97
+)
+
 // DialOption is a functional option for Dial().
 type DialOption func(*DialOptions)
 
@@ -83,6 +91,8 @@ type DialOptions struct {
 	EarlyMedia    bool
 	Timeout       time.Duration
 	CodecOverride []Codec
+	Video         bool         // enable video in SDP offer
+	VideoCodecs   []VideoCodec // video codec preferences (default: [H264, VP8])
 }
 
 func applyDialOptions(opts []DialOption) DialOptions {
@@ -123,6 +133,19 @@ func WithDialTimeout(d time.Duration) DialOption {
 // WithCodecOverride overrides the codec preference for an outbound call.
 func WithCodecOverride(codecs ...Codec) DialOption {
 	return func(o *DialOptions) { o.CodecOverride = codecs }
+}
+
+// WithVideo enables video in the SDP offer. If no codecs are specified,
+// defaults to [H264, VP8] preference order.
+func WithVideo(codecs ...VideoCodec) DialOption {
+	return func(o *DialOptions) {
+		o.Video = true
+		if len(codecs) > 0 {
+			o.VideoCodecs = codecs
+		} else {
+			o.VideoCodecs = []VideoCodec{VideoCodecH264, VideoCodecVP8}
+		}
+	}
 }
 
 // AcceptOption is a functional option for Accept().


### PR DESCRIPTION
## Summary
- Extend SDP builder and parser to handle audio+video sessions with multiple m= lines per RFC 3264
- Add H.264 (PT 96) and VP8 (PT 97) codec support with proper fmtp and rtcp-fb attributes (RFC 6184, RFC 7741)
- Unify all codec fmtp/rtcp-fb into data-driven maps (`codecFmtp`, `codecRtcpFb`) — eliminates hardcoded switch logic
- Add `VideoCodec` type and `WithVideo()` dial option to public API
- Parser lazy-inits Fmtp/RtcpFb maps to avoid allocations for audio-only sessions
- New builder variants: `BuildOfferVideo`, `BuildOfferVideoICE`, `BuildOfferVideoSRTP`, `BuildOfferVideoSRTPICE`
- Session helpers: `AudioMedia()`, `VideoMedia()` for typed media line access

This is PR 1 of 4 in the video support plan (PLAN-VIDEO.md). SDP-only — no changes to call.go or media pipeline.

## Test plan
- [x] 16 new video SDP tests covering build, parse, fmtp, rtcp-fb, SRTP, ICE, external SDP, backwards compat
- [x] All existing audio SDP tests pass unchanged
- [x] `make check` green (fmt, build, test, vet, race)