### PR TITLE
Add video RTP pipeline and call-level video API

### DIFF
--- a/call.go
+++ b/call.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pion/rtp"
 	"github.com/x-phone/xphone-go/ice"
+	"github.com/x-phone/xphone-go/internal/rtcp"
 	"github.com/x-phone/xphone-go/internal/sdp"
 	"github.com/x-phone/xphone-go/internal/srtp"
 )
@@ -126,6 +127,15 @@ type Call interface {
 	OnResume(func())
 	OnMute(func())
 	OnUnmute(func())
+	HasVideo() bool
+	VideoCodec() VideoCodec
+	VideoReader() <-chan VideoFrame
+	VideoWriter() chan<- VideoFrame
+	VideoRTPReader() <-chan *rtp.Packet
+	VideoRTPWriter() chan<- *rtp.Packet
+	MuteVideo() error
+	UnmuteVideo() error
+	RequestKeyframe() error
 	OnMedia(func())
 	OnState(func(state CallState))
 	OnEnded(func(reason EndReason))
@@ -156,8 +166,11 @@ type call struct {
 	onMuteFn       func()
 	onUnmuteFn     func()
 
-	audioStream *mediaStream
-	dtmfMode    DtmfMode
+	audioStream    *mediaStream
+	videoStream    *mediaStream
+	dtmfMode       DtmfMode
+	hasVideo       bool
+	videoCodecType VideoCodec
 
 	codecPrefs  []int          // codec preference order (payload types)
 	jitterDepth time.Duration  // jitter buffer depth (0 = default)
@@ -177,8 +190,10 @@ type call struct {
 	remoteSDP string
 
 	srtpLocalKey string        // base64 inline key for outbound encryption (non-empty = SRTP active)
-	srtpIn       *srtp.Context // inbound SRTP decryption context
-	srtpOut      *srtp.Context // outbound SRTP encryption context
+	srtpIn       *srtp.Context // inbound SRTP decryption context (audio)
+	srtpOut      *srtp.Context // outbound SRTP encryption context (audio)
+	videoSrtpIn  *srtp.Context // inbound SRTP decryption context (video — separate to avoid concurrent state corruption)
+	videoSrtpOut *srtp.Context // outbound SRTP encryption context (video)
 
 	iceEnabled bool       // ICE-Lite enabled for this call
 	iceAgent   *ice.Agent // ICE-Lite agent (nil if ICE disabled)
@@ -199,7 +214,22 @@ type call struct {
 	mediaTimerReset chan time.Duration // signals the media goroutine to reset the timeout
 	callbackCh      chan func()        // single dispatch goroutine for all callbacks
 	callbackOnce    sync.Once          // ensures callbackCh is closed exactly once
-	closeChOnce     sync.Once          // ensures output channels are closed exactly once
+	closeChOnce     sync.Once          // ensures audio output channels are closed exactly once
+
+	// Video pipeline state.
+	videoRTPInbound   chan *rtp.Packet
+	videoRTPReader    chan *rtp.Packet
+	videoRTPRawReader chan *rtp.Packet
+	videoRTPWriter    chan *rtp.Packet
+	videoReader       chan VideoFrame
+	videoWriter       chan VideoFrame
+	videoSentRTP      chan *rtp.Packet // test hook: outbound video packets
+	videoRTPConn      net.PacketConn   // video RTP socket
+	videoRTCPConn     net.PacketConn   // video RTCP socket
+	videoRTPPort      int              // allocated video RTP port
+	videoRemoteAddr   net.Addr         // remote video RTP endpoint
+	videoDone         chan struct{}    // signals video goroutine to stop
+	closeVideoChOnce  sync.Once        // ensures video output channels are closed exactly once
 }
 
 func newInboundCall(d dialog) *call {
@@ -563,8 +593,23 @@ func (c *call) buildLocalSDP(direction string) string {
 	c.ensureRTPPort()
 	iceParams := c.buildICEParams()
 	codecs := c.resolveCodecPrefs()
+
+	// Determine video codecs and port for the offer.
+	videoCodecs := videoCodecPrefsToInts(c.opts.VideoCodecs)
+	videoPort := c.videoRTPPort
+
 	var offer string
-	if c.srtpLocalKey != "" && iceParams != nil {
+	if len(videoCodecs) > 0 && videoPort > 0 {
+		if c.srtpLocalKey != "" && iceParams != nil {
+			offer = sdp.BuildOfferVideoSRTPICE(c.localIP, c.rtpPort, codecs, videoPort, videoCodecs, direction, c.srtpLocalKey, iceParams)
+		} else if c.srtpLocalKey != "" {
+			offer = sdp.BuildOfferVideoSRTP(c.localIP, c.rtpPort, codecs, videoPort, videoCodecs, direction, c.srtpLocalKey)
+		} else if iceParams != nil {
+			offer = sdp.BuildOfferVideoICE(c.localIP, c.rtpPort, codecs, videoPort, videoCodecs, direction, iceParams)
+		} else {
+			offer = sdp.BuildOfferVideo(c.localIP, c.rtpPort, codecs, videoPort, videoCodecs, direction)
+		}
+	} else if c.srtpLocalKey != "" && iceParams != nil {
 		offer = sdp.BuildOfferSRTPICE(c.localIP, c.rtpPort, codecs, direction, c.srtpLocalKey, iceParams)
 	} else if c.srtpLocalKey != "" {
 		offer = sdp.BuildOfferSRTP(c.localIP, c.rtpPort, codecs, direction, c.srtpLocalKey)
@@ -586,36 +631,60 @@ func (c *call) buildAnswerSDP(remote *sdp.Session, direction string) string {
 	if c.iceAgent != nil && remote.IceUfrag != "" && remote.IcePwd != "" {
 		c.iceAgent.SetRemoteCredentials(ice.Credentials{Ufrag: remote.IceUfrag, Pwd: remote.IcePwd})
 	}
-	var remoteCodecs []int
-	if len(remote.Media) > 0 {
-		remoteCodecs = remote.Media[0].Codecs
+	var remoteAudioCodecs []int
+	if am := remote.AudioMedia(); am != nil {
+		remoteAudioCodecs = am.Codecs
 	}
 	codecs := c.resolveCodecPrefs()
+
+	// Check for video m= line in the remote offer.
+	videoCodecs := videoCodecPrefsToInts(c.opts.VideoCodecs)
+	videoPort := c.videoRTPPort
+	var remoteVideoCodecs []int
+	if vm := remote.VideoMedia(); vm != nil {
+		remoteVideoCodecs = vm.Codecs
+	}
+
 	var answer string
-	if c.srtpLocalKey != "" && iceParams != nil {
-		answer = sdp.BuildAnswerSRTPICE(c.localIP, c.rtpPort, codecs, remoteCodecs, direction, c.srtpLocalKey, iceParams)
+	if len(videoCodecs) > 0 && videoPort > 0 && len(remoteVideoCodecs) > 0 {
+		if c.srtpLocalKey != "" && iceParams != nil {
+			answer = sdp.BuildAnswerVideoSRTPICE(c.localIP, c.rtpPort, codecs, remoteAudioCodecs, videoPort, videoCodecs, remoteVideoCodecs, direction, c.srtpLocalKey, iceParams)
+		} else if c.srtpLocalKey != "" {
+			answer = sdp.BuildAnswerVideoSRTP(c.localIP, c.rtpPort, codecs, remoteAudioCodecs, videoPort, videoCodecs, remoteVideoCodecs, direction, c.srtpLocalKey)
+		} else if iceParams != nil {
+			answer = sdp.BuildAnswerVideoICE(c.localIP, c.rtpPort, codecs, remoteAudioCodecs, videoPort, videoCodecs, remoteVideoCodecs, direction, iceParams)
+		} else {
+			answer = sdp.BuildAnswerVideo(c.localIP, c.rtpPort, codecs, remoteAudioCodecs, videoPort, videoCodecs, remoteVideoCodecs, direction)
+		}
+	} else if c.srtpLocalKey != "" && iceParams != nil {
+		answer = sdp.BuildAnswerSRTPICE(c.localIP, c.rtpPort, codecs, remoteAudioCodecs, direction, c.srtpLocalKey, iceParams)
 	} else if c.srtpLocalKey != "" {
-		answer = sdp.BuildAnswerSRTP(c.localIP, c.rtpPort, codecs, remoteCodecs, direction, c.srtpLocalKey)
+		answer = sdp.BuildAnswerSRTP(c.localIP, c.rtpPort, codecs, remoteAudioCodecs, direction, c.srtpLocalKey)
 	} else if iceParams != nil {
-		answer = sdp.BuildAnswerICE(c.localIP, c.rtpPort, codecs, remoteCodecs, direction, iceParams)
+		answer = sdp.BuildAnswerICE(c.localIP, c.rtpPort, codecs, remoteAudioCodecs, direction, iceParams)
 	} else {
-		answer = sdp.BuildAnswer(c.localIP, c.rtpPort, codecs, remoteCodecs, direction)
+		answer = sdp.BuildAnswer(c.localIP, c.rtpPort, codecs, remoteAudioCodecs, direction)
 	}
 	c.logger.Debug("SDP answer built", "id", c.id, "local_ip", c.localIP, "rtp_port", c.rtpPort, "direction", direction, "srtp", c.srtpLocalKey != "", "ice", iceParams != nil, "sdp", answer)
 	return answer
 }
 
 // negotiateCodec updates c.codec from a parsed remote SDP session.
+// Also negotiates video if a video m= line is present.
 // Must be called with c.mu held.
 func (c *call) negotiateCodec(sess *sdp.Session) {
+	// Negotiate audio from the first audio m= line.
 	var remoteCodecs []int
-	if len(sess.Media) > 0 {
-		remoteCodecs = sess.Media[0].Codecs
+	if am := sess.AudioMedia(); am != nil {
+		remoteCodecs = am.Codecs
 	}
 	if pt := sdp.NegotiateCodec(c.resolveCodecPrefs(), remoteCodecs); pt >= 0 {
 		c.codec = Codec(pt)
 	}
 	c.logger.Debug("codec negotiated", "id", c.id, "codec", int(c.codec), "local_prefs", c.resolveCodecPrefs(), "remote_codecs", remoteCodecs)
+
+	// Negotiate video.
+	c.negotiateVideoCodec(sess)
 }
 
 // buildICEParams creates ICE SDP parameters and initializes the ICE agent.
@@ -667,6 +736,85 @@ func candidateStrings(cands []ice.Candidate) []string {
 		s[i] = c.SDPValue()
 	}
 	return s
+}
+
+// initVideoChannels allocates all video pipeline channels and the video mediaStream.
+// Must be called with c.mu held.
+func (c *call) initVideoChannels() {
+	c.videoRTPInbound = make(chan *rtp.Packet, 256)
+	c.videoRTPReader = make(chan *rtp.Packet, 256)
+	c.videoRTPRawReader = make(chan *rtp.Packet, 256)
+	c.videoRTPWriter = make(chan *rtp.Packet, 256)
+	c.videoReader = make(chan VideoFrame, 256)
+	c.videoWriter = make(chan VideoFrame, 256)
+	c.videoStream = &mediaStream{call: c, outSSRC: randUint32()}
+}
+
+// ensureVideoRTPPort lazily allocates a UDP socket for video RTP.
+// Must be called with c.mu held.
+func (c *call) ensureVideoRTPPort() {
+	if c.localIP == "" {
+		c.localIP = localIPFor(c.sipHost)
+	}
+	if c.videoRTPPort == 0 {
+		conn, err := listenRTPPort(c.rtpPortMin, c.rtpPortMax)
+		if err == nil {
+			c.videoRTPPort = conn.LocalAddr().(*net.UDPAddr).Port
+			c.videoRTPConn = conn
+		}
+	}
+}
+
+// videoCodecPrefsToInts converts []VideoCodec to []int.
+func videoCodecPrefsToInts(codecs []VideoCodec) []int {
+	pts := make([]int, len(codecs))
+	for i, c := range codecs {
+		pts[i] = int(c)
+	}
+	return pts
+}
+
+// negotiateVideoCodec updates hasVideo and videoCodecType from a parsed SDP.
+// Must be called with c.mu held.
+func (c *call) negotiateVideoCodec(sess *sdp.Session) {
+	vm := sess.VideoMedia()
+	if vm == nil || len(vm.Codecs) == 0 {
+		return
+	}
+	// Accept the first video codec that we support.
+	for _, pt := range vm.Codecs {
+		switch VideoCodec(pt) {
+		case VideoCodecH264, VideoCodecVP8:
+			c.hasVideo = true
+			c.videoCodecType = VideoCodec(pt)
+			c.logger.Debug("video codec negotiated", "id", c.id, "codec", pt)
+			return
+		}
+	}
+}
+
+// setVideoRemoteEndpoint extracts the video remote address from a parsed SDP.
+// Must be called with c.mu held.
+func (c *call) setVideoRemoteEndpoint(sess *sdp.Session) {
+	vm := sess.VideoMedia()
+	if vm == nil {
+		return
+	}
+	ip := sess.Connection
+	if ip == "" || vm.Port <= 0 {
+		return
+	}
+	addr, _ := net.ResolveUDPAddr("udp", net.JoinHostPort(ip, strconv.Itoa(vm.Port)))
+	c.videoRemoteAddr = addr
+}
+
+// closeVideoOutputChannels closes the consumer-facing video channels exactly once.
+func (c *call) closeVideoOutputChannels() {
+	c.closeVideoChOnce.Do(func() {
+		close(c.videoRTPReader)
+		close(c.videoRTPRawReader)
+		close(c.videoReader)
+	})
 }
 
 func (c *call) startSessionTimer() {
@@ -767,6 +915,23 @@ func (c *call) fireOnEnded(reason EndReason) {
 		}
 		c.mediaActive = false
 	}
+	// Stop video pipeline goroutine.
+	if c.videoDone != nil {
+		select {
+		case <-c.videoDone:
+		default:
+			close(c.videoDone)
+		}
+	}
+	// Close video RTCP and RTP sockets.
+	if c.videoRTCPConn != nil {
+		c.videoRTCPConn.Close()
+		c.videoRTCPConn = nil
+	}
+	if c.videoRTPConn != nil {
+		c.videoRTPConn.Close()
+		c.videoRTPConn = nil
+	}
 	// Close RTP and RTCP sockets (also stops the RTP reader goroutine).
 	if c.rtcpConn != nil {
 		c.rtcpConn.Close()
@@ -783,10 +948,19 @@ func (c *call) fireOnEnded(reason EndReason) {
 	if c.srtpOut != nil {
 		c.srtpOut.Zeroize()
 	}
+	if c.videoSrtpIn != nil {
+		c.videoSrtpIn.Zeroize()
+	}
+	if c.videoSrtpOut != nil {
+		c.videoSrtpOut.Zeroize()
+	}
 	// Close output channels only if the media goroutine was never started
 	// (otherwise the goroutine's defer handles it to avoid send-on-closed panic).
 	if c.mediaDone == nil {
 		c.closeOutputChannels()
+	}
+	if c.videoDone == nil && c.videoRTPReader != nil {
+		c.closeVideoOutputChannels()
 	}
 	// Clear OnNotify to break closure reference cycles.
 	c.dlg.OnNotify(nil)
@@ -825,8 +999,11 @@ func (c *call) Accept(opts ...AcceptOption) error {
 	}
 	// Build SDP answer: if we have the remote offer, restrict to offered codecs.
 	c.logger.Debug("accepting call", "id", c.id, "remote_sdp", c.remoteSDP)
+	var sess *sdp.Session
 	if c.remoteSDP != "" {
-		if sess, err := sdp.Parse(c.remoteSDP); err == nil {
+		var err error
+		sess, err = sdp.Parse(c.remoteSDP)
+		if err == nil {
 			c.negotiateCodec(sess)
 			c.localSDP = c.buildAnswerSDP(sess, sdp.DirSendRecv)
 			c.setRemoteEndpoint(sess)
@@ -839,12 +1016,24 @@ func (c *call) Accept(opts ...AcceptOption) error {
 	if err := c.dlg.Respond(200, "OK", []byte(c.localSDP)); err != nil {
 		c.logger.Error("failed to send 200 OK", "err", err)
 	}
+
+	// Set up video if negotiated.
+	if c.hasVideo && c.videoRTPConn != nil {
+		if sess != nil {
+			c.setVideoRemoteEndpoint(sess)
+		}
+		if c.videoRTPReader == nil {
+			c.initVideoChannels()
+		}
+	}
+
 	c.state = StateActive
 	c.startTime = time.Now()
 	c.startSessionTimer()
 	c.fireOnState(StateActive)
 	c.logger.Info("call accepted", "id", c.id)
 	hasRTP := c.rtpConn != nil
+	hasVideoRTP := c.hasVideo && c.videoRTPConn != nil
 	onMediaFn := c.onMediaFn
 	c.mu.Unlock()
 
@@ -852,6 +1041,10 @@ func (c *call) Accept(opts ...AcceptOption) error {
 	if hasRTP {
 		c.startMedia()
 		c.startRTPReader()
+	}
+	if hasVideoRTP {
+		c.startVideoMedia()
+		c.startVideoRTPReader()
 	}
 	if onMediaFn != nil {
 		c.dispatch(onMediaFn)
@@ -957,6 +1150,9 @@ func (c *call) Mute() error {
 		return ErrAlreadyMuted
 	}
 	c.audioStream.muted = true
+	if c.videoStream != nil {
+		c.videoStream.muted = true
+	}
 	fn := c.onMuteFn
 	c.mu.Unlock()
 	if fn != nil {
@@ -976,6 +1172,9 @@ func (c *call) Unmute() error {
 		return ErrNotMuted
 	}
 	c.audioStream.muted = false
+	if c.videoStream != nil {
+		c.videoStream.muted = false
+	}
 	fn := c.onUnmuteFn
 	c.mu.Unlock()
 	if fn != nil {
@@ -1094,6 +1293,113 @@ func (c *call) RTPReader() <-chan *rtp.Packet    { return c.rtpReader }
 func (c *call) RTPWriter() chan<- *rtp.Packet    { return c.rtpWriter }
 func (c *call) PCMReader() <-chan []int16        { return c.pcmReader }
 func (c *call) PCMWriter() chan<- []int16        { return c.pcmWriter }
+
+func (c *call) HasVideo() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hasVideo
+}
+
+func (c *call) VideoCodec() VideoCodec {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.videoCodecType
+}
+
+func (c *call) VideoReader() <-chan VideoFrame {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.videoReader
+}
+
+func (c *call) VideoWriter() chan<- VideoFrame {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.videoWriter
+}
+
+func (c *call) VideoRTPReader() <-chan *rtp.Packet {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.videoRTPReader
+}
+
+func (c *call) VideoRTPWriter() chan<- *rtp.Packet {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.videoRTPWriter
+}
+
+func (c *call) MuteVideo() error {
+	c.mu.Lock()
+	if c.state != StateActive {
+		c.mu.Unlock()
+		return ErrInvalidState
+	}
+	if !c.hasVideo || c.videoStream == nil {
+		c.mu.Unlock()
+		return ErrNoVideo
+	}
+	if c.videoStream.muted {
+		c.mu.Unlock()
+		return ErrAlreadyMuted
+	}
+	c.videoStream.muted = true
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *call) UnmuteVideo() error {
+	c.mu.Lock()
+	if c.state != StateActive {
+		c.mu.Unlock()
+		return ErrInvalidState
+	}
+	if !c.hasVideo || c.videoStream == nil {
+		c.mu.Unlock()
+		return ErrNoVideo
+	}
+	if !c.videoStream.muted {
+		c.mu.Unlock()
+		return ErrNotMuted
+	}
+	c.videoStream.muted = false
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *call) RequestKeyframe() error {
+	c.mu.Lock()
+	if c.state != StateActive {
+		c.mu.Unlock()
+		return ErrInvalidState
+	}
+	if !c.hasVideo || c.videoStream == nil {
+		c.mu.Unlock()
+		return ErrNoVideo
+	}
+	rtcpConn := c.videoRTCPConn
+	remoteAddr := c.videoRemoteAddr
+	srtpOut := c.videoSrtpOut
+	ssrc := c.videoStream.outSSRC
+	c.mu.Unlock()
+
+	if rtcpConn == nil || remoteAddr == nil {
+		return nil
+	}
+
+	// Build PLI with media SSRC = 0 (we don't know remote video SSRC yet).
+	pli := rtcp.BuildPLI(ssrc, 0)
+	if srtpOut != nil {
+		var err error
+		pli, err = srtpOut.ProtectRTCP(pli)
+		if err != nil {
+			return err
+		}
+	}
+	_, err := rtcpConn.WriteTo(pli, remoteAddr)
+	return err
+}
 
 func (c *call) OnDTMF(fn func(string)) {
 	c.mu.Lock()

--- a/errors.go
+++ b/errors.go
@@ -28,6 +28,8 @@ var (
 	ErrAlreadyMuted = errors.New("xphone: already muted")
 	// ErrNotMuted is returned when Unmute is called on a call that is not muted.
 	ErrNotMuted = errors.New("xphone: not muted")
+	// ErrNoVideo is returned when a video operation is called on an audio-only call.
+	ErrNoVideo = errors.New("xphone: no video stream")
 	// ErrAlreadyConnected is returned when Connect is called on a phone that is already connected.
 	ErrAlreadyConnected = errors.New("xphone: already connected")
 	// ErrNotConnected is returned when Disconnect is called on a phone that is not connected.

--- a/events.go
+++ b/events.go
@@ -84,6 +84,16 @@ type NotifyEvent struct {
 	Reason            string   // reason parameter (e.g. "deactivated", "rejected")
 }
 
+// VideoFrame represents a single assembled video frame from the RTP pipeline.
+// The library does NOT encode/decode video — consumers use platform APIs
+// (VideoToolbox, VA-API, etc.) and feed raw encoded frames in/out.
+type VideoFrame struct {
+	Codec      VideoCodec
+	Timestamp  uint32
+	IsKeyframe bool
+	Data       []byte // H.264: Annex-B NAL units; VP8: raw frame
+}
+
 // VoicemailStatus represents the state of a voicemail mailbox (RFC 3842 MWI).
 type VoicemailStatus struct {
 	// MessagesWaiting indicates whether new messages are waiting.

--- a/internal/rtcp/rtcp.go
+++ b/internal/rtcp/rtcp.go
@@ -11,6 +11,7 @@ import (
 const (
 	ptSR      = 200 // Sender Report (RFC 3550 §6.4.1)
 	ptRR      = 201 // Receiver Report (RFC 3550 §6.4.2)
+	ptPSFB    = 206 // Payload-specific feedback (RFC 4585)
 	rtcpVer   = 2   // RTCP version (matches RTP)
 	reportLen = 24  // bytes per report block
 
@@ -19,6 +20,11 @@ const (
 
 	// IntervalSecs is the minimum RTCP send interval (RFC 3550 §6.2).
 	IntervalSecs = 5
+
+	// PLI FMT (RFC 4585 §6.3.1).
+	fmtPLI = 1
+	// FIR FMT (RFC 5104 §4.3.1.1).
+	fmtFIR = 4
 )
 
 // Stats tracks RTP statistics for RTCP report generation.
@@ -338,6 +344,36 @@ func Parse(data []byte) *Packet {
 	default:
 		return nil
 	}
+}
+
+// BuildPLI builds an RTCP Picture Loss Indication (RFC 4585 §6.3.1).
+// senderSSRC is our SSRC; mediaSSRC is the remote video SSRC.
+func BuildPLI(senderSSRC, mediaSSRC uint32) []byte {
+	// PLI: V=2, P=0, FMT=1, PT=206 (PSFB), length=2 (12 bytes total).
+	buf := make([]byte, 12)
+	buf[0] = (rtcpVer << 6) | fmtPLI
+	buf[1] = ptPSFB
+	binary.BigEndian.PutUint16(buf[2:4], 2) // length in 32-bit words minus one
+	binary.BigEndian.PutUint32(buf[4:8], senderSSRC)
+	binary.BigEndian.PutUint32(buf[8:12], mediaSSRC)
+	return buf
+}
+
+// BuildFIR builds an RTCP Full Intra Request (RFC 5104 §4.3.1.1).
+// senderSSRC is our SSRC; mediaSSRC is the remote video SSRC; seqNr is the FIR sequence number.
+func BuildFIR(senderSSRC, mediaSSRC uint32, seqNr uint8) []byte {
+	// FIR: V=2, P=0, FMT=4, PT=206 (PSFB), length=4 (20 bytes total).
+	buf := make([]byte, 20)
+	buf[0] = (rtcpVer << 6) | fmtFIR
+	buf[1] = ptPSFB
+	binary.BigEndian.PutUint16(buf[2:4], 4) // length
+	binary.BigEndian.PutUint32(buf[4:8], senderSSRC)
+	binary.BigEndian.PutUint32(buf[8:12], 0) // media SSRC field is 0 for FIR
+	// FCI: SSRC + seq + reserved
+	binary.BigEndian.PutUint32(buf[12:16], mediaSSRC)
+	buf[16] = seqNr
+	// buf[17:20] reserved (zero)
+	return buf
 }
 
 func parseReportBlocks(data []byte, count uint8) []ReportBlock {

--- a/internal/rtcp/rtcp_test.go
+++ b/internal/rtcp/rtcp_test.go
@@ -226,6 +226,42 @@ func TestParseSRWithReportBlock(t *testing.T) {
 	assert.Equal(t, uint32(0), parsed.Reports[0].CumLost)
 }
 
+func TestBuildPLI(t *testing.T) {
+	pli := BuildPLI(0x11111111, 0x22222222)
+	require.Len(t, pli, 12)
+
+	// V=2, FMT=1, PT=206.
+	assert.Equal(t, byte(2), (pli[0]>>6)&0x03)
+	assert.Equal(t, byte(1), pli[0]&0x1F)
+	assert.Equal(t, byte(206), pli[1])
+	// Length = 2.
+	assert.Equal(t, uint16(2), uint16(pli[2])<<8|uint16(pli[3]))
+	// Sender SSRC.
+	assert.Equal(t, uint32(0x11111111), be32(pli[4:8]))
+	// Media SSRC.
+	assert.Equal(t, uint32(0x22222222), be32(pli[8:12]))
+}
+
+func TestBuildFIR(t *testing.T) {
+	fir := BuildFIR(0xAAAAAAAA, 0xBBBBBBBB, 7)
+	require.Len(t, fir, 20)
+
+	// V=2, FMT=4, PT=206.
+	assert.Equal(t, byte(2), (fir[0]>>6)&0x03)
+	assert.Equal(t, byte(4), fir[0]&0x1F)
+	assert.Equal(t, byte(206), fir[1])
+	// Length = 4.
+	assert.Equal(t, uint16(4), uint16(fir[2])<<8|uint16(fir[3]))
+	// Sender SSRC.
+	assert.Equal(t, uint32(0xAAAAAAAA), be32(fir[4:8]))
+	// Media SSRC in header = 0 for FIR.
+	assert.Equal(t, uint32(0), be32(fir[8:12]))
+	// FCI: target SSRC.
+	assert.Equal(t, uint32(0xBBBBBBBB), be32(fir[12:16]))
+	// Sequence number.
+	assert.Equal(t, byte(7), fir[16])
+}
+
 // be32 is a test helper to read a big-endian uint32.
 func be32(b []byte) uint32 {
 	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])

--- a/internal/sdp/sdp.go
+++ b/internal/sdp/sdp.go
@@ -386,6 +386,46 @@ func buildSDPMulti(ip string, audioPort int, audioCodecs []int, direction, profi
 	return b.String()
 }
 
+// BuildAnswerVideo creates an SDP answer with audio and video media lines.
+func BuildAnswerVideo(ip string, audioPort int, localPrefs, remoteAudioOffer []int, videoPort int, localVideoPrefs, remoteVideoOffer []int, direction string) string {
+	audioCodecs := intersectCodecs(localPrefs, remoteAudioOffer)
+	if len(audioCodecs) == 0 {
+		audioCodecs = localPrefs
+	}
+	videoCodecs := intersectCodecs(localVideoPrefs, remoteVideoOffer)
+	return buildSDPMulti(ip, audioPort, audioCodecs, direction, ProfileRTP, "", nil, videoPort, videoCodecs)
+}
+
+// BuildAnswerVideoSRTP creates an SDP answer with audio, video, and SRTP.
+func BuildAnswerVideoSRTP(ip string, audioPort int, localPrefs, remoteAudioOffer []int, videoPort int, localVideoPrefs, remoteVideoOffer []int, direction, cryptoInlineKey string) string {
+	audioCodecs := intersectCodecs(localPrefs, remoteAudioOffer)
+	if len(audioCodecs) == 0 {
+		audioCodecs = localPrefs
+	}
+	videoCodecs := intersectCodecs(localVideoPrefs, remoteVideoOffer)
+	return buildSDPMulti(ip, audioPort, audioCodecs, direction, ProfileSRTP, cryptoInlineKey, nil, videoPort, videoCodecs)
+}
+
+// BuildAnswerVideoICE creates an SDP answer with audio, video, and ICE.
+func BuildAnswerVideoICE(ip string, audioPort int, localPrefs, remoteAudioOffer []int, videoPort int, localVideoPrefs, remoteVideoOffer []int, direction string, ice *ICEParams) string {
+	audioCodecs := intersectCodecs(localPrefs, remoteAudioOffer)
+	if len(audioCodecs) == 0 {
+		audioCodecs = localPrefs
+	}
+	videoCodecs := intersectCodecs(localVideoPrefs, remoteVideoOffer)
+	return buildSDPMulti(ip, audioPort, audioCodecs, direction, ProfileRTP, "", ice, videoPort, videoCodecs)
+}
+
+// BuildAnswerVideoSRTPICE creates an SDP answer with audio, video, SRTP, and ICE.
+func BuildAnswerVideoSRTPICE(ip string, audioPort int, localPrefs, remoteAudioOffer []int, videoPort int, localVideoPrefs, remoteVideoOffer []int, direction, cryptoInlineKey string, ice *ICEParams) string {
+	audioCodecs := intersectCodecs(localPrefs, remoteAudioOffer)
+	if len(audioCodecs) == 0 {
+		audioCodecs = localPrefs
+	}
+	videoCodecs := intersectCodecs(localVideoPrefs, remoteVideoOffer)
+	return buildSDPMulti(ip, audioPort, audioCodecs, direction, ProfileSRTP, cryptoInlineKey, ice, videoPort, videoCodecs)
+}
+
 // BuildOfferVideo creates an SDP offer with audio and video media lines.
 func BuildOfferVideo(ip string, audioPort int, audioCodecs []int, videoPort int, videoCodecs []int, direction string) string {
 	return buildSDPMulti(ip, audioPort, audioCodecs, direction, ProfileRTP, "", nil, videoPort, videoCodecs)

--- a/media.go
+++ b/media.go
@@ -443,6 +443,220 @@ func (c *call) startMedia() {
 	go s.run(jb, cp, rtpClockRate)
 }
 
+// runVideo is the video media pipeline goroutine. Unlike audio, video uses
+// RTP passthrough only (no jitter buffer, no PCM, no DTMF).
+func (s *mediaStream) runVideo() {
+	c := s.call
+	conn := s.conn
+	rtcpConn := s.rtcpConn
+	rtcpRemoteAddr := s.rtcpRemoteAddr
+	done := s.done
+
+	defer c.closeVideoOutputChannels()
+
+	// RTCP state for video (90kHz clock).
+	rtcpStats := rtcp.NewStats()
+	var rtcpTick <-chan time.Time
+	var rtcpTicker *time.Ticker
+	if rtcpConn != nil {
+		rtcpTicker = time.NewTicker(time.Duration(rtcp.IntervalSecs) * time.Second)
+		rtcpTick = rtcpTicker.C
+		defer rtcpTicker.Stop()
+	}
+
+	// RTCP reader goroutine.
+	rtcpInbound := make(chan []byte, 16)
+	if rtcpConn != nil {
+		go func() {
+			buf := make([]byte, 1500)
+			for {
+				n, _, err := rtcpConn.ReadFrom(buf)
+				if err != nil {
+					return
+				}
+				if n < 8 {
+					continue
+				}
+				cp := make([]byte, n)
+				copy(cp, buf[:n])
+				select {
+				case rtcpInbound <- cp:
+				default:
+				}
+			}
+		}()
+	}
+
+	for {
+		select {
+		case <-done:
+			return
+
+		case pkt := <-c.videoRTPInbound:
+			s.inboundCount++
+			sendDropOldest(c.videoRTPRawReader, clonePacket(pkt))
+			sendDropOldest(c.videoRTPReader, clonePacket(pkt))
+			rtcpStats.RecordRTPReceived(pkt.SequenceNumber, pkt.Timestamp, pkt.SSRC, 90000)
+
+		case <-c.videoWriter:
+			// VideoFrame write path — packetizer not yet implemented (PR 4).
+			// Drain to prevent writers from blocking.
+
+		case pkt := <-c.videoRTPWriter:
+			c.mu.Lock()
+			muted := s.muted
+			dst := c.videoRemoteAddr
+			srtpOut := c.videoSrtpOut
+			c.mu.Unlock()
+			if muted {
+				continue
+			}
+			rtcpStats.RecordRTPSent(len(pkt.Payload), pkt.Timestamp)
+			if c.videoSentRTP != nil {
+				sendDropOldest(c.videoSentRTP, pkt)
+			}
+			if conn != nil && dst != nil {
+				if data, err := pkt.Marshal(); err == nil {
+					if srtpOut != nil {
+						data, err = srtpOut.Protect(data)
+						if err != nil {
+							continue
+						}
+					}
+					conn.WriteTo(data, dst)
+				}
+			}
+
+		case <-rtcpTick:
+			if rtcpConn != nil && rtcpRemoteAddr != nil {
+				c.mu.Lock()
+				srtcpOut := c.videoSrtpOut
+				c.mu.Unlock()
+				sr := rtcp.BuildSR(s.outSSRC, rtcpStats)
+				if srtcpOut != nil {
+					var err error
+					sr, err = srtcpOut.ProtectRTCP(sr)
+					if err != nil {
+						continue
+					}
+				}
+				rtcpConn.WriteTo(sr, rtcpRemoteAddr)
+			}
+
+		case data := <-rtcpInbound:
+			c.mu.Lock()
+			srtcpIn := c.videoSrtpIn
+			c.mu.Unlock()
+			if srtcpIn != nil {
+				var err error
+				data, err = srtcpIn.UnprotectRTCP(data)
+				if err != nil {
+					continue
+				}
+			}
+			if pkt := rtcp.Parse(data); pkt != nil && pkt.IsSenderReport() {
+				rtcpStats.ProcessIncomingSR(pkt.NTPSec, pkt.NTPFrac)
+			}
+		}
+	}
+}
+
+// startVideoMedia initializes the video pipeline (RTCP socket, launches runVideo goroutine).
+func (c *call) startVideoMedia() {
+	c.mu.Lock()
+	if c.videoDone != nil {
+		c.mu.Unlock()
+		return // already running
+	}
+	conn := c.videoRTPConn
+	c.videoDone = make(chan struct{})
+	done := c.videoDone
+
+	// Bind video RTCP socket (video RTP port + 1). Non-fatal if it fails.
+	if conn != nil && c.videoRTCPConn == nil {
+		rtpLocal := conn.LocalAddr().(*net.UDPAddr)
+		rtcpAddr := net.JoinHostPort(rtpLocal.IP.String(), strconv.Itoa(rtpLocal.Port+1))
+		if rc, err := net.ListenPacket("udp", rtcpAddr); err == nil {
+			c.videoRTCPConn = rc
+		} else {
+			c.logger.Warn("video RTCP port bind failed", "rtcp_addr", rtcpAddr, "error", err)
+		}
+	}
+
+	// Compute remote video RTCP address.
+	var rtcpRemoteAddr net.Addr
+	if c.videoRemoteAddr != nil {
+		if udpAddr, ok := c.videoRemoteAddr.(*net.UDPAddr); ok {
+			rtcpRemoteAddr, _ = net.ResolveUDPAddr("udp", net.JoinHostPort(udpAddr.IP.String(), strconv.Itoa(udpAddr.Port+1)))
+		}
+	}
+
+	s := c.videoStream
+	s.conn = conn
+	s.rtcpConn = c.videoRTCPConn
+	s.rtcpRemoteAddr = rtcpRemoteAddr
+	s.done = done
+	s.outSeq = 0
+	s.outTimestamp = 0
+	s.rtpWriterUsed = false
+	s.inboundCount = 0
+	c.mu.Unlock()
+
+	c.logger.Debug("video pipeline started", "id", c.id)
+	go s.runVideo()
+}
+
+// startVideoRTPReader launches a goroutine that reads RTP packets from the
+// video network socket and feeds them into the video pipeline's videoRTPInbound channel.
+func (c *call) startVideoRTPReader() {
+	c.mu.Lock()
+	conn := c.videoRTPConn
+	iceAgent := c.iceAgent // immutable after call setup
+	c.mu.Unlock()
+	if conn == nil {
+		return
+	}
+
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, from, err := conn.ReadFrom(buf)
+			if err != nil {
+				return // socket closed
+			}
+			cp := make([]byte, n)
+			copy(cp, buf[:n])
+
+			// ICE STUN demux: intercept Binding Requests before RTP processing.
+			if iceAgent != nil && stun.IsMessage(cp) {
+				fromUDP, ok := from.(*net.UDPAddr)
+				if ok {
+					if resp := iceAgent.HandleBindingRequest(cp, fromUDP); resp != nil {
+						conn.WriteTo(resp, from)
+					}
+				}
+				continue
+			}
+
+			c.mu.Lock()
+			srtpIn := c.videoSrtpIn
+			c.mu.Unlock()
+			if srtpIn != nil {
+				cp, err = srtpIn.Unprotect(cp)
+				if err != nil {
+					continue
+				}
+			}
+
+			pkt := &rtp.Packet{}
+			if err := pkt.Unmarshal(cp); err != nil {
+				continue
+			}
+			sendDropOldest(c.videoRTPInbound, pkt)
+		}
+	}()
+}
+
 // stopMedia tears down the media pipeline and releases RTP ports.
 func (c *call) stopMedia() {
 	c.mu.Lock()

--- a/mock_call.go
+++ b/mock_call.go
@@ -51,21 +51,33 @@ type MockCall struct {
 	rtpWriter    chan *rtp.Packet
 	pcmReader    chan []int16
 	pcmWriter    chan []int16
+
+	hasVideo       bool
+	videoCodecType VideoCodec
+	videoReader    chan VideoFrame
+	videoWriter    chan VideoFrame
+	videoRTPReader chan *rtp.Packet
+	videoRTPWriter chan *rtp.Packet
+	videoMuted     bool
 }
 
 // NewMockCall creates a new MockCall with default state (Ringing, Inbound).
 func NewMockCall() *MockCall {
 	return &MockCall{
-		id:           newCallID(),
-		callID:       newCallID(),
-		state:        StateRinging,
-		direction:    DirectionInbound,
-		headers:      make(map[string][]string),
-		rtpRawReader: make(chan *rtp.Packet, 256),
-		rtpReader:    make(chan *rtp.Packet, 256),
-		rtpWriter:    make(chan *rtp.Packet, 256),
-		pcmReader:    make(chan []int16, 256),
-		pcmWriter:    make(chan []int16, 256),
+		id:             newCallID(),
+		callID:         newCallID(),
+		state:          StateRinging,
+		direction:      DirectionInbound,
+		headers:        make(map[string][]string),
+		rtpRawReader:   make(chan *rtp.Packet, 256),
+		rtpReader:      make(chan *rtp.Packet, 256),
+		rtpWriter:      make(chan *rtp.Packet, 256),
+		pcmReader:      make(chan []int16, 256),
+		pcmWriter:      make(chan []int16, 256),
+		videoReader:    make(chan VideoFrame, 256),
+		videoWriter:    make(chan VideoFrame, 256),
+		videoRTPReader: make(chan *rtp.Packet, 256),
+		videoRTPWriter: make(chan *rtp.Packet, 256),
 	}
 }
 
@@ -558,6 +570,118 @@ func (c *MockCall) SimulateDTMF(digit string) {
 // InjectRTP pushes an RTP packet onto the RTPReader channel.
 func (c *MockCall) InjectRTP(pkt *rtp.Packet) {
 	c.rtpReader <- pkt
+}
+
+func (c *MockCall) HasVideo() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hasVideo
+}
+
+func (c *MockCall) VideoCodec() VideoCodec {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.videoCodecType
+}
+
+func (c *MockCall) VideoReader() <-chan VideoFrame {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.hasVideo {
+		return nil
+	}
+	return c.videoReader
+}
+
+func (c *MockCall) VideoWriter() chan<- VideoFrame {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.hasVideo {
+		return nil
+	}
+	return c.videoWriter
+}
+
+func (c *MockCall) VideoRTPReader() <-chan *rtp.Packet {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.hasVideo {
+		return nil
+	}
+	return c.videoRTPReader
+}
+
+func (c *MockCall) VideoRTPWriter() chan<- *rtp.Packet {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.hasVideo {
+		return nil
+	}
+	return c.videoRTPWriter
+}
+
+func (c *MockCall) MuteVideo() error {
+	c.mu.Lock()
+	if c.state != StateActive {
+		c.mu.Unlock()
+		return ErrInvalidState
+	}
+	if !c.hasVideo {
+		c.mu.Unlock()
+		return ErrNoVideo
+	}
+	if c.videoMuted {
+		c.mu.Unlock()
+		return ErrAlreadyMuted
+	}
+	c.videoMuted = true
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *MockCall) UnmuteVideo() error {
+	c.mu.Lock()
+	if c.state != StateActive {
+		c.mu.Unlock()
+		return ErrInvalidState
+	}
+	if !c.hasVideo {
+		c.mu.Unlock()
+		return ErrNoVideo
+	}
+	if !c.videoMuted {
+		c.mu.Unlock()
+		return ErrNotMuted
+	}
+	c.videoMuted = false
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *MockCall) RequestKeyframe() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state != StateActive {
+		return ErrInvalidState
+	}
+	if !c.hasVideo {
+		return ErrNoVideo
+	}
+	return nil
+}
+
+// SetHasVideo enables or disables video on the mock call.
+func (c *MockCall) SetHasVideo(v bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hasVideo = v
+}
+
+// SetVideoCodec sets the negotiated video codec.
+func (c *MockCall) SetVideoCodec(vc VideoCodec) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.videoCodecType = vc
 }
 
 // Ensure MockCall satisfies Call at compile time.

--- a/sipgo_dialog.go
+++ b/sipgo_dialog.go
@@ -147,6 +147,7 @@ type sipgoDialogUAC struct {
 	dialogBase
 	cancelFn     context.CancelFunc // cancels the WaitAnswer context
 	rtpConn      net.PacketConn     // bound RTP socket from dial; ownership transferred to call
+	videoRtpConn net.PacketConn     // bound video RTP socket from dial; ownership transferred to call
 	srtpLocalKey string             // base64 SRTP inline key generated for this dialog
 }
 

--- a/sipua.go
+++ b/sipua.go
@@ -157,16 +157,12 @@ func newSipUA(cfg Config, contactIP string) (*sipUA, error) {
 // maxRedirects is the maximum number of 3xx redirect hops before giving up.
 const maxRedirects = 3
 
-// dial establishes an outbound SIP dialog using sipgo's dialog API.
-// It sends INVITE with SDP, waits for the answer (handling provisionals via
-// onResponse and 3xx redirects), sends ACK, and returns a sipgoDialogUAC.
-//
-// target may be a full SIP URI ("sip:1002@pbx.example.com") or just the
-// user part ("1002"), in which case the configured Host and Port are used.
-func (s *sipUA) dial(ctx context.Context, target string, onResponse func(code int, reason string)) (dialog, error) {
+// dialWithOpts establishes an outbound SIP dialog with DialOptions.
+// It delegates to dial, passing through video options for SDP construction.
+func (s *sipUA) dialWithOpts(ctx context.Context, target string, opts DialOptions, onResponse func(code int, reason string)) (dialog, error) {
 	currentTarget := target
 	for redirects := 0; ; redirects++ {
-		dlg, redirectURI, err := s.dialOnce(ctx, currentTarget, onResponse)
+		dlg, redirectURI, err := s.dialOnce(ctx, currentTarget, opts, onResponse)
 		if err != nil {
 			return nil, err
 		}
@@ -183,7 +179,7 @@ func (s *sipUA) dial(ctx context.Context, target string, onResponse func(code in
 
 // dialOnce sends a single INVITE attempt. Returns (dialog, "", nil) on success,
 // or (nil, redirectURI, nil) on 3xx redirect.
-func (s *sipUA) dialOnce(ctx context.Context, target string, onResponse func(code int, reason string)) (dialog, string, error) {
+func (s *sipUA) dialOnce(ctx context.Context, target string, opts DialOptions, onResponse func(code int, reason string)) (dialog, string, error) {
 	recipient := parseSIPTarget(target, s.cfg.Host, s.cfg.Port)
 
 	// Build SDP offer with cached local IP and an allocated RTP port.
@@ -197,18 +193,43 @@ func (s *sipUA) dialOnce(ctx context.Context, target string, onResponse func(cod
 	if len(codecPT) == 0 {
 		codecPT = defaultCodecPrefs
 	}
+
+	// Allocate video RTP port if video is requested.
+	var videoRtpConn net.PacketConn
+	var videoRtpPort int
+	if opts.Video && len(opts.VideoCodecs) > 0 {
+		videoRtpConn, err = listenRTPPort(s.cfg.RTPPortMin, s.cfg.RTPPortMax)
+		if err != nil {
+			rtpConn.Close()
+			return nil, "", fmt.Errorf("xphone: allocate video RTP port: %w", err)
+		}
+		videoRtpPort = videoRtpConn.LocalAddr().(*net.UDPAddr).Port
+	}
+	videoCodecs := videoCodecPrefsToInts(opts.VideoCodecs)
+
 	var sdpOffer string
 	var srtpLocalKey string
 	if s.cfg.SRTP {
 		key, err := srtp.GenerateKeyingMaterial()
 		if err != nil {
 			rtpConn.Close()
+			if videoRtpConn != nil {
+				videoRtpConn.Close()
+			}
 			return nil, "", fmt.Errorf("xphone: generate SRTP key: %w", err)
 		}
 		srtpLocalKey = key
-		sdpOffer = sdp.BuildOfferSRTP(ip, rtpPort, codecPT, sdp.DirSendRecv, key)
+		if len(videoCodecs) > 0 && videoRtpPort > 0 {
+			sdpOffer = sdp.BuildOfferVideoSRTP(ip, rtpPort, codecPT, videoRtpPort, videoCodecs, sdp.DirSendRecv, key)
+		} else {
+			sdpOffer = sdp.BuildOfferSRTP(ip, rtpPort, codecPT, sdp.DirSendRecv, key)
+		}
 	} else {
-		sdpOffer = sdp.BuildOffer(ip, rtpPort, codecPT, sdp.DirSendRecv)
+		if len(videoCodecs) > 0 && videoRtpPort > 0 {
+			sdpOffer = sdp.BuildOfferVideo(ip, rtpPort, codecPT, videoRtpPort, videoCodecs, sdp.DirSendRecv)
+		} else {
+			sdpOffer = sdp.BuildOffer(ip, rtpPort, codecPT, sdp.DirSendRecv)
+		}
 	}
 
 	// Create the dialog session and send INVITE.
@@ -218,6 +239,9 @@ func (s *sipUA) dialOnce(ctx context.Context, target string, onResponse func(cod
 	sess, err := s.dc.Invite(ctx, recipient, []byte(sdpOffer), contentType)
 	if err != nil {
 		rtpConn.Close()
+		if videoRtpConn != nil {
+			videoRtpConn.Close()
+		}
 		return nil, "", fmt.Errorf("xphone: invite: %w", err)
 	}
 
@@ -227,6 +251,9 @@ func (s *sipUA) dialOnce(ctx context.Context, target string, onResponse func(cod
 	defer func() {
 		if !ok {
 			rtpConn.Close()
+			if videoRtpConn != nil {
+				videoRtpConn.Close()
+			}
 			waitCancel()
 			sess.Close()
 		}
@@ -275,6 +302,7 @@ func (s *sipUA) dialOnce(ctx context.Context, target string, onResponse func(cod
 		},
 		cancelFn:     waitCancel,
 		rtpConn:      rtpConn,
+		videoRtpConn: videoRtpConn,
 		srtpLocalKey: srtpLocalKey,
 	}, "", nil
 }

--- a/video_test.go
+++ b/video_test.go
@@ -1,0 +1,312 @@
+package xphone
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/x-phone/xphone-go/testutil"
+)
+
+// activeVideoCall creates an inbound call in StateActive with both audio and
+// video media pipelines ready. sentRTP and videoSentRTP are initialized so
+// tests can observe outbound packets.
+func activeVideoCall(t *testing.T) *call {
+	t.Helper()
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	c.sentRTP = make(chan *rtp.Packet, 256)
+
+	// Set up video state before Accept.
+	c.hasVideo = true
+	c.videoCodecType = VideoCodecH264
+	c.initVideoChannels()
+	c.videoSentRTP = make(chan *rtp.Packet, 256)
+
+	// Allocate a real UDP socket for video.
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	c.videoRTPConn = conn
+	c.videoRTPPort = conn.LocalAddr().(*net.UDPAddr).Port
+
+	// Set a dummy remote address for video.
+	c.videoRemoteAddr, _ = net.ResolveUDPAddr("udp", "127.0.0.1:19000")
+
+	c.Accept()
+	c.startMedia()
+	c.startVideoMedia()
+	return c
+}
+
+// --- Video negotiation tests ---
+
+func TestCall_HasVideo_AudioOnly(t *testing.T) {
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	assert.False(t, c.HasVideo(), "audio-only call should have HasVideo=false")
+}
+
+func TestCall_HasVideo_WithVideo(t *testing.T) {
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	c.mu.Lock()
+	c.hasVideo = true
+	c.videoCodecType = VideoCodecH264
+	c.mu.Unlock()
+	assert.True(t, c.HasVideo())
+	assert.Equal(t, VideoCodecH264, c.VideoCodec())
+}
+
+func TestCall_VideoChannelAccessors_Nil_AudioOnly(t *testing.T) {
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	assert.Nil(t, c.VideoReader())
+	assert.Nil(t, c.VideoWriter())
+	assert.Nil(t, c.VideoRTPReader())
+	assert.Nil(t, c.VideoRTPWriter())
+}
+
+func TestCall_VideoChannelAccessors_NotNil_WithVideo(t *testing.T) {
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	c.mu.Lock()
+	c.hasVideo = true
+	c.initVideoChannels()
+	c.mu.Unlock()
+	assert.NotNil(t, c.VideoReader())
+	assert.NotNil(t, c.VideoWriter())
+	assert.NotNil(t, c.VideoRTPReader())
+	assert.NotNil(t, c.VideoRTPWriter())
+}
+
+// --- MuteVideo / UnmuteVideo tests ---
+
+func TestCall_MuteVideo_NoVideo(t *testing.T) {
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	c.Accept()
+	assert.Equal(t, ErrNoVideo, c.MuteVideo())
+	assert.Equal(t, ErrNoVideo, c.UnmuteVideo())
+}
+
+func TestCall_MuteVideo_NotActive(t *testing.T) {
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	// Still in StateRinging
+	assert.Equal(t, ErrInvalidState, c.MuteVideo())
+}
+
+func TestCall_MuteVideo_MuteUnmute(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	require.NoError(t, c.MuteVideo())
+
+	// Second mute should fail.
+	assert.Equal(t, ErrAlreadyMuted, c.MuteVideo())
+
+	// Unmute.
+	require.NoError(t, c.UnmuteVideo())
+
+	// Second unmute should fail.
+	assert.Equal(t, ErrNotMuted, c.UnmuteVideo())
+}
+
+func TestCall_MuteVideo_SuppressesOutboundVideo(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	require.NoError(t, c.MuteVideo())
+
+	// Write a video RTP packet — should be silently dropped (muted).
+	pkt := &rtp.Packet{Header: rtp.Header{SequenceNumber: 1, PayloadType: 96}}
+	select {
+	case c.VideoRTPWriter() <- pkt:
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// No packet should appear on videoSentRTP.
+	time.Sleep(50 * time.Millisecond)
+	pkts := drainPackets(c.videoSentRTP)
+	assert.Empty(t, pkts, "VideoRTPWriter output must be suppressed while muted")
+}
+
+// --- Video pipeline tests ---
+
+func TestVideoMedia_RTPPassthrough(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	// Inject a video RTP packet into the pipeline.
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 42, PayloadType: 96, Timestamp: 12345, SSRC: 0xABCD},
+		Payload: []byte{0x00, 0x01, 0x02},
+	}
+	c.videoRTPInbound <- pkt
+
+	// Should appear on both videoRTPRawReader and videoRTPReader.
+	raw := readPacket(t, c.videoRTPRawReader, 200*time.Millisecond)
+	reader := readPacket(t, c.videoRTPReader, 200*time.Millisecond)
+	assert.Equal(t, uint16(42), raw.SequenceNumber)
+	assert.Equal(t, uint16(42), reader.SequenceNumber)
+}
+
+func TestVideoMedia_OutboundRTPWriter(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 99, PayloadType: 96, Timestamp: 90000},
+		Payload: []byte{0xDE, 0xAD},
+	}
+	select {
+	case c.VideoRTPWriter() <- pkt:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("VideoRTPWriter blocked")
+	}
+
+	sent := readPacket(t, c.videoSentRTP, 200*time.Millisecond)
+	assert.Equal(t, uint16(99), sent.SequenceNumber)
+	assert.Equal(t, uint8(96), sent.PayloadType)
+	assert.Equal(t, []byte{0xDE, 0xAD}, sent.Payload)
+}
+
+// --- RequestKeyframe tests ---
+
+func TestCall_RequestKeyframe_NoVideo(t *testing.T) {
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	c.Accept()
+	assert.Equal(t, ErrNoVideo, c.RequestKeyframe())
+}
+
+func TestCall_RequestKeyframe_NotActive(t *testing.T) {
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	// Still in StateRinging
+	assert.Equal(t, ErrInvalidState, c.RequestKeyframe())
+}
+
+func TestCall_RequestKeyframe_SendsPLI(t *testing.T) {
+	// Build a call with video RTCP pre-configured before pipeline starts.
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	c.sentRTP = make(chan *rtp.Packet, 256)
+	c.hasVideo = true
+	c.videoCodecType = VideoCodecH264
+	c.initVideoChannels()
+	c.videoSentRTP = make(chan *rtp.Packet, 256)
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	c.videoRTPConn = conn
+	c.videoRTPPort = conn.LocalAddr().(*net.UDPAddr).Port
+	c.videoRemoteAddr, _ = net.ResolveUDPAddr("udp", "127.0.0.1:19000")
+
+	// Pre-bind video RTCP socket so startVideoMedia picks it up.
+	rtcpConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	c.videoRTCPConn = rtcpConn
+
+	c.Accept()
+	c.startMedia()
+	c.startVideoMedia()
+	defer c.stopMedia()
+	defer conn.Close()
+	defer rtcpConn.Close()
+
+	err = c.RequestKeyframe()
+	require.NoError(t, err)
+}
+
+// --- Mute/Unmute also mutes video ---
+
+func TestCall_Mute_AlsoMutesVideo(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	require.NoError(t, c.Mute())
+
+	c.mu.Lock()
+	videoMuted := c.videoStream.muted
+	c.mu.Unlock()
+	assert.True(t, videoMuted, "Mute() should also mute the video stream")
+
+	require.NoError(t, c.Unmute())
+
+	c.mu.Lock()
+	videoMuted = c.videoStream.muted
+	c.mu.Unlock()
+	assert.False(t, videoMuted, "Unmute() should also unmute the video stream")
+}
+
+// --- MockCall video tests ---
+
+func TestMockCall_VideoMethods(t *testing.T) {
+	c := NewMockCall()
+	c.SetState(StateActive)
+
+	// Without video enabled.
+	assert.False(t, c.HasVideo())
+	assert.Equal(t, ErrNoVideo, c.MuteVideo())
+	assert.Equal(t, ErrNoVideo, c.UnmuteVideo())
+	assert.Equal(t, ErrNoVideo, c.RequestKeyframe())
+
+	// Enable video.
+	c.SetHasVideo(true)
+	c.SetVideoCodec(VideoCodecVP8)
+	assert.True(t, c.HasVideo())
+	assert.Equal(t, VideoCodecVP8, c.VideoCodec())
+
+	// Mute/Unmute video.
+	require.NoError(t, c.MuteVideo())
+	assert.Equal(t, ErrAlreadyMuted, c.MuteVideo())
+	require.NoError(t, c.UnmuteVideo())
+	assert.Equal(t, ErrNotMuted, c.UnmuteVideo())
+
+	// Channels should be non-nil.
+	assert.NotNil(t, c.VideoReader())
+	assert.NotNil(t, c.VideoWriter())
+	assert.NotNil(t, c.VideoRTPReader())
+	assert.NotNil(t, c.VideoRTPWriter())
+
+	// RequestKeyframe with video.
+	require.NoError(t, c.RequestKeyframe())
+}
+
+// --- Close output channels includes video ---
+
+func TestCall_CloseVideoOutputChannels(t *testing.T) {
+	c := newInboundCall(testutil.NewMockDialog())
+	t.Cleanup(c.cleanup)
+	c.mu.Lock()
+	c.hasVideo = true
+	c.initVideoChannels()
+	c.mu.Unlock()
+
+	c.closeVideoOutputChannels()
+
+	// Verify video reader channels are closed.
+	_, ok := <-c.videoRTPReader
+	assert.False(t, ok, "videoRTPReader should be closed")
+	_, ok = <-c.videoRTPRawReader
+	assert.False(t, ok, "videoRTPRawReader should be closed")
+	_, ok = <-c.videoReader
+	assert.False(t, ok, "videoReader should be closed")
+
+	// Verify audio channels are NOT closed (separate lifecycle).
+	select {
+	case c.rtpReader <- nil:
+		// can still send — not closed
+	default:
+		// channel full, but not closed
+	}
+}

--- a/xphone.go
+++ b/xphone.go
@@ -63,7 +63,7 @@ type phone struct {
 	// Production: set by Connect() to use sipgo's dialog API.
 	// Tests: set by connectWithTransport() to use the mock transport.
 	// The onResponse callback is invoked for each provisional/final SIP response.
-	dialFn func(ctx context.Context, target string, onResponse func(code int, reason string)) (dialog, error)
+	dialFn func(ctx context.Context, target string, opts DialOptions, onResponse func(code int, reason string)) (dialog, error)
 
 	// Buffered callbacks set before Connect.
 	onRegisteredFn   func()
@@ -132,6 +132,8 @@ func (p *phone) wireCallCallbacks(c *call) {
 // setupSRTP initializes SRTP contexts on a call.
 // localKey is the base64 inline key for outbound encryption.
 // remoteKey is the base64 inline key from the remote SDP for inbound decryption.
+// Audio and video get separate contexts because srtp.Context has mutable state
+// (ROC, sequence tracking, HMAC) that would corrupt under concurrent access.
 func (p *phone) setupSRTP(c *call, localKey, remoteKey string) {
 	outCtx, err := srtp.FromSDESInline(localKey)
 	if err != nil {
@@ -147,7 +149,26 @@ func (p *phone) setupSRTP(c *call, localKey, remoteKey string) {
 	c.srtpLocalKey = localKey
 	c.srtpOut = outCtx
 	c.srtpIn = inCtx
+	hasVideo := c.hasVideo
 	c.mu.Unlock()
+
+	// Video needs its own contexts — independent ROC/seq/HMAC state.
+	if hasVideo {
+		videoOutCtx, err := srtp.FromSDESInline(localKey)
+		if err != nil {
+			p.logger.Error("SRTP video outbound context setup failed", "err", err)
+			return
+		}
+		videoInCtx, err := srtp.FromSDESInline(remoteKey)
+		if err != nil {
+			p.logger.Error("SRTP video inbound context setup failed", "err", err)
+			return
+		}
+		c.mu.Lock()
+		c.videoSrtpOut = videoOutCtx
+		c.videoSrtpIn = videoInCtx
+		c.mu.Unlock()
+	}
 	p.logger.Info("SRTP enabled for call", "id", c.id)
 }
 
@@ -164,7 +185,7 @@ func (p *phone) applyCallConfig(c *call) {
 
 // transportDial implements dialFn using the sipTransport interface.
 // Used by connectWithTransport() for test mocks.
-func (p *phone) transportDial(ctx context.Context, target string, onResponse func(code int, reason string)) (dialog, error) {
+func (p *phone) transportDial(ctx context.Context, target string, _ DialOptions, onResponse func(code int, reason string)) (dialog, error) {
 	p.mu.Lock()
 	tr := p.tr
 	p.mu.Unlock()
@@ -287,7 +308,7 @@ func (p *phone) Connect(ctx context.Context) error {
 
 	// Set dialFn to use sipgo's dialog API before connecting.
 	p.mu.Lock()
-	p.dialFn = tr.dial
+	p.dialFn = tr.dialWithOpts
 	p.mu.Unlock()
 
 	// Wire inbound INVITE, BYE, and NOTIFY handlers for sipgo path.
@@ -401,7 +422,7 @@ func (p *phone) Dial(ctx context.Context, target string, opts ...DialOption) (Ca
 	var responses []sipResponse
 
 	// Establish the SIP dialog via dialFn.
-	dlg, err := dialFn(dialCtx, target, func(code int, reason string) {
+	dlg, err := dialFn(dialCtx, target, dialOpts, func(code int, reason string) {
 		responses = append(responses, sipResponse{code, reason})
 	})
 	if err != nil {
@@ -421,6 +442,11 @@ func (p *phone) Dial(ctx context.Context, target string, opts ...DialOption) (Ca
 			c.rtpPort = uac.rtpConn.LocalAddr().(*net.UDPAddr).Port
 			c.localIP = p.localIP
 			uac.rtpConn = nil // transfer ownership
+		}
+		if uac.videoRtpConn != nil {
+			c.videoRTPConn = uac.videoRtpConn
+			c.videoRTPPort = uac.videoRtpConn.LocalAddr().(*net.UDPAddr).Port
+			uac.videoRtpConn = nil // transfer ownership
 		}
 		if uac.invite != nil {
 			c.localSDP = string(uac.invite.Body())
@@ -445,6 +471,12 @@ func (p *phone) Dial(ctx context.Context, target string, opts ...DialOption) (Ca
 							p.setupSRTP(c, uac.srtpLocalKey, crypto.InlineKey())
 						}
 					}
+
+					// Set up video if negotiated.
+					if c.hasVideo && c.videoRTPConn != nil {
+						c.setVideoRemoteEndpoint(sess)
+						c.initVideoChannels()
+					}
 				}
 			}
 		}
@@ -458,6 +490,10 @@ func (p *phone) Dial(ctx context.Context, target string, opts ...DialOption) (Ca
 	if c.rtpConn != nil {
 		c.startMedia()
 		c.startRTPReader()
+	}
+	if c.hasVideo && c.videoRTPConn != nil {
+		c.startVideoMedia()
+		c.startVideoRTPReader()
 	}
 
 	return c, nil
@@ -607,14 +643,23 @@ func (p *phone) handleDialogInvite(dlg dialog, from, to, sdpBody string) {
 		p.logger.Debug("incoming remote SDP", "sdp", sdpBody)
 	}
 
-	// Set up SRTP if remote offers it and we have SRTP enabled.
-	if p.cfg.SRTP && sdpBody != "" {
-		if sess, err := sdp.Parse(sdpBody); err == nil && sess.IsSRTP() {
-			if crypto := sess.FirstCrypto(); crypto != nil {
-				localKey, err := srtp.GenerateKeyingMaterial()
-				if err == nil {
-					p.setupSRTP(c, localKey, crypto.InlineKey())
+	// Parse remote SDP once for SRTP and video setup.
+	if sdpBody != "" {
+		if sess, err := sdp.Parse(sdpBody); err == nil {
+			// Set up SRTP if remote offers it and we have SRTP enabled.
+			if p.cfg.SRTP && sess.IsSRTP() {
+				if crypto := sess.FirstCrypto(); crypto != nil {
+					localKey, err := srtp.GenerateKeyingMaterial()
+					if err == nil {
+						p.setupSRTP(c, localKey, crypto.InlineKey())
+					}
 				}
+			}
+			// Set up video if remote offers it.
+			if vm := sess.VideoMedia(); vm != nil && len(vm.Codecs) > 0 {
+				c.mu.Lock()
+				c.ensureVideoRTPPort()
+				c.mu.Unlock()
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Wire up video RTP+RTCP socket pair with dedicated `mediaStream` and `runVideo()` goroutine (RTP passthrough at 90kHz, RTCP SR/RR, no jitter/codec processing)
- Per-stream SRTP contexts for audio and video to prevent concurrent state corruption (separate ROC/seq/HMAC)
- RTCP PLI (RFC 4585 §6.3.1) and FIR (RFC 5104 §4.3.1.1) packet builders for keyframe requests
- SDP answer now includes video m= line when remote offers video (4 new `BuildAnswerVideo*` functions)
- ICE STUN demux on video RTP socket
- Call interface extended: `HasVideo`, `VideoCodec`, `VideoReader`, `VideoWriter`, `VideoRTPReader`, `VideoRTPWriter`, `MuteVideo`, `UnmuteVideo`, `RequestKeyframe`
- MockCall updated with full video method support

## Test plan
- [x] 16 new tests in `video_test.go` covering negotiation, channels, mute/unmute, RTP passthrough, keyframe, and cleanup
- [x] `make check` passes (fmt, build, test, vet, race)
- [x] 6-way code review: 4 Claude agents (reuse, quality, efficiency, memory leak) + Codex + Gemini