### PR TITLE
Add H.264 and VP8 video packetizers (RFC 6184, RFC 7741)

### DIFF
--- a/internal/media/h264.go
+++ b/internal/media/h264.go
@@ -1,0 +1,298 @@
+package media
+
+import "github.com/pion/rtp"
+
+// H.264 NAL unit types (RFC 6184 §5.2).
+const (
+	h264NalSingleMin = 1
+	h264NalSingleMax = 23
+	h264NalSTAPA     = 24
+	h264NalFUA       = 28
+
+	h264NalIDR = 5 // Instantaneous Decoding Refresh (keyframe)
+	h264NalSPS = 7 // Sequence Parameter Set
+	h264NalPPS = 8 // Picture Parameter Set
+)
+
+// annexBStartCode is the 4-byte Annex-B start code.
+var annexBStartCode = []byte{0x00, 0x00, 0x00, 0x01}
+
+// H264Depacketizer reassembles H.264 video frames from RTP packets (RFC 6184).
+// Supports Single NAL, STAP-A, and FU-A packet types.
+type H264Depacketizer struct {
+	currentTS  uint32
+	nals       [][]byte // accumulated NAL units for current frame
+	isKeyframe bool
+	hasData    bool
+
+	// FU-A reassembly state.
+	fuaBuf    []byte
+	fuaActive bool
+}
+
+// Push processes an RTP packet and returns any completed frames.
+func (d *H264Depacketizer) Push(pkt *rtp.Packet) []VideoFrame {
+	if len(pkt.Payload) == 0 {
+		return nil
+	}
+
+	var frames []VideoFrame
+
+	// Timestamp change means the previous frame is complete.
+	if d.hasData && pkt.Timestamp != d.currentTS {
+		frames = append(frames, d.flushFrame())
+	}
+
+	d.currentTS = pkt.Timestamp
+	d.hasData = true
+
+	nalType := pkt.Payload[0] & 0x1F
+
+	switch {
+	case nalType >= h264NalSingleMin && nalType <= h264NalSingleMax:
+		d.pushSingleNAL(pkt.Payload)
+	case nalType == h264NalSTAPA:
+		d.pushSTAPA(pkt.Payload)
+	case nalType == h264NalFUA:
+		d.pushFUA(pkt.Payload)
+	}
+
+	// Marker bit signals end of frame.
+	if pkt.Marker && d.hasData {
+		frames = append(frames, d.flushFrame())
+	}
+
+	return frames
+}
+
+// pushSingleNAL handles a single NAL unit packet (types 1-23).
+func (d *H264Depacketizer) pushSingleNAL(payload []byte) {
+	nal := make([]byte, len(payload))
+	copy(nal, payload)
+	d.nals = append(d.nals, nal)
+	d.checkKeyframe(payload[0] & 0x1F)
+}
+
+// pushSTAPA handles STAP-A aggregation packets (type 24).
+func (d *H264Depacketizer) pushSTAPA(payload []byte) {
+	// Skip the STAP-A header byte.
+	off := 1
+	for off+2 <= len(payload) {
+		nalSize := int(payload[off])<<8 | int(payload[off+1])
+		off += 2
+		if off+nalSize > len(payload) {
+			break // malformed
+		}
+		nal := make([]byte, nalSize)
+		copy(nal, payload[off:off+nalSize])
+		d.nals = append(d.nals, nal)
+		if nalSize > 0 {
+			d.checkKeyframe(nal[0] & 0x1F)
+		}
+		off += nalSize
+	}
+}
+
+// pushFUA handles FU-A fragmentation packets (type 28).
+func (d *H264Depacketizer) pushFUA(payload []byte) {
+	if len(payload) < 2 {
+		return
+	}
+	fuIndicator := payload[0]
+	fuHeader := payload[1]
+	startBit := (fuHeader >> 7) & 1
+	endBit := (fuHeader >> 6) & 1
+	nalType := fuHeader & 0x1F
+
+	if startBit == 1 {
+		// Reconstruct the NAL header: NRI from FU indicator + type from FU header.
+		nalHeader := (fuIndicator & 0xE0) | nalType
+		d.fuaBuf = make([]byte, 1, len(payload)+1024)
+		d.fuaBuf[0] = nalHeader
+		d.fuaBuf = append(d.fuaBuf, payload[2:]...)
+		d.fuaActive = true
+		d.checkKeyframe(nalType)
+	} else if d.fuaActive {
+		d.fuaBuf = append(d.fuaBuf, payload[2:]...)
+	}
+
+	if endBit == 1 && d.fuaActive {
+		d.nals = append(d.nals, d.fuaBuf)
+		d.fuaBuf = nil
+		d.fuaActive = false
+	}
+}
+
+// checkKeyframe marks the current frame as a keyframe if the NAL type indicates it.
+func (d *H264Depacketizer) checkKeyframe(nalType uint8) {
+	if nalType == h264NalIDR || nalType == h264NalSPS || nalType == h264NalPPS {
+		d.isKeyframe = true
+	}
+}
+
+// flushFrame assembles accumulated NALs into an Annex-B frame and resets state.
+func (d *H264Depacketizer) flushFrame() VideoFrame {
+	// Calculate total size: for each NAL, 4-byte start code + NAL data.
+	totalSize := 0
+	for _, nal := range d.nals {
+		totalSize += 4 + len(nal)
+	}
+	data := make([]byte, 0, totalSize)
+	for _, nal := range d.nals {
+		data = append(data, annexBStartCode...)
+		data = append(data, nal...)
+	}
+
+	frame := VideoFrame{
+		Timestamp:  d.currentTS,
+		IsKeyframe: d.isKeyframe,
+		Data:       data,
+	}
+
+	// Nil out stale references to allow GC of old NAL buffers.
+	for i := range d.nals {
+		d.nals[i] = nil
+	}
+	d.nals = d.nals[:0]
+	d.isKeyframe = false
+	d.hasData = false
+	d.fuaBuf = nil
+	d.fuaActive = false
+	return frame
+}
+
+// H264Packetizer fragments H.264 Annex-B frames into RTP payloads (RFC 6184).
+type H264Packetizer struct {
+	MTU int // max RTP payload size (0 = DefaultMTU)
+}
+
+// Packetize splits an Annex-B encoded frame into RTP payloads.
+func (p *H264Packetizer) Packetize(data []byte) [][]byte {
+	mtu := p.MTU
+	if mtu <= 0 {
+		mtu = DefaultMTU
+	}
+	// FU-A requires at least 3 bytes: indicator + header + 1 byte payload.
+	if mtu < 3 {
+		mtu = 3
+	}
+
+	nals := splitAnnexB(data)
+	if len(nals) == 0 {
+		return nil
+	}
+
+	var payloads [][]byte
+	for _, nal := range nals {
+		if len(nal) == 0 {
+			continue
+		}
+		if len(nal) <= mtu {
+			// Single NAL unit packet.
+			payload := make([]byte, len(nal))
+			copy(payload, nal)
+			payloads = append(payloads, payload)
+		} else {
+			// FU-A fragmentation.
+			payloads = append(payloads, fragmentFUA(nal, mtu)...)
+		}
+	}
+	return payloads
+}
+
+// fragmentFUA splits a single NAL unit into FU-A fragments.
+func fragmentFUA(nal []byte, mtu int) [][]byte {
+	if len(nal) < 1 {
+		return nil
+	}
+
+	nalHeader := nal[0]
+	nalType := nalHeader & 0x1F
+	nri := nalHeader & 0xE0
+
+	// FU indicator: NRI from original + type 28 (FU-A).
+	fuIndicator := nri | h264NalFUA
+
+	// Payload data starts after the NAL header byte.
+	data := nal[1:]
+	maxPayload := mtu - 2 // 2 bytes for FU indicator + FU header
+
+	numFragments := (len(data) + maxPayload - 1) / maxPayload
+	payloads := make([][]byte, 0, numFragments)
+	offset := 0
+	for offset < len(data) {
+		end := offset + maxPayload
+		if end > len(data) {
+			end = len(data)
+		}
+
+		fuHeader := nalType
+		if offset == 0 {
+			fuHeader |= 0x80 // S bit
+		}
+		if end == len(data) {
+			fuHeader |= 0x40 // E bit
+		}
+
+		payload := make([]byte, 2+end-offset)
+		payload[0] = fuIndicator
+		payload[1] = fuHeader
+		copy(payload[2:], data[offset:end])
+		payloads = append(payloads, payload)
+		offset = end
+	}
+	return payloads
+}
+
+// splitAnnexB parses Annex-B encoded data into individual NAL units.
+// Handles both 3-byte (0x000001) and 4-byte (0x00000001) start codes.
+func splitAnnexB(data []byte) [][]byte {
+	var nals [][]byte
+	i := 0
+	n := len(data)
+
+	// Skip to first start code.
+	for i < n {
+		if i+3 <= n && data[i] == 0 && data[i+1] == 0 && data[i+2] == 1 {
+			i += 3
+			break
+		}
+		if i+4 <= n && data[i] == 0 && data[i+1] == 0 && data[i+2] == 0 && data[i+3] == 1 {
+			i += 4
+			break
+		}
+		i++
+	}
+
+	for i < n {
+		nalStart := i
+		// Scan for next start code.
+		for i < n {
+			if i+3 <= n && data[i] == 0 && data[i+1] == 0 {
+				if data[i+2] == 1 {
+					break
+				}
+				if i+4 <= n && data[i+2] == 0 && data[i+3] == 1 {
+					break
+				}
+			}
+			i++
+		}
+
+		nal := data[nalStart:i]
+		if len(nal) > 0 {
+			nals = append(nals, nal)
+		}
+
+		// Skip the start code.
+		if i+4 <= n && data[i] == 0 && data[i+1] == 0 && data[i+2] == 0 && data[i+3] == 1 {
+			i += 4
+		} else if i+3 <= n && data[i] == 0 && data[i+1] == 0 && data[i+2] == 1 {
+			i += 3
+		} else {
+			break
+		}
+	}
+
+	return nals
+}

--- a/internal/media/h264_test.go
+++ b/internal/media/h264_test.go
@@ -1,0 +1,267 @@
+package media
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitAnnexB(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want int
+	}{
+		{
+			name: "4-byte start codes",
+			data: []byte{0, 0, 0, 1, 0x65, 0xAA, 0xBB, 0, 0, 0, 1, 0x67, 0xCC},
+			want: 2,
+		},
+		{
+			name: "3-byte start codes",
+			data: []byte{0, 0, 1, 0x65, 0xAA, 0, 0, 1, 0x67, 0xCC},
+			want: 2,
+		},
+		{
+			name: "mixed start codes",
+			data: []byte{0, 0, 0, 1, 0x67, 0xAA, 0, 0, 1, 0x68, 0xBB, 0, 0, 0, 1, 0x65, 0xCC},
+			want: 3,
+		},
+		{
+			name: "empty",
+			data: nil,
+			want: 0,
+		},
+		{
+			name: "single NAL",
+			data: []byte{0, 0, 0, 1, 0x65, 0xAA, 0xBB, 0xCC},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nals := splitAnnexB(tt.data)
+			assert.Equal(t, tt.want, len(nals))
+		})
+	}
+}
+
+func TestH264Depacketizer_SingleNAL(t *testing.T) {
+	d := &H264Depacketizer{}
+
+	// Single IDR NAL (type 5 = keyframe), marker set.
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 1000, Marker: true, PayloadType: 96},
+		Payload: []byte{0x65, 0xAA, 0xBB, 0xCC}, // NAL type 5 (IDR)
+	}
+	frames := d.Push(pkt)
+	require.Len(t, frames, 1)
+	assert.True(t, frames[0].IsKeyframe)
+	assert.Equal(t, uint32(1000), frames[0].Timestamp)
+	// Should have Annex-B start code prefix.
+	assert.True(t, bytes.HasPrefix(frames[0].Data, annexBStartCode))
+}
+
+func TestH264Depacketizer_STAPA(t *testing.T) {
+	d := &H264Depacketizer{}
+
+	// STAP-A with SPS (type 7) + PPS (type 8).
+	sps := []byte{0x67, 0x42, 0xE0, 0x1F} // NAL type 7
+	pps := []byte{0x68, 0xCE, 0x01}       // NAL type 8
+
+	payload := []byte{h264NalSTAPA}
+	// SPS: length (2 bytes) + data
+	payload = append(payload, byte(len(sps)>>8), byte(len(sps)))
+	payload = append(payload, sps...)
+	// PPS: length (2 bytes) + data
+	payload = append(payload, byte(len(pps)>>8), byte(len(pps)))
+	payload = append(payload, pps...)
+
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 2000, Marker: true},
+		Payload: payload,
+	}
+	frames := d.Push(pkt)
+	require.Len(t, frames, 1)
+	assert.True(t, frames[0].IsKeyframe) // SPS/PPS = keyframe
+	// Should contain 2 NALs with Annex-B start codes.
+	assert.Equal(t, 4+len(sps)+4+len(pps), len(frames[0].Data))
+}
+
+func TestH264Depacketizer_FUA(t *testing.T) {
+	d := &H264Depacketizer{}
+
+	// Simulate FU-A fragmentation of a large IDR NAL.
+	// Original NAL: type 5 (IDR), NRI=3 (0x60).
+	nalHeader := byte(0x65) // NRI=3, type=5
+	fuIndicator := (nalHeader & 0xE0) | h264NalFUA
+
+	// Fragment 1: S=1, E=0.
+	frag1 := append([]byte{fuIndicator, 0x80 | 0x05}, bytes.Repeat([]byte{0xAA}, 100)...)
+	pkt1 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 3000},
+		Payload: frag1,
+	}
+	frames := d.Push(pkt1)
+	assert.Empty(t, frames, "FU-A start should not produce a frame")
+
+	// Fragment 2: S=0, E=0 (middle).
+	frag2 := append([]byte{fuIndicator, 0x05}, bytes.Repeat([]byte{0xBB}, 100)...)
+	pkt2 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 2, Timestamp: 3000},
+		Payload: frag2,
+	}
+	frames = d.Push(pkt2)
+	assert.Empty(t, frames, "FU-A middle should not produce a frame")
+
+	// Fragment 3: S=0, E=1 (end), marker set.
+	frag3 := append([]byte{fuIndicator, 0x40 | 0x05}, bytes.Repeat([]byte{0xCC}, 50)...)
+	pkt3 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 3, Timestamp: 3000, Marker: true},
+		Payload: frag3,
+	}
+	frames = d.Push(pkt3)
+	require.Len(t, frames, 1)
+	assert.True(t, frames[0].IsKeyframe)
+	assert.Equal(t, uint32(3000), frames[0].Timestamp)
+
+	// Verify the reassembled NAL: start code + original header + payload.
+	assert.True(t, bytes.HasPrefix(frames[0].Data, annexBStartCode))
+	// After start code: reconstructed NAL header (0x65) + payload.
+	assert.Equal(t, nalHeader, frames[0].Data[4])
+	assert.Equal(t, 4+1+100+100+50, len(frames[0].Data)) // start code + header + 3 fragments
+}
+
+func TestH264Depacketizer_TimestampChange(t *testing.T) {
+	d := &H264Depacketizer{}
+
+	// First frame (non-keyframe), no marker bit.
+	pkt1 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 1000},
+		Payload: []byte{0x41, 0xAA}, // NAL type 1 (non-IDR slice)
+	}
+	frames := d.Push(pkt1)
+	assert.Empty(t, frames)
+
+	// Second frame with different timestamp — should flush first frame.
+	pkt2 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 2, Timestamp: 4000, Marker: true},
+		Payload: []byte{0x41, 0xBB},
+	}
+	frames = d.Push(pkt2)
+	require.Len(t, frames, 2) // first flushed by timestamp change, second by marker
+	assert.Equal(t, uint32(1000), frames[0].Timestamp)
+	assert.Equal(t, uint32(4000), frames[1].Timestamp)
+}
+
+func TestH264Packetizer_SingleNAL(t *testing.T) {
+	p := &H264Packetizer{MTU: 1200}
+
+	// Small NAL that fits in a single packet.
+	nal := bytes.Repeat([]byte{0xAA}, 100)
+	data := append(annexBStartCode, 0x65) // IDR
+	data = append(data, nal...)
+
+	payloads := p.Packetize(data)
+	require.Len(t, payloads, 1)
+	assert.Equal(t, byte(0x65), payloads[0][0]) // NAL header preserved
+}
+
+func TestH264Packetizer_FUA(t *testing.T) {
+	p := &H264Packetizer{MTU: 100}
+
+	// Large NAL that requires FU-A fragmentation.
+	nal := make([]byte, 300)
+	nal[0] = 0x65 // NAL type 5 (IDR), NRI=3
+	for i := 1; i < len(nal); i++ {
+		nal[i] = byte(i)
+	}
+	data := append(annexBStartCode, nal...)
+
+	payloads := p.Packetize(data)
+	require.True(t, len(payloads) > 1, "should produce multiple FU-A fragments")
+
+	// First fragment: S=1, E=0.
+	assert.Equal(t, byte((0x65&0xE0)|h264NalFUA), payloads[0][0]) // FU indicator
+	assert.Equal(t, byte(0x80|0x05), payloads[0][1])              // FU header: S=1, type=5
+
+	// Last fragment: S=0, E=1.
+	last := payloads[len(payloads)-1]
+	assert.Equal(t, byte(0x40|0x05), last[1]) // FU header: E=1, type=5
+
+	// Middle fragments: S=0, E=0.
+	for _, mid := range payloads[1 : len(payloads)-1] {
+		assert.Equal(t, byte(0x05), mid[1]) // FU header: type=5 only
+	}
+}
+
+func TestH264Packetizer_MultipleNALs(t *testing.T) {
+	p := &H264Packetizer{MTU: 1200}
+
+	// SPS + PPS + IDR, each small enough for single NAL.
+	var data []byte
+	data = append(data, annexBStartCode...)
+	data = append(data, 0x67, 0x42, 0xE0, 0x1F) // SPS
+	data = append(data, annexBStartCode...)
+	data = append(data, 0x68, 0xCE, 0x01) // PPS
+	data = append(data, annexBStartCode...)
+	data = append(data, 0x65)                              // IDR header
+	data = append(data, bytes.Repeat([]byte{0xAA}, 50)...) // IDR payload
+
+	payloads := p.Packetize(data)
+	require.Len(t, payloads, 3)
+	assert.Equal(t, byte(0x67), payloads[0][0]&0x1F|0x60) // SPS
+	assert.Equal(t, byte(0x68), payloads[1][0])           // PPS
+	assert.Equal(t, byte(0x65), payloads[2][0])           // IDR
+}
+
+func TestH264RoundTrip(t *testing.T) {
+	// Build a frame with SPS + PPS + IDR.
+	var original []byte
+	original = append(original, annexBStartCode...)
+	original = append(original, 0x67, 0x42, 0xE0, 0x1F) // SPS
+	original = append(original, annexBStartCode...)
+	original = append(original, 0x68, 0xCE, 0x01) // PPS
+	original = append(original, annexBStartCode...)
+	idr := make([]byte, 500)
+	idr[0] = 0x65
+	for i := 1; i < len(idr); i++ {
+		idr[i] = byte(i)
+	}
+	original = append(original, idr...)
+
+	// Packetize with small MTU to force FU-A.
+	p := &H264Packetizer{MTU: 200}
+	payloads := p.Packetize(original)
+	require.True(t, len(payloads) > 0)
+
+	// Depacketize.
+	d := &H264Depacketizer{}
+	var frames []VideoFrame
+	for i, payload := range payloads {
+		pkt := &rtp.Packet{
+			Header: rtp.Header{
+				SequenceNumber: uint16(i),
+				Timestamp:      90000,
+				Marker:         i == len(payloads)-1,
+			},
+			Payload: payload,
+		}
+		frames = append(frames, d.Push(pkt)...)
+	}
+
+	require.Len(t, frames, 1)
+	assert.True(t, frames[0].IsKeyframe)
+	assert.Equal(t, uint32(90000), frames[0].Timestamp)
+
+	// Verify all NALs survived the round trip.
+	recoveredNALs := splitAnnexB(frames[0].Data)
+	originalNALs := splitAnnexB(original)
+	require.Equal(t, len(originalNALs), len(recoveredNALs))
+	for i := range originalNALs {
+		assert.Equal(t, originalNALs[i], recoveredNALs[i], "NAL %d mismatch", i)
+	}
+}

--- a/internal/media/video.go
+++ b/internal/media/video.go
@@ -1,0 +1,28 @@
+package media
+
+import "github.com/pion/rtp"
+
+// VideoFrame is an assembled video frame from RTP depacketization.
+type VideoFrame struct {
+	Timestamp  uint32
+	IsKeyframe bool
+	Data       []byte
+}
+
+// VideoDepacketizer reassembles video frames from RTP packets.
+type VideoDepacketizer interface {
+	// Push feeds an RTP packet to the depacketizer.
+	// Returns assembled frames (usually 0 or 1 per call).
+	Push(pkt *rtp.Packet) []VideoFrame
+}
+
+// VideoPacketizer fragments video frames into RTP payloads.
+type VideoPacketizer interface {
+	// Packetize splits a video frame into RTP-sized payloads.
+	// The caller sets RTP headers (seq, timestamp, SSRC, marker on last).
+	Packetize(data []byte) [][]byte
+}
+
+// DefaultMTU is the default maximum RTP payload size.
+// Conservative: leaves room for RTP (12) + UDP (8) + IP (20) + SRTP (10) headers.
+const DefaultMTU = 1200

--- a/internal/media/vp8.go
+++ b/internal/media/vp8.go
@@ -1,0 +1,154 @@
+package media
+
+import "github.com/pion/rtp"
+
+// VP8Depacketizer reassembles VP8 video frames from RTP packets (RFC 7741).
+type VP8Depacketizer struct {
+	currentTS  uint32
+	frameBuf   []byte
+	hasData    bool
+	isKeyframe bool
+}
+
+// Push processes an RTP packet and returns any completed frames.
+func (d *VP8Depacketizer) Push(pkt *rtp.Packet) []VideoFrame {
+	if len(pkt.Payload) == 0 {
+		return nil
+	}
+
+	var frames []VideoFrame
+
+	// Timestamp change means the previous frame is complete.
+	if d.hasData && pkt.Timestamp != d.currentTS {
+		frames = append(frames, d.flushFrame())
+	}
+
+	d.currentTS = pkt.Timestamp
+
+	// Parse VP8 payload descriptor (RFC 7741 §4.2).
+	off := 0
+	if off >= len(pkt.Payload) {
+		return frames
+	}
+	desc0 := pkt.Payload[off]
+	xBit := (desc0 >> 7) & 1
+	sBit := (desc0 >> 4) & 1
+	off++
+
+	if xBit == 1 && off < len(pkt.Payload) {
+		ext := pkt.Payload[off]
+		iBit := (ext >> 7) & 1
+		lBit := (ext >> 6) & 1
+		tBit := (ext >> 5) & 1
+		kBit := (ext >> 4) & 1
+		off++
+
+		// PictureID (I=1)
+		if iBit == 1 && off < len(pkt.Payload) {
+			if pkt.Payload[off]&0x80 != 0 && off+1 < len(pkt.Payload) {
+				off += 2 // 16-bit PictureID (M=1)
+			} else {
+				off++ // 8-bit PictureID (or truncated 16-bit)
+			}
+		}
+		// TL0PICIDX (L=1)
+		if lBit == 1 {
+			off++
+		}
+		// TID/KEYIDX (T=1 or K=1)
+		if tBit == 1 || kBit == 1 {
+			off++
+		}
+	}
+
+	if off > len(pkt.Payload) {
+		return frames
+	}
+
+	vpPayload := pkt.Payload[off:]
+
+	if sBit == 1 {
+		// Start of a new partition — detect keyframe from VP8 frame header.
+		if len(vpPayload) > 0 {
+			// VP8 spec §9.1: frame_tag bits 0 = frame_type (0 = key, 1 = inter).
+			d.isKeyframe = (vpPayload[0] & 0x01) == 0
+		}
+		d.hasData = true
+	}
+
+	if d.hasData {
+		d.frameBuf = append(d.frameBuf, vpPayload...)
+	}
+
+	// Marker bit signals end of frame.
+	if pkt.Marker && d.hasData {
+		frames = append(frames, d.flushFrame())
+	}
+
+	return frames
+}
+
+// flushFrame returns the assembled frame and resets state.
+// The backing array of frameBuf is reused across frames to reduce allocations.
+func (d *VP8Depacketizer) flushFrame() VideoFrame {
+	data := make([]byte, len(d.frameBuf))
+	copy(data, d.frameBuf)
+	frame := VideoFrame{
+		Timestamp:  d.currentTS,
+		IsKeyframe: d.isKeyframe,
+		Data:       data,
+	}
+	d.frameBuf = d.frameBuf[:0] // reuse capacity
+	d.hasData = false
+	d.isKeyframe = false
+	return frame
+}
+
+// VP8Packetizer fragments VP8 video frames into RTP payloads (RFC 7741).
+type VP8Packetizer struct {
+	MTU int // max RTP payload size (0 = DefaultMTU)
+}
+
+// Packetize splits a VP8 frame into RTP payloads with VP8 payload descriptors.
+func (p *VP8Packetizer) Packetize(data []byte) [][]byte {
+	mtu := p.MTU
+	if mtu <= 0 {
+		mtu = DefaultMTU
+	}
+	// Need at least 2 bytes: descriptor + 1 byte payload.
+	if mtu < 2 {
+		mtu = 2
+	}
+
+	if len(data) == 0 {
+		return nil
+	}
+
+	// VP8 payload descriptor: 1 byte (minimal).
+	// First packet: X=0, R=0, N=0, S=1, R=0, PID=0 → 0x10
+	// Continuation: X=0, R=0, N=0, S=0, R=0, PID=0 → 0x00
+	maxPayload := mtu - 1 // 1 byte for payload descriptor
+
+	var payloads [][]byte
+	offset := 0
+	first := true
+	for offset < len(data) {
+		end := offset + maxPayload
+		if end > len(data) {
+			end = len(data)
+		}
+
+		var desc byte
+		if first {
+			desc = 0x10 // S bit set
+			first = false
+		}
+
+		payload := make([]byte, 1+end-offset)
+		payload[0] = desc
+		copy(payload[1:], data[offset:end])
+		payloads = append(payloads, payload)
+		offset = end
+	}
+	return payloads
+}

--- a/internal/media/vp8_test.go
+++ b/internal/media/vp8_test.go
@@ -1,0 +1,204 @@
+package media
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVP8Depacketizer_SinglePacket(t *testing.T) {
+	d := &VP8Depacketizer{}
+
+	// Keyframe: S=1 (0x10), VP8 frame tag byte 0 bit 0 = 0 (keyframe).
+	// 0x10 = show_frame=1, version=0, frame_type=0 (key).
+	frameData := []byte{0x10, 0x10, 0x00, 0x00, 0x9D, 0x01, 0x2A} // desc + VP8 keyframe
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 1000, Marker: true},
+		Payload: frameData,
+	}
+	frames := d.Push(pkt)
+	require.Len(t, frames, 1)
+	assert.True(t, frames[0].IsKeyframe)
+	assert.Equal(t, uint32(1000), frames[0].Timestamp)
+	assert.Equal(t, frameData[1:], frames[0].Data) // VP8 data without descriptor
+}
+
+func TestVP8Depacketizer_Interframe(t *testing.T) {
+	d := &VP8Depacketizer{}
+
+	// Interframe: S=1, VP8 frame byte 0 bit 0 = 1.
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 2000, Marker: true},
+		Payload: []byte{0x10, 0x01, 0xAA}, // desc=0x10 (S=1), VP8 header bit0=1 (inter)
+	}
+	frames := d.Push(pkt)
+	require.Len(t, frames, 1)
+	assert.False(t, frames[0].IsKeyframe)
+}
+
+func TestVP8Depacketizer_MultiPacket(t *testing.T) {
+	d := &VP8Depacketizer{}
+
+	// First packet: S=1. VP8 keyframe (byte 0 bit 0 = 0).
+	pkt1 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 3000},
+		Payload: []byte{0x10, 0x10, 0x00, 0x2A}, // S=1, keyframe (0x10 bit0=0)
+	}
+	frames := d.Push(pkt1)
+	assert.Empty(t, frames)
+
+	// Continuation packet: S=0.
+	pkt2 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 2, Timestamp: 3000},
+		Payload: []byte{0x00, 0xBB, 0xCC}, // S=0
+	}
+	frames = d.Push(pkt2)
+	assert.Empty(t, frames)
+
+	// Last packet: S=0, marker set.
+	pkt3 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 3, Timestamp: 3000, Marker: true},
+		Payload: []byte{0x00, 0xDD}, // S=0
+	}
+	frames = d.Push(pkt3)
+	require.Len(t, frames, 1)
+	assert.True(t, frames[0].IsKeyframe)
+	// Data should be: 0x10 0x00 0x2A 0xBB 0xCC 0xDD
+	assert.Equal(t, []byte{0x10, 0x00, 0x2A, 0xBB, 0xCC, 0xDD}, frames[0].Data)
+}
+
+func TestVP8Depacketizer_TimestampChange(t *testing.T) {
+	d := &VP8Depacketizer{}
+
+	// Frame 1, no marker.
+	pkt1 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 1000},
+		Payload: []byte{0x10, 0x01, 0xAA}, // S=1, inter
+	}
+	d.Push(pkt1)
+
+	// Frame 2 with different timestamp — should flush frame 1.
+	pkt2 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 2, Timestamp: 4000, Marker: true},
+		Payload: []byte{0x10, 0x9D, 0xBB}, // S=1, keyframe
+	}
+	frames := d.Push(pkt2)
+	require.Len(t, frames, 2)
+	assert.Equal(t, uint32(1000), frames[0].Timestamp)
+	assert.Equal(t, uint32(4000), frames[1].Timestamp)
+}
+
+func TestVP8Depacketizer_ExtendedDescriptor(t *testing.T) {
+	d := &VP8Depacketizer{}
+
+	// Extended descriptor: X=1, I=1 (8-bit PictureID).
+	// VP8 frame byte: 0x10 = keyframe (bit 0 = 0).
+	payload := []byte{
+		0x90,       // X=1, S=1
+		0x80,       // I=1, L=0, T=0, K=0
+		42,         // PictureID (8-bit, M=0)
+		0x10, 0x01, // VP8 frame data (keyframe: bit0=0)
+	}
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 5000, Marker: true},
+		Payload: payload,
+	}
+	frames := d.Push(pkt)
+	require.Len(t, frames, 1)
+	assert.True(t, frames[0].IsKeyframe)
+	assert.Equal(t, []byte{0x10, 0x01}, frames[0].Data)
+}
+
+func TestVP8Depacketizer_ExtendedDescriptor16bitPictureID(t *testing.T) {
+	d := &VP8Depacketizer{}
+
+	// Extended descriptor: X=1, I=1 (16-bit PictureID, M=1).
+	payload := []byte{
+		0x90,       // X=1, S=1
+		0x80,       // I=1
+		0x80, 0x2A, // 16-bit PictureID (M=1)
+		0x9D, 0x01, // VP8 frame data
+	}
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 6000, Marker: true},
+		Payload: payload,
+	}
+	frames := d.Push(pkt)
+	require.Len(t, frames, 1)
+	assert.Equal(t, []byte{0x9D, 0x01}, frames[0].Data)
+}
+
+func TestVP8Packetizer_SmallFrame(t *testing.T) {
+	p := &VP8Packetizer{MTU: 1200}
+
+	data := []byte{0x9D, 0x01, 0x2A, 0xAA, 0xBB}
+	payloads := p.Packetize(data)
+	require.Len(t, payloads, 1)
+	assert.Equal(t, byte(0x10), payloads[0][0]) // S=1
+	assert.Equal(t, data, payloads[0][1:])
+}
+
+func TestVP8Packetizer_LargeFrame(t *testing.T) {
+	p := &VP8Packetizer{MTU: 100}
+
+	data := bytes.Repeat([]byte{0xAA}, 250)
+	payloads := p.Packetize(data)
+	require.True(t, len(payloads) > 1)
+
+	// First packet: S=1.
+	assert.Equal(t, byte(0x10), payloads[0][0])
+	// Continuation packets: S=0.
+	for _, payload := range payloads[1:] {
+		assert.Equal(t, byte(0x00), payload[0])
+	}
+
+	// Reassemble and verify.
+	var assembled []byte
+	for _, payload := range payloads {
+		assembled = append(assembled, payload[1:]...) // skip descriptor
+	}
+	assert.Equal(t, data, assembled)
+}
+
+func TestVP8RoundTrip(t *testing.T) {
+	original := make([]byte, 500)
+	original[0] = 0x10 // keyframe (bit 0 = 0)
+	original[1] = 0x00
+	original[2] = 0x00
+	for i := 3; i < len(original); i++ {
+		original[i] = byte(i)
+	}
+
+	// Packetize with small MTU.
+	p := &VP8Packetizer{MTU: 150}
+	payloads := p.Packetize(original)
+	require.True(t, len(payloads) > 1)
+
+	// Depacketize.
+	d := &VP8Depacketizer{}
+	var frames []VideoFrame
+	for i, payload := range payloads {
+		pkt := &rtp.Packet{
+			Header: rtp.Header{
+				SequenceNumber: uint16(i),
+				Timestamp:      90000,
+				Marker:         i == len(payloads)-1,
+			},
+			Payload: payload,
+		}
+		frames = append(frames, d.Push(pkt)...)
+	}
+
+	require.Len(t, frames, 1)
+	assert.True(t, frames[0].IsKeyframe)
+	assert.Equal(t, original, frames[0].Data)
+}
+
+func TestVP8Packetizer_Empty(t *testing.T) {
+	p := &VP8Packetizer{}
+	assert.Nil(t, p.Packetize(nil))
+	assert.Nil(t, p.Packetize([]byte{}))
+}

--- a/media.go
+++ b/media.go
@@ -57,23 +57,13 @@ func clonePacket(pkt *rtp.Packet) *rtp.Packet {
 	return clone
 }
 
-// sendDropOldest sends pkt to ch; if full, drains one oldest entry first.
-func sendDropOldest(ch chan *rtp.Packet, pkt *rtp.Packet) {
+// sendDropOldest sends val to ch; if full, drains one oldest entry first.
+func sendDropOldest[T any](ch chan T, val T) {
 	select {
-	case ch <- pkt:
+	case ch <- val:
 	default:
 		<-ch // drop oldest
-		ch <- pkt
-	}
-}
-
-// sendDropOldestPCM sends samples to ch; if full, drains one oldest entry first.
-func sendDropOldestPCM(ch chan []int16, samples []int16) {
-	select {
-	case ch <- samples:
-	default:
-		<-ch // drop oldest
-		ch <- samples
+		ch <- val
 	}
 }
 
@@ -88,7 +78,7 @@ func (s *mediaStream) drainJB(jb *media.JitterBuffer, cp media.CodecProcessor) {
 		}
 		sendDropOldest(c.rtpReader, clonePacket(pkt))
 		if len(pkt.Payload) > 0 && cp != nil {
-			sendDropOldestPCM(c.pcmReader, cp.Decode(pkt.Payload))
+			sendDropOldest(c.pcmReader, cp.Decode(pkt.Payload))
 		}
 	}
 }
@@ -443,8 +433,34 @@ func (c *call) startMedia() {
 	go s.run(jb, cp, rtpClockRate)
 }
 
-// runVideo is the video media pipeline goroutine. Unlike audio, video uses
-// RTP passthrough only (no jitter buffer, no PCM, no DTMF).
+// newVideoDepacketizer creates a depacketizer for the given video codec.
+func newVideoDepacketizer(codec VideoCodec) media.VideoDepacketizer {
+	switch codec {
+	case VideoCodecH264:
+		return &media.H264Depacketizer{}
+	case VideoCodecVP8:
+		return &media.VP8Depacketizer{}
+	default:
+		return nil
+	}
+}
+
+// newVideoPacketizer creates a packetizer for the given video codec.
+func newVideoPacketizer(codec VideoCodec) media.VideoPacketizer {
+	switch codec {
+	case VideoCodecH264:
+		return &media.H264Packetizer{}
+	case VideoCodecVP8:
+		return &media.VP8Packetizer{}
+	default:
+		return nil
+	}
+}
+
+// runVideo is the video media pipeline goroutine. Handles:
+// - Inbound: RTP → depacketizer → VideoFrame assembly → videoReader + raw RTP taps
+// - Outbound: VideoFrame → packetizer → RTP; or raw RTP passthrough via videoRTPWriter
+// - RTCP SR/RR
 func (s *mediaStream) runVideo() {
 	c := s.call
 	conn := s.conn
@@ -453,6 +469,12 @@ func (s *mediaStream) runVideo() {
 	done := s.done
 
 	defer c.closeVideoOutputChannels()
+
+	// Create depacketizer and packetizer based on negotiated codec.
+	// videoCodecType is set before the pipeline starts and never modified while running.
+	codec := c.videoCodecType
+	depacketizer := newVideoDepacketizer(codec)
+	packetizer := newVideoPacketizer(codec)
 
 	// RTCP state for video (90kHz clock).
 	rtcpStats := rtcp.NewStats()
@@ -498,11 +520,68 @@ func (s *mediaStream) runVideo() {
 			sendDropOldest(c.videoRTPReader, clonePacket(pkt))
 			rtcpStats.RecordRTPReceived(pkt.SequenceNumber, pkt.Timestamp, pkt.SSRC, 90000)
 
-		case <-c.videoWriter:
-			// VideoFrame write path — packetizer not yet implemented (PR 4).
-			// Drain to prevent writers from blocking.
+			// Depacketize into assembled VideoFrames. The depacketizer copies
+			// what it needs from pkt.Payload, so passing the original is safe.
+			if depacketizer != nil {
+				for _, mf := range depacketizer.Push(pkt) {
+					frame := VideoFrame{
+						Codec:      codec,
+						Timestamp:  mf.Timestamp,
+						IsKeyframe: mf.IsKeyframe,
+						Data:       mf.Data,
+					}
+					sendDropOldest(c.videoReader, frame)
+				}
+			}
+
+		case frame := <-c.videoWriter:
+			// Packetize VideoFrame into RTP packets.
+			// Skip if raw RTP writer is in use (mutual exclusion, same as audio).
+			// Drop frames with mismatched codec to prevent corrupt packetization.
+			if packetizer == nil || s.rtpWriterUsed || frame.Codec != codec {
+				continue
+			}
+			c.mu.Lock()
+			muted := s.muted
+			dst := c.videoRemoteAddr
+			srtpOut := c.videoSrtpOut
+			c.mu.Unlock()
+			if muted {
+				continue
+			}
+			payloads := packetizer.Packetize(frame.Data)
+			outPkt := rtp.Packet{
+				Header: rtp.Header{
+					Version:     2,
+					PayloadType: uint8(codec),
+					Timestamp:   frame.Timestamp,
+					SSRC:        s.outSSRC,
+				},
+			}
+			for i, payload := range payloads {
+				outPkt.Header.SequenceNumber = s.outSeq
+				outPkt.Header.Marker = i == len(payloads)-1
+				outPkt.Payload = payload
+				s.outSeq++
+				rtcpStats.RecordRTPSent(len(payload), outPkt.Timestamp)
+				if c.videoSentRTP != nil {
+					sendDropOldest(c.videoSentRTP, clonePacket(&outPkt))
+				}
+				if conn != nil && dst != nil {
+					if data, err := outPkt.Marshal(); err == nil {
+						if srtpOut != nil {
+							data, err = srtpOut.Protect(data)
+							if err != nil {
+								continue
+							}
+						}
+						conn.WriteTo(data, dst)
+					}
+				}
+			}
 
 		case pkt := <-c.videoRTPWriter:
+			s.rtpWriterUsed = true
 			c.mu.Lock()
 			muted := s.muted
 			dst := c.videoRemoteAddr

--- a/video_test.go
+++ b/video_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/x-phone/xphone-go/testutil"
 )
 
-// activeVideoCall creates an inbound call in StateActive with both audio and
+// activeVideoCallWithCodec creates an inbound call in StateActive with both audio and
 // video media pipelines ready. sentRTP and videoSentRTP are initialized so
 // tests can observe outbound packets.
-func activeVideoCall(t *testing.T) *call {
+func activeVideoCallWithCodec(t *testing.T, codec VideoCodec) *call {
 	t.Helper()
 	c := newInboundCall(testutil.NewMockDialog())
 	t.Cleanup(c.cleanup)
@@ -22,7 +22,7 @@ func activeVideoCall(t *testing.T) *call {
 
 	// Set up video state before Accept.
 	c.hasVideo = true
-	c.videoCodecType = VideoCodecH264
+	c.videoCodecType = codec
 	c.initVideoChannels()
 	c.videoSentRTP = make(chan *rtp.Packet, 256)
 
@@ -39,6 +39,11 @@ func activeVideoCall(t *testing.T) *call {
 	c.startMedia()
 	c.startVideoMedia()
 	return c
+}
+
+func activeVideoCall(t *testing.T) *call {
+	t.Helper()
+	return activeVideoCallWithCodec(t, VideoCodecH264)
 }
 
 // --- Video negotiation tests ---
@@ -176,6 +181,173 @@ func TestVideoMedia_OutboundRTPWriter(t *testing.T) {
 	assert.Equal(t, uint16(99), sent.SequenceNumber)
 	assert.Equal(t, uint8(96), sent.PayloadType)
 	assert.Equal(t, []byte{0xDE, 0xAD}, sent.Payload)
+}
+
+// --- Depacketizer integration tests ---
+
+func TestVideoMedia_H264Depacketize(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	// Inject an H.264 IDR NAL as a single RTP packet (marker set).
+	nal := []byte{0x65, 0xAA, 0xBB, 0xCC} // NAL type 5 = IDR
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, PayloadType: 96, Timestamp: 90000, SSRC: 0x1234, Marker: true},
+		Payload: nal,
+	}
+	c.videoRTPInbound <- pkt
+
+	// Should appear as an assembled VideoFrame on videoReader.
+	select {
+	case frame := <-c.VideoReader():
+		assert.True(t, frame.IsKeyframe, "IDR should be detected as keyframe")
+		assert.Equal(t, uint32(90000), frame.Timestamp)
+		assert.Equal(t, VideoCodecH264, frame.Codec)
+		// Frame data should contain Annex-B start code + NAL.
+		assert.True(t, len(frame.Data) > 4, "frame should have start code + NAL")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("VideoReader did not receive assembled frame")
+	}
+}
+
+func TestVideoMedia_H264FUADepacketize(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	// Simulate FU-A fragmentation of an IDR NAL.
+	nalHeader := byte(0x65) // NRI=3, type=5 (IDR)
+	fuIndicator := (nalHeader & 0xE0) | 28
+
+	// Fragment 1: S=1, E=0.
+	frag1 := append([]byte{fuIndicator, 0x80 | 0x05}, make([]byte, 100)...)
+	pkt1 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, Timestamp: 90000, PayloadType: 96},
+		Payload: frag1,
+	}
+	c.videoRTPInbound <- pkt1
+
+	// Fragment 2: S=0, E=1, marker set.
+	frag2 := append([]byte{fuIndicator, 0x40 | 0x05}, make([]byte, 50)...)
+	pkt2 := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 2, Timestamp: 90000, PayloadType: 96, Marker: true},
+		Payload: frag2,
+	}
+	c.videoRTPInbound <- pkt2
+
+	// Should produce a single assembled keyframe.
+	select {
+	case frame := <-c.VideoReader():
+		assert.True(t, frame.IsKeyframe)
+		assert.Equal(t, uint32(90000), frame.Timestamp)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("VideoReader did not receive FU-A reassembled frame")
+	}
+}
+
+func TestVideoMedia_OutboundVideoFrame(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	// Build an Annex-B encoded frame (SPS + IDR).
+	var frameData []byte
+	frameData = append(frameData, 0x00, 0x00, 0x00, 0x01) // start code
+	frameData = append(frameData, 0x67, 0x42, 0xE0, 0x1F) // SPS
+	frameData = append(frameData, 0x00, 0x00, 0x00, 0x01) // start code
+	frameData = append(frameData, 0x65)                   // IDR header
+	frameData = append(frameData, make([]byte, 50)...)    // IDR payload
+
+	frame := VideoFrame{
+		Codec:      VideoCodecH264,
+		Timestamp:  180000,
+		IsKeyframe: true,
+		Data:       frameData,
+	}
+
+	// Send via VideoWriter.
+	select {
+	case c.VideoWriter() <- frame:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("VideoWriter blocked")
+	}
+
+	// Should produce RTP packets on videoSentRTP.
+	time.Sleep(50 * time.Millisecond)
+	pkts := drainPackets(c.videoSentRTP)
+	require.True(t, len(pkts) >= 2, "expected at least 2 RTP packets (SPS + IDR), got %d", len(pkts))
+
+	// Last packet should have marker bit set.
+	assert.True(t, pkts[len(pkts)-1].Marker, "last packet should have marker bit")
+	// All packets should have the correct timestamp.
+	for _, p := range pkts {
+		assert.Equal(t, uint32(180000), p.Timestamp)
+		assert.Equal(t, uint8(96), p.PayloadType)
+	}
+}
+
+// --- VP8 pipeline tests ---
+
+func activeVP8VideoCall(t *testing.T) *call {
+	t.Helper()
+	return activeVideoCallWithCodec(t, VideoCodecVP8)
+}
+
+func TestVideoMedia_VP8Depacketize(t *testing.T) {
+	c := activeVP8VideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	// VP8 keyframe: descriptor S=1 (0x10), frame byte bit0=0 (keyframe).
+	pkt := &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 1, PayloadType: 97, Timestamp: 90000, Marker: true},
+		Payload: []byte{0x10, 0x10, 0x00, 0x00, 0xAA, 0xBB}, // S=1, keyframe
+	}
+	c.videoRTPInbound <- pkt
+
+	select {
+	case frame := <-c.VideoReader():
+		assert.True(t, frame.IsKeyframe)
+		assert.Equal(t, VideoCodecVP8, frame.Codec)
+		assert.Equal(t, uint32(90000), frame.Timestamp)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("VP8 VideoReader did not receive frame")
+	}
+}
+
+func TestVideoMedia_VP8OutboundFrame(t *testing.T) {
+	c := activeVP8VideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	frameData := make([]byte, 200)
+	frameData[0] = 0x10 // keyframe (bit 0 = 0)
+	for i := 1; i < len(frameData); i++ {
+		frameData[i] = byte(i)
+	}
+
+	frame := VideoFrame{
+		Codec:      VideoCodecVP8,
+		Timestamp:  270000,
+		IsKeyframe: true,
+		Data:       frameData,
+	}
+
+	select {
+	case c.VideoWriter() <- frame:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("VP8 VideoWriter blocked")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	pkts := drainPackets(c.videoSentRTP)
+	require.True(t, len(pkts) >= 1, "expected at least 1 RTP packet")
+	assert.True(t, pkts[len(pkts)-1].Marker, "last packet should have marker bit")
+	for _, p := range pkts {
+		assert.Equal(t, uint32(270000), p.Timestamp)
+		assert.Equal(t, uint8(97), p.PayloadType)
+	}
 }
 
 // --- RequestKeyframe tests ---


### PR DESCRIPTION
## Summary
- Implement H.264 RTP depacketizer (Single NAL, STAP-A, FU-A) and packetizer with Annex-B framing per RFC 6184
- Implement VP8 RTP depacketizer (payload descriptor parsing, extended headers) and packetizer per RFC 7741
- Wire depacketizers/packetizers into `runVideo()` pipeline: inbound RTP → VideoFrame assembly → `VideoReader()`; outbound `VideoWriter()` → RTP fragmentation
- Collapse 3 type-specific `sendDropOldest` functions into generic `sendDropOldest[T any]`
- Add `videoRTPWriter` / `videoWriter` mutual exclusion (matches audio behavior)
- Add codec mismatch guard, MTU floor enforcement, VP8 PictureID bounds check

## Test plan
- [x] 18 unit tests: splitAnnexB, H264 depacketizer (single NAL, STAP-A, FU-A, timestamp change), H264 packetizer (single, FU-A, multi-NAL), H264 round-trip, VP8 depacketizer (single, inter, multi-packet, timestamp change, extended descriptors), VP8 packetizer (small, large), VP8 round-trip
- [x] 6 integration tests: H264 depacketize, H264 FU-A depacketize, H264 outbound frame, VP8 depacketize, VP8 outbound frame
- [x] `make check` passes (fmt, build, test, vet, race)