### PR TITLE
Extract media pipeline into per-stream mediaStream abstraction

### DIFF
--- a/call.go
+++ b/call.go
@@ -112,6 +112,8 @@ type Call interface {
 	Resume() error
 	Mute() error
 	Unmute() error
+	MuteAudio() error
+	UnmuteAudio() error
 	SendDTMF(digit string) error
 	BlindTransfer(target string) error
 	RTPRawReader() <-chan *rtp.Packet
@@ -154,8 +156,8 @@ type call struct {
 	onMuteFn       func()
 	onUnmuteFn     func()
 
-	muted    bool
-	dtmfMode DtmfMode
+	audioStream *mediaStream
+	dtmfMode    DtmfMode
 
 	codecPrefs  []int          // codec preference order (payload types)
 	jitterDepth time.Duration  // jitter buffer depth (0 = default)
@@ -215,6 +217,7 @@ func newInboundCall(d dialog) *call {
 		pcmWriter:    make(chan []int16, 256),
 		callbackCh:   make(chan func(), 16),
 	}
+	c.audioStream = &mediaStream{call: c, outSSRC: randUint32()}
 	go c.runCallbackDispatcher()
 	return c
 }
@@ -236,6 +239,7 @@ func newOutboundCall(d dialog, dialOpts ...DialOption) *call {
 		pcmWriter:    make(chan []int16, 256),
 		callbackCh:   make(chan func(), 16),
 	}
+	c.audioStream = &mediaStream{call: c, outSSRC: randUint32()}
 	go c.runCallbackDispatcher()
 	return c
 }
@@ -948,11 +952,11 @@ func (c *call) Mute() error {
 		c.mu.Unlock()
 		return ErrInvalidState
 	}
-	if c.muted {
+	if c.audioStream.muted {
 		c.mu.Unlock()
 		return ErrAlreadyMuted
 	}
-	c.muted = true
+	c.audioStream.muted = true
 	fn := c.onMuteFn
 	c.mu.Unlock()
 	if fn != nil {
@@ -967,17 +971,25 @@ func (c *call) Unmute() error {
 		c.mu.Unlock()
 		return ErrInvalidState
 	}
-	if !c.muted {
+	if !c.audioStream.muted {
 		c.mu.Unlock()
 		return ErrNotMuted
 	}
-	c.muted = false
+	c.audioStream.muted = false
 	fn := c.onUnmuteFn
 	c.mu.Unlock()
 	if fn != nil {
 		c.dispatch(fn)
 	}
 	return nil
+}
+
+func (c *call) MuteAudio() error {
+	return c.Mute()
+}
+
+func (c *call) UnmuteAudio() error {
+	return c.Unmute()
 }
 func (c *call) SendDTMF(digit string) error {
 	c.mu.Lock()

--- a/media.go
+++ b/media.go
@@ -21,6 +21,32 @@ const (
 	defaultPCMRate          = 8000
 )
 
+// mediaStream manages the RTP pipeline for a single media stream (audio or video).
+// The call struct owns the channels and sockets; mediaStream reads/writes them via
+// its back-pointer during run(). Per-stream mutable state (muted, RTP counters) lives here.
+type mediaStream struct {
+	call *call // back-pointer for shared state (channels, sockets, SRTP, callbacks)
+
+	// Per-stream mute flag (protected by call.mu).
+	muted bool
+
+	// Pipeline config (set by startMedia before launching run goroutine).
+	timeout        time.Duration
+	conn           net.PacketConn
+	rtcpConn       net.PacketConn
+	rtcpRemoteAddr net.Addr
+	done           chan struct{}
+
+	// Goroutine-local pipeline state (only accessed by run goroutine — no lock needed).
+	outSeq            uint16
+	outTimestamp      uint32
+	outSSRC           uint32
+	rtpWriterUsed     bool
+	inboundCount      int
+	lastDTMFTimestamp uint32
+	lastDTMFSeen      bool
+}
+
 // clonePacket returns a deep copy of an RTP packet so taps are independent.
 func clonePacket(pkt *rtp.Packet) *rtp.Packet {
 	clone := &rtp.Packet{Header: pkt.Header}
@@ -52,8 +78,9 @@ func sendDropOldestPCM(ch chan []int16, samples []int16) {
 }
 
 // drainJB pops all depth-expired packets from the jitter buffer and fans
-// them out to rtpReader and pcmReader.
-func (c *call) drainJB(jb *media.JitterBuffer, cp media.CodecProcessor) {
+// them out to rtpReader and pcmReader on the owning call.
+func (s *mediaStream) drainJB(jb *media.JitterBuffer, cp media.CodecProcessor) {
+	c := s.call
 	for {
 		pkt := jb.Pop()
 		if pkt == nil {
@@ -71,6 +98,221 @@ func randUint32() uint32 {
 	var b [4]byte
 	rand.Read(b[:])
 	return binary.BigEndian.Uint32(b[:])
+}
+
+// run is the media pipeline goroutine for a single stream.
+// It handles: inbound RTP demux, jitter buffer, DTMF interception, codec encode/decode,
+// outbound RTP forwarding, RTCP, and media timeout.
+// Pipeline config must be set on the struct before calling run.
+func (s *mediaStream) run(jb *media.JitterBuffer, cp media.CodecProcessor, rtpClockRate uint32) {
+	c := s.call
+	timeout := s.timeout
+	conn := s.conn
+	rtcpConn := s.rtcpConn
+	rtcpRemoteAddr := s.rtcpRemoteAddr
+	done := s.done
+
+	mediaTimer := time.NewTimer(timeout)
+	defer mediaTimer.Stop()
+	jitterTick := time.NewTicker(5 * time.Millisecond)
+	defer jitterTick.Stop()
+	defer c.closeOutputChannels()
+
+	// RTCP state.
+	rtcpStats := rtcp.NewStats()
+	var rtcpTick <-chan time.Time
+	var rtcpTicker *time.Ticker
+	if rtcpConn != nil {
+		rtcpTicker = time.NewTicker(time.Duration(rtcp.IntervalSecs) * time.Second)
+		rtcpTick = rtcpTicker.C
+		defer rtcpTicker.Stop()
+	}
+
+	// RTCP reader goroutine.
+	rtcpInbound := make(chan []byte, 16)
+	if rtcpConn != nil {
+		go func() {
+			buf := make([]byte, 1500)
+			for {
+				n, _, err := rtcpConn.ReadFrom(buf)
+				if err != nil {
+					return
+				}
+				if n < 8 {
+					continue
+				}
+				cp := make([]byte, n)
+				copy(cp, buf[:n])
+				select {
+				case rtcpInbound <- cp:
+				default:
+				}
+			}
+		}()
+	}
+
+	resetTimer := func(d time.Duration) {
+		if !mediaTimer.Stop() {
+			select {
+			case <-mediaTimer.C:
+			default:
+			}
+		}
+		mediaTimer.Reset(d)
+	}
+
+	for {
+		select {
+		case <-done:
+			return
+
+		case pkt := <-c.rtpInbound:
+			s.inboundCount++
+			if s.inboundCount == 1 {
+				c.logger.Debug("first RTP packet received",
+					"id", c.id, "pt", pkt.PayloadType, "ssrc", pkt.SSRC,
+					"seq", pkt.SequenceNumber, "payload_len", len(pkt.Payload))
+			}
+			sendDropOldest(c.rtpRawReader, clonePacket(pkt))
+
+			// DTMF dispatch: intercept PT=101 before jitter buffer.
+			if pkt.PayloadType == DTMFPayloadType {
+				if ev := DecodeDTMF(pkt.Payload); ev != nil && ev.End && !(s.lastDTMFSeen && pkt.Timestamp == s.lastDTMFTimestamp) {
+					s.lastDTMFTimestamp = pkt.Timestamp
+					s.lastDTMFSeen = true
+					c.mu.Lock()
+					mode := c.dtmfMode
+					c.mu.Unlock()
+					if mode != DtmfSipInfo {
+						c.fireOnDTMF(ev.Digit)
+					}
+				}
+				resetTimer(timeout)
+				continue
+			}
+
+			rtcpStats.RecordRTPReceived(pkt.SequenceNumber, pkt.Timestamp, pkt.SSRC, rtpClockRate)
+			jb.Push(pkt)
+			resetTimer(timeout)
+			s.drainJB(jb, cp)
+
+		case <-jitterTick.C:
+			s.drainJB(jb, cp)
+
+		case pkt := <-c.rtpWriter:
+			if !s.rtpWriterUsed {
+				c.logger.Debug("first outbound RTP (raw writer)", "id", c.id, "pt", pkt.PayloadType)
+			}
+			s.rtpWriterUsed = true
+			c.mu.Lock()
+			muted := s.muted
+			dst := c.remoteAddr
+			srtpOut := c.srtpOut
+			c.mu.Unlock()
+			if muted {
+				continue
+			}
+			rtcpStats.RecordRTPSent(len(pkt.Payload), pkt.Timestamp)
+			if c.sentRTP != nil {
+				sendDropOldest(c.sentRTP, pkt)
+			}
+			if conn != nil && dst != nil {
+				if data, err := pkt.Marshal(); err == nil {
+					if srtpOut != nil {
+						data, err = srtpOut.Protect(data)
+						if err != nil {
+							continue
+						}
+					}
+					conn.WriteTo(data, dst)
+				}
+			}
+
+		case pcmFrame := <-c.pcmWriter:
+			if s.rtpWriterUsed || cp == nil {
+				continue
+			}
+			c.mu.Lock()
+			muted := s.muted
+			dst := c.remoteAddr
+			srtpOut := c.srtpOut
+			c.mu.Unlock()
+			if muted {
+				continue
+			}
+			encoded := cp.Encode(pcmFrame)
+			outPkt := &rtp.Packet{
+				Header: rtp.Header{
+					Version:        2,
+					PayloadType:    cp.PayloadType(),
+					SequenceNumber: s.outSeq,
+					Timestamp:      s.outTimestamp,
+					SSRC:           s.outSSRC,
+				},
+				Payload: encoded,
+			}
+			s.outSeq++
+			s.outTimestamp += cp.SamplesPerFrame()
+			rtcpStats.RecordRTPSent(len(outPkt.Payload), outPkt.Timestamp)
+			if c.sentRTP != nil {
+				sendDropOldest(c.sentRTP, outPkt)
+			}
+			if conn != nil && dst != nil {
+				if data, err := outPkt.Marshal(); err == nil {
+					if srtpOut != nil {
+						data, err = srtpOut.Protect(data)
+						if err != nil {
+							continue
+						}
+					}
+					conn.WriteTo(data, dst)
+				}
+			}
+
+		case <-rtcpTick:
+			if rtcpConn != nil && rtcpRemoteAddr != nil {
+				c.mu.Lock()
+				srtcpOut := c.srtpOut
+				c.mu.Unlock()
+				sr := rtcp.BuildSR(s.outSSRC, rtcpStats)
+				if srtcpOut != nil {
+					var err error
+					sr, err = srtcpOut.ProtectRTCP(sr)
+					if err != nil {
+						continue
+					}
+				}
+				rtcpConn.WriteTo(sr, rtcpRemoteAddr)
+			}
+
+		case data := <-rtcpInbound:
+			c.mu.Lock()
+			srtcpIn := c.srtpIn
+			c.mu.Unlock()
+			if srtcpIn != nil {
+				var err error
+				data, err = srtcpIn.UnprotectRTCP(data)
+				if err != nil {
+					continue
+				}
+			}
+			if pkt := rtcp.Parse(data); pkt != nil && pkt.IsSenderReport() {
+				rtcpStats.ProcessIncomingSR(pkt.NTPSec, pkt.NTPFrac)
+			}
+
+		case d := <-c.mediaTimerReset:
+			resetTimer(d)
+
+		case <-mediaTimer.C:
+			c.mu.Lock()
+			c.state = StateEnded
+			c.fireOnState(StateEnded)
+			c.logger.Warn("media timeout", "id", c.id)
+			c.fireOnEnded(EndedByTimeout)
+			c.mu.Unlock()
+			return
+		}
+	}
 }
 
 // startRTPReader launches a goroutine that reads RTP packets from the
@@ -168,6 +410,20 @@ func (c *call) startMedia() {
 	if c.remotePort > 0 && c.remoteIP != "" {
 		rtcpRemoteAddr, _ = net.ResolveUDPAddr("udp", net.JoinHostPort(c.remoteIP, strconv.Itoa(c.remotePort+1)))
 	}
+
+	s := c.audioStream
+	// Set pipeline config on stream and reset goroutine-local state.
+	s.timeout = timeout
+	s.conn = conn
+	s.rtcpConn = rtcpConn
+	s.rtcpRemoteAddr = rtcpRemoteAddr
+	s.done = done
+	s.outSeq = 0
+	s.outTimestamp = 0
+	s.rtpWriterUsed = false
+	s.inboundCount = 0
+	s.lastDTMFTimestamp = 0
+	s.lastDTMFSeen = false
 	c.mu.Unlock()
 
 	jb := media.NewJitterBuffer(jitterDepth)
@@ -184,220 +440,7 @@ func (c *call) startMedia() {
 		"jitter_depth", jitterDepth, "media_timeout", timeout,
 		"local_addr", conn.LocalAddr().String())
 
-	// Outbound RTP state for PCMWriter encode path.
-	var outSeq uint16
-	var outTimestamp uint32
-	outSSRC := randUint32()
-	var rtpWriterUsed bool
-	var inboundCount int
-	var lastDTMFTimestamp uint32 // dedup RFC 4733 redundant end events
-	var lastDTMFSeen bool
-
-	// Start RTCP reader goroutine if we have an RTCP socket.
-	rtcpInbound := make(chan []byte, 16)
-	if rtcpConn != nil {
-		go func() {
-			buf := make([]byte, 1500)
-			for {
-				n, _, err := rtcpConn.ReadFrom(buf)
-				if err != nil {
-					return // socket closed
-				}
-				if n < 8 {
-					continue
-				}
-				cp := make([]byte, n)
-				copy(cp, buf[:n])
-				select {
-				case rtcpInbound <- cp:
-				default: // drop if full
-				}
-			}
-		}()
-	}
-
-	go func() {
-		mediaTimer := time.NewTimer(timeout)
-		defer mediaTimer.Stop()
-		jitterTick := time.NewTicker(5 * time.Millisecond)
-		defer jitterTick.Stop()
-		// Close output channels so consumers unblock on call end.
-		defer c.closeOutputChannels()
-
-		// RTCP state.
-		rtcpStats := rtcp.NewStats()
-		var rtcpTick <-chan time.Time
-		var rtcpTicker *time.Ticker
-		if rtcpConn != nil {
-			rtcpTicker = time.NewTicker(time.Duration(rtcp.IntervalSecs) * time.Second)
-			rtcpTick = rtcpTicker.C
-			defer rtcpTicker.Stop()
-		}
-
-		resetTimer := func(d time.Duration) {
-			if !mediaTimer.Stop() {
-				select {
-				case <-mediaTimer.C:
-				default:
-				}
-			}
-			mediaTimer.Reset(d)
-		}
-
-		for {
-			select {
-			case <-done:
-				return
-
-			case pkt := <-c.rtpInbound:
-				inboundCount++
-				if inboundCount == 1 {
-					c.logger.Debug("first RTP packet received",
-						"id", c.id, "pt", pkt.PayloadType, "ssrc", pkt.SSRC,
-						"seq", pkt.SequenceNumber, "payload_len", len(pkt.Payload))
-				}
-				sendDropOldest(c.rtpRawReader, clonePacket(pkt))
-
-				// DTMF dispatch: intercept PT=101 before jitter buffer.
-				if pkt.PayloadType == DTMFPayloadType {
-					if ev := DecodeDTMF(pkt.Payload); ev != nil && ev.End && !(lastDTMFSeen && pkt.Timestamp == lastDTMFTimestamp) {
-						lastDTMFTimestamp = pkt.Timestamp
-						lastDTMFSeen = true
-						// Skip RTP DTMF callbacks in SipInfo-only mode.
-						c.mu.Lock()
-						mode := c.dtmfMode
-						c.mu.Unlock()
-						if mode != DtmfSipInfo {
-							c.fireOnDTMF(ev.Digit)
-						}
-					}
-					resetTimer(timeout)
-					continue
-				}
-
-				rtcpStats.RecordRTPReceived(pkt.SequenceNumber, pkt.Timestamp, pkt.SSRC, rtpClockRate)
-				jb.Push(pkt)
-				resetTimer(timeout)
-				c.drainJB(jb, cp)
-
-			case <-jitterTick.C:
-				c.drainJB(jb, cp)
-
-			case pkt := <-c.rtpWriter:
-				if !rtpWriterUsed {
-					c.logger.Debug("first outbound RTP (raw writer)", "id", c.id, "pt", pkt.PayloadType)
-				}
-				rtpWriterUsed = true
-				c.mu.Lock()
-				muted := c.muted
-				dst := c.remoteAddr
-				srtpOut := c.srtpOut
-				c.mu.Unlock()
-				if muted {
-					continue
-				}
-				rtcpStats.RecordRTPSent(len(pkt.Payload), pkt.Timestamp)
-				if c.sentRTP != nil {
-					sendDropOldest(c.sentRTP, pkt)
-				}
-				if conn != nil && dst != nil {
-					if data, err := pkt.Marshal(); err == nil {
-						if srtpOut != nil {
-							data, err = srtpOut.Protect(data)
-							if err != nil {
-								continue
-							}
-						}
-						conn.WriteTo(data, dst)
-					}
-				}
-
-			case pcmFrame := <-c.pcmWriter:
-				if rtpWriterUsed || cp == nil {
-					continue
-				}
-				c.mu.Lock()
-				muted := c.muted
-				dst := c.remoteAddr
-				srtpOut := c.srtpOut
-				c.mu.Unlock()
-				if muted {
-					continue
-				}
-				encoded := cp.Encode(pcmFrame)
-				outPkt := &rtp.Packet{
-					Header: rtp.Header{
-						Version:        2,
-						PayloadType:    cp.PayloadType(),
-						SequenceNumber: outSeq,
-						Timestamp:      outTimestamp,
-						SSRC:           outSSRC,
-					},
-					Payload: encoded,
-				}
-				outSeq++
-				outTimestamp += cp.SamplesPerFrame()
-				rtcpStats.RecordRTPSent(len(outPkt.Payload), outPkt.Timestamp)
-				if c.sentRTP != nil {
-					sendDropOldest(c.sentRTP, outPkt)
-				}
-				if conn != nil && dst != nil {
-					if data, err := outPkt.Marshal(); err == nil {
-						if srtpOut != nil {
-							data, err = srtpOut.Protect(data)
-							if err != nil {
-								continue
-							}
-						}
-						conn.WriteTo(data, dst)
-					}
-				}
-
-			case <-rtcpTick:
-				if rtcpConn != nil && rtcpRemoteAddr != nil {
-					c.mu.Lock()
-					srtcpOut := c.srtpOut
-					c.mu.Unlock()
-					sr := rtcp.BuildSR(outSSRC, rtcpStats)
-					if srtcpOut != nil {
-						var err error
-						sr, err = srtcpOut.ProtectRTCP(sr)
-						if err != nil {
-							continue
-						}
-					}
-					rtcpConn.WriteTo(sr, rtcpRemoteAddr)
-				}
-
-			case data := <-rtcpInbound:
-				c.mu.Lock()
-				srtcpIn := c.srtpIn
-				c.mu.Unlock()
-				if srtcpIn != nil {
-					var err error
-					data, err = srtcpIn.UnprotectRTCP(data)
-					if err != nil {
-						continue
-					}
-				}
-				if pkt := rtcp.Parse(data); pkt != nil && pkt.IsSenderReport() {
-					rtcpStats.ProcessIncomingSR(pkt.NTPSec, pkt.NTPFrac)
-				}
-
-			case d := <-c.mediaTimerReset:
-				resetTimer(d)
-
-			case <-mediaTimer.C:
-				c.mu.Lock()
-				c.state = StateEnded
-				c.fireOnState(StateEnded)
-				c.logger.Warn("media timeout", "id", c.id)
-				c.fireOnEnded(EndedByTimeout)
-				c.mu.Unlock()
-				return
-			}
-		}
-	}()
+	go s.run(jb, cp, rtpClockRate)
 }
 
 // stopMedia tears down the media pipeline and releases RTP ports.

--- a/media_test.go
+++ b/media_test.go
@@ -532,3 +532,33 @@ func TestCall_Mute_InboundStillFlows(t *testing.T) {
 	raw := readPacket(t, c.RTPRawReader(), 200*time.Millisecond)
 	assert.NotNil(t, raw, "inbound RTP must still flow while muted")
 }
+
+// --- MuteAudio / UnmuteAudio tests ---
+
+func TestCall_MuteAudio_EquivalentToMute(t *testing.T) {
+	// MuteAudio + Unmute should work (they share the same flag).
+	c := activeCall(t)
+	defer c.stopMedia()
+
+	require.NoError(t, c.MuteAudio())
+	require.NoError(t, c.Unmute())
+
+	// And vice versa.
+	require.NoError(t, c.Mute())
+	require.NoError(t, c.UnmuteAudio())
+}
+
+func TestCall_MuteAudio_AlreadyMutedReturnsError(t *testing.T) {
+	c := activeCall(t)
+	defer c.stopMedia()
+
+	require.NoError(t, c.MuteAudio())
+	assert.Equal(t, ErrAlreadyMuted, c.MuteAudio())
+}
+
+func TestCall_UnmuteAudio_WhenNotMutedReturnsError(t *testing.T) {
+	c := activeCall(t)
+	defer c.stopMedia()
+
+	assert.Equal(t, ErrNotMuted, c.UnmuteAudio())
+}

--- a/mock_call.go
+++ b/mock_call.go
@@ -369,6 +369,14 @@ func (c *MockCall) Unmute() error {
 	return nil
 }
 
+func (c *MockCall) MuteAudio() error {
+	return c.Mute()
+}
+
+func (c *MockCall) UnmuteAudio() error {
+	return c.Unmute()
+}
+
 func (c *MockCall) SendDTMF(digit string) error {
 	c.mu.Lock()
 	if c.state != StateActive {


### PR DESCRIPTION
## Summary
- Refactor monolithic media goroutine into `mediaStream` struct with per-stream state (mute flag, RTP counters, RTCP context, jitter buffer config)
- `call` holds `audioStream *mediaStream`; future video streams reuse the same abstraction
- Add `MuteAudio()`/`UnmuteAudio()` for granular per-stream mute alongside existing `Mute()`/`Unmute()` (all-stream)

## Test plan
- [x] All existing tests pass unchanged (primary acceptance criteria for pure refactor)
- [x] New tests: `TestCall_MuteAudio_EquivalentToMute`, `TestCall_MuteAudio_AlreadyMutedReturnsError`, `TestCall_UnmuteAudio_WhenNotMutedReturnsError`
- [x] `make check` passes (fmt, build, test, vet, race)