### PR TITLE
Fire OnVideo from startVideoMedia for all activation paths

### DIFF
--- a/media.go
+++ b/media.go
@@ -680,11 +680,17 @@ func (c *call) startVideoMedia() {
 	s.outTimestamp = 0
 	s.rtpWriterUsed = false
 	s.inboundCount = 0
+	videoFn := c.onVideoFn
 	c.videoWg.Add(1) // must be under lock so stopVideoPipeline.Wait() can't race
 	c.mu.Unlock()
 
 	c.logger.Debug("video pipeline started", "id", c.id)
 	go s.runVideo()
+
+	// Fire OnVideo callback for all paths (initial video call, mid-call upgrade).
+	if videoFn != nil {
+		c.dispatch(videoFn)
+	}
 }
 
 // startVideoRTPReader launches a goroutine that reads RTP packets from the

--- a/video_upgrade.go
+++ b/video_upgrade.go
@@ -119,7 +119,6 @@ func (c *call) acceptVideoUpgrade(r *VideoUpgradeRequest) {
 		}
 	}
 
-	videoFn := c.onVideoFn
 	c.pendingVideoUpgrade = nil
 	c.mu.Unlock()
 
@@ -146,14 +145,9 @@ func (c *call) acceptVideoUpgrade(r *VideoUpgradeRequest) {
 		}
 	}
 
-	// Start video pipeline.
+	// Start video pipeline (also fires OnVideo callback).
 	c.startVideoMedia()
 	c.startVideoRTPReader()
-
-	// Fire OnVideo callback.
-	if videoFn != nil {
-		c.dispatch(videoFn)
-	}
 	c.logger.Info("video upgrade accepted", "id", c.id)
 }
 


### PR DESCRIPTION
## Summary
- Move OnVideo callback firing into `startVideoMedia()` so it covers all video activation paths: initial inbound video call, outbound vdial, and mid-call upgrade
- Previously OnVideo only fired for mid-call upgrade in `acceptVideoUpgrade`, missing the initial call paths

## Test plan
- [x] `make check` passes (fmt, build, test, vet, race)
- [x] Existing `TestVideoUpgrade_Accept` still verifies OnVideo fires after upgrade