### PR TITLE
Add mid-call video upgrade/downgrade via re-INVITE

### DIFF
--- a/call.go
+++ b/call.go
@@ -136,6 +136,9 @@ type Call interface {
 	MuteVideo() error
 	UnmuteVideo() error
 	RequestKeyframe() error
+	AddVideo(codecs ...VideoCodec) error
+	OnVideoRequest(func(*VideoUpgradeRequest))
+	OnVideo(func())
 	OnMedia(func())
 	OnState(func(state CallState))
 	OnEnded(func(reason EndReason))
@@ -153,18 +156,21 @@ type call struct {
 	startTime time.Time
 	logger    *slog.Logger
 
-	onEndedFn      func(EndReason)
-	onEndedCleanup func(EndReason) // internal: call tracking (untrackCall)
-	onStatePhone   func(CallState) // internal: phone-level OnCallState
-	onEndedPhone   func(EndReason) // internal: phone-level OnCallEnded
-	onDTMFPhone    func(string)    // internal: phone-level OnCallDTMF
-	onMediaFn      func()
-	onStateFn      func(CallState)
-	onDTMFFn       func(string)
-	onHoldFn       func()
-	onResumeFn     func()
-	onMuteFn       func()
-	onUnmuteFn     func()
+	onEndedFn           func(EndReason)
+	onEndedCleanup      func(EndReason) // internal: call tracking (untrackCall)
+	onStatePhone        func(CallState) // internal: phone-level OnCallState
+	onEndedPhone        func(EndReason) // internal: phone-level OnCallEnded
+	onDTMFPhone         func(string)    // internal: phone-level OnCallDTMF
+	onMediaFn           func()
+	onStateFn           func(CallState)
+	onDTMFFn            func(string)
+	onHoldFn            func()
+	onResumeFn          func()
+	onMuteFn            func()
+	onUnmuteFn          func()
+	onVideoRequestFn    func(*VideoUpgradeRequest)
+	onVideoFn           func()
+	pendingVideoUpgrade *VideoUpgradeRequest
 
 	audioStream    *mediaStream
 	videoStream    *mediaStream
@@ -229,6 +235,7 @@ type call struct {
 	videoRTPPort      int              // allocated video RTP port
 	videoRemoteAddr   net.Addr         // remote video RTP endpoint
 	videoDone         chan struct{}    // signals video goroutine to stop
+	videoWg           sync.WaitGroup   // waits for video goroutine to exit
 	closeVideoChOnce  sync.Once        // ensures video output channels are closed exactly once
 }
 
@@ -673,7 +680,13 @@ func (c *call) buildAnswerSDP(remote *sdp.Session, direction string) string {
 // Also negotiates video if a video m= line is present.
 // Must be called with c.mu held.
 func (c *call) negotiateCodec(sess *sdp.Session) {
-	// Negotiate audio from the first audio m= line.
+	c.negotiateAudioCodec(sess)
+	c.negotiateVideoCodec(sess)
+}
+
+// negotiateAudioCodec updates c.codec from the audio m= line only.
+// Must be called with c.mu held.
+func (c *call) negotiateAudioCodec(sess *sdp.Session) {
 	var remoteCodecs []int
 	if am := sess.AudioMedia(); am != nil {
 		remoteCodecs = am.Codecs
@@ -682,9 +695,6 @@ func (c *call) negotiateCodec(sess *sdp.Session) {
 		c.codec = Codec(pt)
 	}
 	c.logger.Debug("codec negotiated", "id", c.id, "codec", int(c.codec), "local_prefs", c.resolveCodecPrefs(), "remote_codecs", remoteCodecs)
-
-	// Negotiate video.
-	c.negotiateVideoCodec(sess)
 }
 
 // buildICEParams creates ICE SDP parameters and initializes the ICE agent.
@@ -748,6 +758,7 @@ func (c *call) initVideoChannels() {
 	c.videoReader = make(chan VideoFrame, 256)
 	c.videoWriter = make(chan VideoFrame, 256)
 	c.videoStream = &mediaStream{call: c, outSSRC: randUint32()}
+	c.closeVideoChOnce = sync.Once{} // reset for re-upgrade after downgrade
 }
 
 // ensureVideoRTPPort lazily allocates a UDP socket for video RTP.
@@ -809,11 +820,18 @@ func (c *call) setVideoRemoteEndpoint(sess *sdp.Session) {
 }
 
 // closeVideoOutputChannels closes the consumer-facing video channels exactly once.
+// Safe to call after channels have been nil'd (e.g. by stopVideoPipeline).
 func (c *call) closeVideoOutputChannels() {
 	c.closeVideoChOnce.Do(func() {
-		close(c.videoRTPReader)
-		close(c.videoRTPRawReader)
-		close(c.videoReader)
+		if c.videoRTPReader != nil {
+			close(c.videoRTPReader)
+		}
+		if c.videoRTPRawReader != nil {
+			close(c.videoRTPRawReader)
+		}
+		if c.videoReader != nil {
+			close(c.videoReader)
+		}
 	})
 }
 
@@ -961,6 +979,12 @@ func (c *call) fireOnEnded(reason EndReason) {
 	}
 	if c.videoDone == nil && c.videoRTPReader != nil {
 		c.closeVideoOutputChannels()
+	}
+	// Reject any pending video upgrade request.
+	if c.pendingVideoUpgrade != nil {
+		req := c.pendingVideoUpgrade
+		c.pendingVideoUpgrade = nil
+		go req.Reject()
 	}
 	// Clear OnNotify to break closure reference cycles.
 	c.dlg.OnNotify(nil)

--- a/errors.go
+++ b/errors.go
@@ -40,4 +40,6 @@ var (
 	ErrSubscriptionRejected = errors.New("xphone: subscription rejected")
 	// ErrSubscriptionNotFound is returned when UnsubscribeEvent is called with an unknown ID.
 	ErrSubscriptionNotFound = errors.New("xphone: subscription not found")
+	// ErrVideoAlreadyActive is returned when AddVideo is called on a call that already has video.
+	ErrVideoAlreadyActive = errors.New("xphone: video already active")
 )

--- a/media.go
+++ b/media.go
@@ -463,6 +463,7 @@ func newVideoPacketizer(codec VideoCodec) media.VideoPacketizer {
 // - RTCP SR/RR
 func (s *mediaStream) runVideo() {
 	c := s.call
+	defer c.videoWg.Done()
 	conn := s.conn
 	rtcpConn := s.rtcpConn
 	rtcpRemoteAddr := s.rtcpRemoteAddr
@@ -679,6 +680,7 @@ func (c *call) startVideoMedia() {
 	s.outTimestamp = 0
 	s.rtpWriterUsed = false
 	s.inboundCount = 0
+	c.videoWg.Add(1) // must be under lock so stopVideoPipeline.Wait() can't race
 	c.mu.Unlock()
 
 	c.logger.Debug("video pipeline started", "id", c.id)

--- a/mock_call.go
+++ b/mock_call.go
@@ -670,6 +670,27 @@ func (c *MockCall) RequestKeyframe() error {
 	return nil
 }
 
+func (c *MockCall) AddVideo(codecs ...VideoCodec) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state != StateActive {
+		return ErrInvalidState
+	}
+	if c.hasVideo {
+		return ErrVideoAlreadyActive
+	}
+	c.hasVideo = true
+	if len(codecs) > 0 {
+		c.videoCodecType = codecs[0]
+	} else {
+		c.videoCodecType = VideoCodecH264
+	}
+	return nil
+}
+
+func (c *MockCall) OnVideoRequest(fn func(*VideoUpgradeRequest)) {}
+func (c *MockCall) OnVideo(fn func())                            {}
+
 // SetHasVideo enables or disables video on the mock call.
 func (c *MockCall) SetHasVideo(v bool) {
 	c.mu.Lock()

--- a/sipua.go
+++ b/sipua.go
@@ -86,6 +86,10 @@ type sipUA struct {
 	// The phone uses this to fire DTMF callbacks on the call.
 	onDialogInfo func(callID string, digit string)
 
+	// onDialogReInvite is called when an inbound re-INVITE is received for an
+	// existing dialog. Returns true if the call was found and handled.
+	onDialogReInvite func(callID string, responder reInviteResponder, sdpBody string) bool
+
 	// onNotify is the general NOTIFY callback for SUBSCRIBE/NOTIFY (RFC 6665).
 	// Receives event, from, contentType, body, subscriptionState.
 	onNotify func(event, from, contentType, body, subscriptionState string)
@@ -316,6 +320,35 @@ func (s *sipUA) startServer() {
 			return
 		}
 
+		// Extract Call-ID and SDP body.
+		callID := ""
+		if h := req.CallID(); h != nil {
+			callID = h.Value()
+		}
+		sdpBody := string(req.Body())
+
+		// Check if this is a re-INVITE for an existing call.
+		s.mu.Lock()
+		reInvFn := s.onDialogReInvite
+		s.mu.Unlock()
+		if reInvFn != nil && callID != "" {
+			responder := &sipgoDialogUAS{
+				dialogBase: dialogBase{sess: sess, invite: req},
+			}
+			if reInvFn(callID, responder, sdpBody) {
+				// Re-INVITE handled — wait for confirmed state.
+				stateCh := sess.StateRead()
+				for state := range stateCh {
+					if state >= sip.DialogStateConfirmed {
+						break
+					}
+				}
+				tx.Terminate()
+				return
+			}
+		}
+
+		// Not a re-INVITE — handle as new INVITE.
 		// Send 100 Trying immediately to stop INVITE retransmissions.
 		sess.Respond(100, "Trying", nil)
 
@@ -335,9 +368,6 @@ func (s *sipUA) startServer() {
 				invite: req,
 			},
 		}
-
-		// Extract SDP body from INVITE.
-		sdpBody := string(req.Body())
 
 		s.mu.Lock()
 		fn := s.onDialogInvite

--- a/video_upgrade.go
+++ b/video_upgrade.go
@@ -1,0 +1,421 @@
+package xphone
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/x-phone/xphone-go/internal/sdp"
+	"github.com/x-phone/xphone-go/internal/srtp"
+)
+
+// videoUpgradeTimeout is how long the app has to accept or reject a video
+// upgrade request before it is automatically rejected.
+const videoUpgradeTimeout = 30 * time.Second
+
+// reInviteResponder allows responding to a specific re-INVITE transaction.
+type reInviteResponder interface {
+	Respond(code int, reason string, body []byte) error
+}
+
+// VideoUpgradeRequest is created when the remote sends a re-INVITE adding video.
+// The app must call Accept() or Reject(). If neither is called within 30 seconds,
+// the request is automatically rejected. Calling Accept or Reject more than once
+// is a no-op.
+type VideoUpgradeRequest struct {
+	call      *call
+	responder reInviteResponder
+	remoteSDP string
+	sess      *sdp.Session
+	videoConn net.PacketConn // pre-allocated video socket (closed on reject)
+	videoPort int
+	responded sync.Once
+	timer     *time.Timer
+}
+
+func newVideoUpgradeRequest(c *call, resp reInviteResponder, rawSDP string, sess *sdp.Session, videoConn net.PacketConn, videoPort int) *VideoUpgradeRequest {
+	req := &VideoUpgradeRequest{
+		call:      c,
+		responder: resp,
+		remoteSDP: rawSDP,
+		sess:      sess,
+		videoConn: videoConn,
+		videoPort: videoPort,
+	}
+	req.timer = time.AfterFunc(videoUpgradeTimeout, func() {
+		req.Reject()
+	})
+	return req
+}
+
+// Accept accepts the video upgrade, starts the video pipeline, and responds
+// 200 OK with a video SDP answer to the remote party.
+func (r *VideoUpgradeRequest) Accept() {
+	r.responded.Do(func() {
+		r.timer.Stop()
+		r.call.acceptVideoUpgrade(r)
+	})
+}
+
+// Reject rejects the video upgrade and responds 200 OK with m=video 0
+// (RFC 3264 media rejection). Audio is unchanged.
+func (r *VideoUpgradeRequest) Reject() {
+	r.responded.Do(func() {
+		r.timer.Stop()
+		r.call.rejectVideoUpgrade(r)
+	})
+}
+
+// RemoteCodec returns the video codec offered by the remote party.
+func (r *VideoUpgradeRequest) RemoteCodec() VideoCodec {
+	if vm := r.sess.VideoMedia(); vm != nil && len(vm.Codecs) > 0 {
+		return VideoCodec(vm.Codecs[0])
+	}
+	return 0
+}
+
+// --- call methods for accept/reject ---
+
+func (c *call) acceptVideoUpgrade(r *VideoUpgradeRequest) {
+	c.mu.Lock()
+	if c.state == StateEnded {
+		c.mu.Unlock()
+		if r.videoConn != nil {
+			r.videoConn.Close()
+		}
+		return
+	}
+
+	// Install video socket.
+	c.videoRTPConn = r.videoConn
+	c.videoRTPPort = r.videoPort
+
+	// Update remote SDP and negotiate video codec.
+	c.remoteSDP = r.remoteSDP
+	c.setRemoteEndpoint(r.sess)
+	c.negotiateVideoCodec(r.sess)
+	c.setVideoRemoteEndpoint(r.sess)
+
+	// Populate video codec prefs so buildAnswerSDP includes video m= line.
+	c.opts.VideoCodecs = []VideoCodec{c.videoCodecType}
+	c.opts.Video = true
+
+	// Initialize video pipeline channels.
+	if c.videoRTPReader == nil {
+		c.initVideoChannels()
+	}
+
+	// Build SDP answer with video.
+	answerSDP := c.buildAnswerSDP(r.sess, sdp.DirSendRecv)
+	c.localSDP = answerSDP
+
+	// Capture SRTP state for setup outside lock.
+	srtpLocalKey := c.srtpLocalKey
+	isSRTP := srtpLocalKey != "" && r.sess.IsSRTP()
+	var remoteKey string
+	if isSRTP {
+		if crypto := r.sess.FirstCrypto(); crypto != nil {
+			remoteKey = crypto.InlineKey()
+		}
+	}
+
+	videoFn := c.onVideoFn
+	c.pendingVideoUpgrade = nil
+	c.mu.Unlock()
+
+	// Respond 200 OK with video SDP answer.
+	if r.responder != nil {
+		r.responder.Respond(200, "OK", []byte(answerSDP))
+	}
+
+	// Set up video SRTP contexts if SRTP is active.
+	if isSRTP && remoteKey != "" {
+		videoOutCtx, err := srtp.FromSDESInline(srtpLocalKey)
+		if err != nil {
+			c.logger.Error("video SRTP out context failed", "id", c.id, "error", err)
+		} else {
+			videoInCtx, err := srtp.FromSDESInline(remoteKey)
+			if err != nil {
+				c.logger.Error("video SRTP in context failed", "id", c.id, "error", err)
+			} else {
+				c.mu.Lock()
+				c.videoSrtpOut = videoOutCtx
+				c.videoSrtpIn = videoInCtx
+				c.mu.Unlock()
+			}
+		}
+	}
+
+	// Start video pipeline.
+	c.startVideoMedia()
+	c.startVideoRTPReader()
+
+	// Fire OnVideo callback.
+	if videoFn != nil {
+		c.dispatch(videoFn)
+	}
+	c.logger.Info("video upgrade accepted", "id", c.id)
+}
+
+func (c *call) rejectVideoUpgrade(r *VideoUpgradeRequest) {
+	// Close pre-allocated video socket.
+	if r.videoConn != nil {
+		r.videoConn.Close()
+	}
+
+	c.mu.Lock()
+	if c.state == StateEnded {
+		c.mu.Unlock()
+		return
+	}
+
+	// Update remote SDP for audio changes only (skip video negotiation).
+	c.remoteSDP = r.remoteSDP
+	c.setRemoteEndpoint(r.sess)
+	c.negotiateAudioCodec(r.sess)
+
+	// Build audio-only answer with m=video 0 (RFC 3264 rejection).
+	answerSDP := c.buildAnswerRejectVideoSDP(r.sess)
+	c.localSDP = answerSDP
+	c.pendingVideoUpgrade = nil
+	c.mu.Unlock()
+
+	if r.responder != nil {
+		r.responder.Respond(200, "OK", []byte(answerSDP))
+	}
+	c.logger.Info("video upgrade rejected", "id", c.id)
+}
+
+// handleReInvite processes an inbound re-INVITE for an existing call.
+// It detects video upgrade, video downgrade, and hold/resume transitions.
+func (c *call) handleReInvite(responder reInviteResponder, rawSDP string) {
+	sess, err := sdp.Parse(rawSDP)
+	if err != nil {
+		c.logger.Warn("re-INVITE SDP parse failed", "id", c.id, "error", err)
+		if responder != nil {
+			responder.Respond(400, "Bad Request", nil)
+		}
+		return
+	}
+
+	c.mu.Lock()
+	if c.state == StateEnded {
+		c.mu.Unlock()
+		return
+	}
+
+	vm := sess.VideoMedia()
+	currentlyHasVideo := c.hasVideo
+
+	// Video downgrade: remote sends m=video 0 (or no video) when we have video.
+	if currentlyHasVideo && (vm == nil || vm.Port == 0 || len(vm.Codecs) == 0) {
+		c.mu.Unlock()
+		c.stopVideoPipeline()
+		// Respond with audio-only answer.
+		c.mu.Lock()
+		c.remoteSDP = rawSDP
+		c.setRemoteEndpoint(sess)
+		c.negotiateAudioCodec(sess) // audio only — video is being removed
+		dir := sess.Dir()
+		if dir == "" {
+			dir = sdp.DirSendRecv
+		}
+		answerSDP := c.buildAnswerSDP(sess, dir)
+		c.localSDP = answerSDP
+		c.mu.Unlock()
+		if responder != nil {
+			responder.Respond(200, "OK", []byte(answerSDP))
+		}
+		c.logger.Info("video downgrade processed", "id", c.id)
+		return
+	}
+
+	// Video upgrade: remote adds m=video with codecs, we don't have video yet.
+	if !currentlyHasVideo && vm != nil && vm.Port > 0 && len(vm.Codecs) > 0 {
+		requestFn := c.onVideoRequestFn
+		c.mu.Unlock()
+
+		// Pre-allocate video socket outside the lock.
+		videoConn, err := listenRTPPort(c.rtpPortMin, c.rtpPortMax)
+		var videoPort int
+		if err == nil {
+			videoPort = videoConn.LocalAddr().(*net.UDPAddr).Port
+		} else {
+			c.logger.Error("video upgrade: failed to allocate video RTP port", "id", c.id, "error", err)
+			if responder != nil {
+				responder.Respond(500, "Internal Server Error", nil)
+			}
+			return
+		}
+
+		req := newVideoUpgradeRequest(c, responder, rawSDP, sess, videoConn, videoPort)
+		c.mu.Lock()
+		c.pendingVideoUpgrade = req
+		c.mu.Unlock()
+
+		if requestFn != nil {
+			c.dispatch(func() { requestFn(req) })
+		} else {
+			// No handler — auto-reject (safe default, no video without consent).
+			req.Reject()
+		}
+		return
+	}
+
+	// Audio-only re-INVITE (hold/resume/codec change).
+	// Update remote SDP and handle direction changes.
+	// ICE credentials are updated by buildAnswerSDP below.
+	c.remoteSDP = rawSDP
+	c.setRemoteEndpoint(sess)
+
+	dir := sess.Dir()
+	var holdFn, resumeFn func()
+	switch {
+	case dir == sdp.DirSendOnly && c.state == StateActive:
+		c.state = StateOnHold
+		holdFn = c.onHoldFn
+		c.fireOnState(StateOnHold)
+		c.signalMediaTimerReset(defaultHoldMediaTimeout)
+	case dir == sdp.DirSendRecv && c.state == StateOnHold:
+		c.state = StateActive
+		resumeFn = c.onResumeFn
+		c.fireOnState(StateActive)
+		c.signalMediaTimerReset(c.effectiveMediaTimeout())
+	}
+
+	c.negotiateCodec(sess)
+
+	// Build SDP answer preserving direction semantics.
+	answerDir := sdp.DirSendRecv
+	if dir == sdp.DirSendOnly {
+		answerDir = sdp.DirRecvOnly
+	}
+	answerSDP := c.buildAnswerSDP(sess, answerDir)
+	c.localSDP = answerSDP
+	c.mu.Unlock()
+
+	if responder != nil {
+		responder.Respond(200, "OK", []byte(answerSDP))
+	}
+
+	if holdFn != nil {
+		c.dispatch(holdFn)
+	}
+	if resumeFn != nil {
+		c.dispatch(resumeFn)
+	}
+}
+
+// stopVideoPipeline stops the video media pipeline and cleans up video state.
+// Safe to call when video is not active (no-op).
+func (c *call) stopVideoPipeline() {
+	c.mu.Lock()
+	// Signal video goroutine to stop.
+	if c.videoDone != nil {
+		select {
+		case <-c.videoDone:
+		default:
+			close(c.videoDone)
+		}
+		c.videoDone = nil
+	}
+	c.mu.Unlock()
+
+	// Wait for video goroutine to exit before modifying shared state.
+	c.videoWg.Wait()
+
+	c.mu.Lock()
+	// Close video sockets.
+	if c.videoRTCPConn != nil {
+		c.videoRTCPConn.Close()
+		c.videoRTCPConn = nil
+	}
+	if c.videoRTPConn != nil {
+		c.videoRTPConn.Close()
+		c.videoRTPConn = nil
+	}
+	// Zeroize video SRTP contexts.
+	if c.videoSrtpIn != nil {
+		c.videoSrtpIn.Zeroize()
+		c.videoSrtpIn = nil
+	}
+	if c.videoSrtpOut != nil {
+		c.videoSrtpOut.Zeroize()
+		c.videoSrtpOut = nil
+	}
+	// Reset video state.
+	c.hasVideo = false
+	c.videoCodecType = 0
+	c.videoRTPPort = 0
+	c.videoRemoteAddr = nil
+	c.videoStream = nil
+	// Close video output channels if pipeline was running.
+	if c.videoRTPReader != nil {
+		c.closeVideoOutputChannels()
+	}
+	// Nil out channels to allow re-initialization on future upgrade.
+	c.videoRTPInbound = nil
+	c.videoRTPReader = nil
+	c.videoRTPRawReader = nil
+	c.videoRTPWriter = nil
+	c.videoReader = nil
+	c.videoWriter = nil
+	c.videoSentRTP = nil
+	c.mu.Unlock()
+	c.logger.Debug("video pipeline stopped", "id", c.id)
+}
+
+// buildAnswerRejectVideoSDP builds an SDP answer that accepts audio but
+// rejects video with m=video 0 RTP/AVP 0 (RFC 3264 §6).
+// Delegates to buildAnswerSDP (audio-only since video opts are not set)
+// and appends the rejection m= line.
+func (c *call) buildAnswerRejectVideoSDP(remote *sdp.Session) string {
+	return c.buildAnswerSDP(remote, sdp.DirSendRecv) + "m=video 0 RTP/AVP 0\r\n"
+}
+
+// AddVideo initiates an outbound video upgrade by sending a re-INVITE with
+// audio + video SDP. The remote peer's response determines if video is activated.
+func (c *call) AddVideo(codecs ...VideoCodec) error {
+	if len(codecs) == 0 {
+		codecs = []VideoCodec{VideoCodecH264, VideoCodecVP8}
+	}
+
+	c.mu.Lock()
+	if c.state != StateActive {
+		c.mu.Unlock()
+		return ErrInvalidState
+	}
+	if c.hasVideo {
+		c.mu.Unlock()
+		return ErrVideoAlreadyActive
+	}
+
+	// Store video codec preferences and allocate video port.
+	c.opts.VideoCodecs = codecs
+	c.opts.Video = true
+	c.ensureVideoRTPPort()
+
+	// Build SDP offer with audio + video.
+	sdpOffer := c.buildLocalSDP(sdp.DirSendRecv)
+	c.localSDP = sdpOffer
+	c.mu.Unlock()
+
+	return c.dlg.SendReInvite([]byte(sdpOffer))
+}
+
+// OnVideoRequest registers a callback for inbound video upgrade requests.
+// The callback receives a *VideoUpgradeRequest that the app must Accept() or Reject().
+// If no callback is registered, video upgrades are automatically rejected.
+func (c *call) OnVideoRequest(fn func(*VideoUpgradeRequest)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onVideoRequestFn = fn
+}
+
+// OnVideo registers a callback that fires when video becomes active on the call
+// (after a video upgrade is accepted).
+func (c *call) OnVideo(fn func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onVideoFn = fn
+}

--- a/video_upgrade_test.go
+++ b/video_upgrade_test.go
@@ -1,0 +1,475 @@
+package xphone
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/x-phone/xphone-go/internal/sdp"
+	"github.com/x-phone/xphone-go/testutil"
+)
+
+// mockResponder records the SIP response sent for a re-INVITE.
+type mockResponder struct {
+	code   int
+	reason string
+	body   []byte
+}
+
+func (r *mockResponder) Respond(code int, reason string, body []byte) error {
+	r.code = code
+	r.reason = reason
+	r.body = body
+	return nil
+}
+
+// testVideoOfferSDP generates a remote SDP offer with audio + video.
+func testVideoOfferSDP(ip string, audioPort, videoPort int, videoCodecs ...int) string {
+	return sdp.BuildOfferVideo(ip, audioPort, []int{0}, videoPort, videoCodecs, "sendrecv")
+}
+
+// --- Video upgrade accept ---
+
+func TestVideoUpgrade_Accept(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	var reqReceived *VideoUpgradeRequest
+	requestCh := make(chan *VideoUpgradeRequest, 1)
+	c.OnVideoRequest(func(req *VideoUpgradeRequest) {
+		requestCh <- req
+	})
+
+	videoCh := make(chan struct{}, 1)
+	c.OnVideo(func() { videoCh <- struct{}{} })
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 96)
+	c.handleReInvite(resp, offer)
+
+	// Should receive the upgrade request via callback.
+	select {
+	case reqReceived = <-requestCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnVideoRequest callback never fired")
+	}
+
+	require.NotNil(t, reqReceived)
+	assert.Equal(t, VideoCodecH264, reqReceived.RemoteCodec())
+
+	// Accept the upgrade.
+	reqReceived.Accept()
+
+	// Should respond 200 OK with video SDP.
+	assert.Equal(t, 200, resp.code)
+	assert.Equal(t, "OK", resp.reason)
+	assert.Contains(t, string(resp.body), "m=video")
+	assert.NotContains(t, string(resp.body), "m=video 0")
+
+	// OnVideo callback should fire.
+	select {
+	case <-videoCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnVideo callback never fired after accept")
+	}
+
+	// Call should have video active.
+	assert.True(t, c.HasVideo())
+}
+
+// --- Video upgrade reject ---
+
+func TestVideoUpgrade_Reject(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	requestCh := make(chan *VideoUpgradeRequest, 1)
+	c.OnVideoRequest(func(req *VideoUpgradeRequest) {
+		requestCh <- req
+	})
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 96)
+	c.handleReInvite(resp, offer)
+
+	var req *VideoUpgradeRequest
+	select {
+	case req = <-requestCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnVideoRequest callback never fired")
+	}
+
+	req.Reject()
+
+	// Should respond 200 OK with m=video 0 (rejection).
+	assert.Equal(t, 200, resp.code)
+	assert.Contains(t, string(resp.body), "m=video 0")
+
+	// Call should NOT have video.
+	assert.False(t, c.HasVideo())
+}
+
+// --- Auto-reject when no handler ---
+
+func TestVideoUpgrade_AutoRejectNoHandler(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+	// No OnVideoRequest handler registered.
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 96)
+	c.handleReInvite(resp, offer)
+
+	// Give time for auto-reject to process.
+	time.Sleep(100 * time.Millisecond)
+
+	// Should respond 200 OK with m=video 0 (auto-rejected).
+	assert.Equal(t, 200, resp.code)
+	assert.Contains(t, string(resp.body), "m=video 0")
+	assert.False(t, c.HasVideo())
+}
+
+// --- Timeout auto-reject ---
+
+func TestVideoUpgrade_TimeoutAutoReject(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	requestCh := make(chan *VideoUpgradeRequest, 1)
+	c.OnVideoRequest(func(req *VideoUpgradeRequest) {
+		requestCh <- req
+	})
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 96)
+	c.handleReInvite(resp, offer)
+
+	var req *VideoUpgradeRequest
+	select {
+	case req = <-requestCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnVideoRequest callback never fired")
+	}
+
+	// Manually trigger the timer callback (simulating timeout).
+	req.timer.Stop()
+	req.Reject() // simulate what the timer would do
+
+	assert.Equal(t, 200, resp.code)
+	assert.Contains(t, string(resp.body), "m=video 0")
+	assert.False(t, c.HasVideo())
+}
+
+// --- Idempotent Accept/Reject ---
+
+func TestVideoUpgrade_IdempotentAcceptReject(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	requestCh := make(chan *VideoUpgradeRequest, 1)
+	c.OnVideoRequest(func(req *VideoUpgradeRequest) {
+		requestCh <- req
+	})
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 96)
+	c.handleReInvite(resp, offer)
+
+	var req *VideoUpgradeRequest
+	select {
+	case req = <-requestCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnVideoRequest callback never fired")
+	}
+
+	// Accept first — should succeed.
+	req.Accept()
+	assert.Equal(t, 200, resp.code)
+
+	// Second Accept is a no-op (sync.Once).
+	req.Accept()
+	// Second Reject is a no-op.
+	req.Reject()
+
+	// State should still be video-active from first Accept.
+	assert.True(t, c.HasVideo())
+}
+
+// --- Ended call ignores upgrade ---
+
+func TestVideoUpgrade_EndedCallIgnoresAccept(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	requestCh := make(chan *VideoUpgradeRequest, 1)
+	c.OnVideoRequest(func(req *VideoUpgradeRequest) {
+		requestCh <- req
+	})
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 96)
+	c.handleReInvite(resp, offer)
+
+	var req *VideoUpgradeRequest
+	select {
+	case req = <-requestCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnVideoRequest callback never fired")
+	}
+
+	// End the call first.
+	c.End()
+
+	// Accept on ended call is a no-op (no panic, video socket cleaned up).
+	req.Accept()
+	assert.False(t, c.HasVideo())
+}
+
+func TestVideoUpgrade_EndedCallIgnoresReInvite(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+	c.End()
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 96)
+	c.handleReInvite(resp, offer)
+
+	// Responder should not have been called (early return for ended call).
+	assert.Equal(t, 0, resp.code)
+}
+
+// --- Video downgrade ---
+
+func TestVideoDowngrade(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	assert.True(t, c.HasVideo())
+
+	// Send re-INVITE with m=video 0 (downgrade).
+	resp := &mockResponder{}
+	audioOnlySDP := testSDP("10.0.0.1", 5000, "sendrecv", 0)
+	c.handleReInvite(resp, audioOnlySDP)
+
+	// Should respond 200 OK, audio-only.
+	assert.Equal(t, 200, resp.code)
+	assert.False(t, c.HasVideo())
+}
+
+func TestVideoDowngrade_VideoPort0(t *testing.T) {
+	c := activeVideoCall(t)
+	defer c.stopMedia()
+	defer c.videoRTPConn.Close()
+
+	assert.True(t, c.HasVideo())
+
+	// Send re-INVITE with explicit m=video 0 (port 0 rejection).
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 0, 96)
+	c.handleReInvite(resp, offer)
+
+	assert.Equal(t, 200, resp.code)
+	assert.False(t, c.HasVideo())
+}
+
+// --- Hold delegation (audio-only re-INVITE while no video) ---
+
+func TestReInvite_HoldResumeWithoutVideo(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	holdResp := &mockResponder{}
+	holdSDP := testSDP("10.0.0.1", 5000, "sendonly", 0)
+	c.handleReInvite(holdResp, holdSDP)
+
+	assert.Equal(t, 200, holdResp.code)
+	assert.Equal(t, StateOnHold, c.State())
+
+	resumeResp := &mockResponder{}
+	resumeSDP := testSDP("10.0.0.1", 5000, "sendrecv", 0)
+	c.handleReInvite(resumeResp, resumeSDP)
+
+	assert.Equal(t, 200, resumeResp.code)
+	assert.Equal(t, StateActive, c.State())
+}
+
+// --- AddVideo sends re-INVITE ---
+
+func TestAddVideo_SendsReInvite(t *testing.T) {
+	dlg := testutil.NewMockDialog()
+	c := testInboundCall(t, dlg)
+	c.Accept()
+
+	err := c.AddVideo(VideoCodecH264, VideoCodecVP8)
+	require.NoError(t, err)
+
+	reInviteSDP := dlg.LastReInviteSDP()
+	assert.NotEmpty(t, reInviteSDP)
+	assert.Contains(t, reInviteSDP, "m=video")
+}
+
+func TestAddVideo_RequiresActiveState(t *testing.T) {
+	c := testInboundCall(t)
+	// Still ringing — not accepted yet.
+	err := c.AddVideo()
+	assert.Equal(t, ErrInvalidState, err)
+}
+
+func TestAddVideo_AlreadyActive(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+	c.mu.Lock()
+	c.hasVideo = true
+	c.mu.Unlock()
+
+	err := c.AddVideo()
+	assert.Equal(t, ErrVideoAlreadyActive, err)
+}
+
+func TestAddVideo_DefaultCodecs(t *testing.T) {
+	dlg := testutil.NewMockDialog()
+	c := testInboundCall(t, dlg)
+	c.Accept()
+
+	// No codecs specified — should default to H264 + VP8.
+	err := c.AddVideo()
+	require.NoError(t, err)
+
+	reInviteSDP := dlg.LastReInviteSDP()
+	assert.Contains(t, reInviteSDP, "m=video")
+}
+
+// --- RemoteCodec ---
+
+func TestVideoUpgrade_RemoteCodecVP8(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	requestCh := make(chan *VideoUpgradeRequest, 1)
+	c.OnVideoRequest(func(req *VideoUpgradeRequest) {
+		requestCh <- req
+	})
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 97) // VP8
+	c.handleReInvite(resp, offer)
+
+	var req *VideoUpgradeRequest
+	select {
+	case req = <-requestCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnVideoRequest callback never fired")
+	}
+
+	assert.Equal(t, VideoCodecVP8, req.RemoteCodec())
+	req.Reject() // clean up
+}
+
+// --- Bad SDP ---
+
+func TestReInvite_BadSDP(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	resp := &mockResponder{}
+	c.handleReInvite(resp, "not valid sdp")
+
+	assert.Equal(t, 400, resp.code)
+}
+
+// --- Pending upgrade cleaned up on End ---
+
+func TestVideoUpgrade_PendingCleanedUpOnEnd(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	requestCh := make(chan *VideoUpgradeRequest, 1)
+	c.OnVideoRequest(func(req *VideoUpgradeRequest) {
+		requestCh <- req
+	})
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 96)
+	c.handleReInvite(resp, offer)
+
+	select {
+	case <-requestCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnVideoRequest callback never fired")
+	}
+
+	// pendingVideoUpgrade should be set.
+	c.mu.Lock()
+	hasPending := c.pendingVideoUpgrade != nil
+	c.mu.Unlock()
+	assert.True(t, hasPending)
+
+	// End the call — should clean up the pending upgrade.
+	c.End()
+
+	time.Sleep(100 * time.Millisecond)
+	c.mu.Lock()
+	hasPending = c.pendingVideoUpgrade != nil
+	c.mu.Unlock()
+	assert.False(t, hasPending)
+}
+
+// --- Reject SDP contains m=video 0 ---
+
+func TestVideoUpgrade_RejectSDPContainsVideoZero(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+
+	requestCh := make(chan *VideoUpgradeRequest, 1)
+	c.OnVideoRequest(func(req *VideoUpgradeRequest) {
+		requestCh <- req
+	})
+
+	resp := &mockResponder{}
+	offer := testVideoOfferSDP("10.0.0.1", 5000, 5002, 96)
+	c.handleReInvite(resp, offer)
+
+	var req *VideoUpgradeRequest
+	select {
+	case req = <-requestCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnVideoRequest callback never fired")
+	}
+
+	req.Reject()
+
+	body := string(resp.body)
+	// Must contain audio m= line.
+	assert.True(t, strings.Contains(body, "m=audio"), "reject SDP must contain audio")
+	// Must contain m=video 0 rejection line (RFC 3264).
+	assert.True(t, strings.Contains(body, "m=video 0"), "reject SDP must contain m=video 0")
+}
+
+// --- stopVideoPipeline ---
+
+func TestStopVideoPipeline_NoOpWhenNoVideo(t *testing.T) {
+	c := testInboundCall(t)
+	c.Accept()
+	// Should not panic when called without video.
+	c.stopVideoPipeline()
+}
+
+// --- MockCall video upgrade methods ---
+
+func TestMockCall_AddVideo(t *testing.T) {
+	c := NewMockCall()
+	c.SetState(StateActive)
+
+	err := c.AddVideo()
+	assert.NoError(t, err)
+}
+
+func TestMockCall_OnVideoRequest(t *testing.T) {
+	c := NewMockCall()
+	// Should not panic.
+	c.OnVideoRequest(func(req *VideoUpgradeRequest) {})
+	c.OnVideo(func() {})
+}

--- a/xphone.go
+++ b/xphone.go
@@ -314,6 +314,7 @@ func (p *phone) Connect(ctx context.Context) error {
 	// Wire inbound INVITE, BYE, and NOTIFY handlers for sipgo path.
 	tr.mu.Lock()
 	tr.onDialogInvite = p.handleDialogInvite
+	tr.onDialogReInvite = p.handleDialogReInvite
 	tr.onDialogBye = p.handleDialogBye
 	tr.onDialogCancel = p.handleDialogCancel
 	tr.onDialogNotify = p.handleDialogNotify
@@ -675,6 +676,18 @@ func (p *phone) handleDialogInvite(dlg dialog, from, to, sdpBody string) {
 	if fn != nil {
 		fn(c)
 	}
+}
+
+// handleDialogReInvite is called by sipUA's OnInvite handler when an INVITE
+// arrives with a Call-ID that may match an existing call. Returns true if the
+// re-INVITE was handled (existing call found).
+func (p *phone) handleDialogReInvite(callID string, responder reInviteResponder, sdpBody string) bool {
+	c := p.findCall(callID)
+	if c == nil {
+		return false // not a re-INVITE — fall through to new call handling
+	}
+	c.handleReInvite(responder, sdpBody)
+	return true
 }
 
 // handleDialogBye is called by sipUA's OnBye handler when a BYE is received


### PR DESCRIPTION
## Summary
- Implement `VideoUpgradeRequest` with `Accept()`/`Reject()` API for inbound video upgrade requests, with auto-reject on 30s timeout and privacy-safe default (no handler = auto-reject)
- Add `AddVideo()` for outbound video upgrade via re-INVITE with audio+video SDP
- Handle video downgrade when remote sends `m=video 0` — stops video pipeline cleanly
- Route inbound re-INVITEs to existing calls by Call-ID in sipua.go (prevents duplicate call creation)
- Add `videoWg` synchronization to prevent data races between `stopVideoPipeline` and video goroutine

## Test plan
- [x] 21 tests: accept, reject, auto-reject (no handler), timeout, idempotent accept/reject, ended call ignores accept, ended call ignores re-INVITE, downgrade (audio-only SDP), downgrade (video port 0), hold/resume delegation, AddVideo sends re-INVITE, AddVideo requires active state, AddVideo already active, AddVideo default codecs, RemoteCodec VP8, bad SDP returns 400, pending upgrade cleaned up on End, reject SDP contains m=video 0, stopVideoPipeline no-op, MockCall stubs
- [x] `make check` passes (fmt, build, test, vet, race)