### PR TITLE
Reduce cyclomatic complexity in hotspot functions

### DIFF
--- a/internal/sdp/sdp.go
+++ b/internal/sdp/sdp.go
@@ -107,6 +107,50 @@ var codecRtcpFb = map[int][]string{
 	97: {"nack", "nack pli", "ccm fir"},
 }
 
+// parseAttribute handles a single SDP a= line, updating the session and
+// current media descriptor accordingly.
+func parseAttribute(s *Session, curMedia *MediaDesc, val string) {
+	switch {
+	case val == DirSendRecv || val == DirSendOnly || val == DirRecvOnly || val == DirInactive:
+		if curMedia != nil {
+			curMedia.Direction = val
+		}
+	case strings.HasPrefix(val, "crypto:") && curMedia != nil:
+		if ca, err := parseCryptoVal(val[7:]); err == nil {
+			curMedia.Crypto = append(curMedia.Crypto, ca)
+		}
+	case val == "ice-lite":
+		s.IceLite = true
+	case strings.HasPrefix(val, "ice-ufrag:"):
+		s.IceUfrag = val[10:]
+	case strings.HasPrefix(val, "ice-pwd:"):
+		s.IcePwd = val[8:]
+	case strings.HasPrefix(val, "candidate:") && curMedia != nil:
+		curMedia.Candidates = append(curMedia.Candidates, val[10:])
+	case strings.HasPrefix(val, "fmtp:") && curMedia != nil:
+		parseFmtp(val[5:], curMedia)
+	case strings.HasPrefix(val, "rtcp-fb:") && curMedia != nil:
+		parseRtcpFb(val[8:], curMedia)
+	}
+}
+
+// parseMediaLine parses an m= line into a MediaDesc.
+func parseMediaLine(val string) *MediaDesc {
+	parts := strings.Fields(val)
+	if len(parts) < 3 {
+		return nil
+	}
+	md := MediaDesc{Type: parts[0]}
+	md.Port, _ = strconv.Atoi(parts[1])
+	md.Profile = parts[2]
+	for _, ptStr := range parts[3:] {
+		if pt, err := strconv.Atoi(ptStr); err == nil {
+			md.Codecs = append(md.Codecs, pt)
+		}
+	}
+	return &md
+}
+
 // Parse parses a raw SDP string into a Session.
 func Parse(raw string) (*Session, error) {
 	s := &Session{Raw: raw}
@@ -128,51 +172,17 @@ func Parse(raw string) (*Session, error) {
 		case 'o':
 			s.Origin = val
 		case 'c':
-			// c=IN IP4 <ip>
 			parts := strings.Fields(val)
 			if len(parts) >= 3 {
 				s.Connection = parts[2]
 			}
 		case 'm':
-			// m=<type> <port> <profile> <pt...>
-			parts := strings.Fields(val)
-			if len(parts) >= 3 {
-				md := MediaDesc{
-					Type: parts[0],
-				}
-				md.Port, _ = strconv.Atoi(parts[1])
-				md.Profile = parts[2]
-				for _, ptStr := range parts[3:] {
-					if pt, err := strconv.Atoi(ptStr); err == nil {
-						md.Codecs = append(md.Codecs, pt)
-					}
-				}
-				s.Media = append(s.Media, md)
+			if md := parseMediaLine(val); md != nil {
+				s.Media = append(s.Media, *md)
 				curMedia = &s.Media[len(s.Media)-1]
 			}
 		case 'a':
-			switch {
-			case val == DirSendRecv || val == DirSendOnly || val == DirRecvOnly || val == DirInactive:
-				if curMedia != nil {
-					curMedia.Direction = val
-				}
-			case strings.HasPrefix(val, "crypto:") && curMedia != nil:
-				if ca, err := parseCryptoVal(val[7:]); err == nil {
-					curMedia.Crypto = append(curMedia.Crypto, ca)
-				}
-			case val == "ice-lite":
-				s.IceLite = true
-			case strings.HasPrefix(val, "ice-ufrag:"):
-				s.IceUfrag = val[10:]
-			case strings.HasPrefix(val, "ice-pwd:"):
-				s.IcePwd = val[8:]
-			case strings.HasPrefix(val, "candidate:") && curMedia != nil:
-				curMedia.Candidates = append(curMedia.Candidates, val[10:])
-			case strings.HasPrefix(val, "fmtp:") && curMedia != nil:
-				parseFmtp(val[5:], curMedia)
-			case strings.HasPrefix(val, "rtcp-fb:") && curMedia != nil:
-				parseRtcpFb(val[8:], curMedia)
-			}
+			parseAttribute(s, curMedia, val)
 		}
 	}
 

--- a/internal/sip/message.go
+++ b/internal/sip/message.go
@@ -173,13 +173,64 @@ func (m *Message) Bytes() []byte {
 	return buf.Bytes()
 }
 
+// parseStartLine parses the first line of a SIP message, populating the
+// Message's request or response fields.
+func parseStartLine(msg *Message, line string) error {
+	if strings.HasPrefix(line, "SIP/2.0 ") {
+		rest := line[8:]
+		spaceIdx := strings.IndexByte(rest, ' ')
+		if spaceIdx < 0 {
+			return errors.New("sip: malformed status line")
+		}
+		code, err := strconv.Atoi(rest[:spaceIdx])
+		if err != nil {
+			return errors.New("sip: invalid status code")
+		}
+		msg.StatusCode = code
+		msg.Reason = rest[spaceIdx+1:]
+		return nil
+	}
+	parts := strings.SplitN(line, " ", 3)
+	if len(parts) < 3 || parts[2] != "SIP/2.0" {
+		return errors.New("sip: malformed request line")
+	}
+	msg.Method = parts[0]
+	msg.RequestURI = parts[1]
+	return nil
+}
+
+// extractBody determines the message body from raw data after the header
+// section, respecting Content-Length when present.
+func extractBody(msg *Message, body []byte) {
+	if len(body) == 0 {
+		return
+	}
+	clStr := msg.Header("Content-Length")
+	if clStr == "" {
+		msg.Body = body
+		return
+	}
+	cl, err := strconv.Atoi(clStr)
+	if err != nil || cl < 0 {
+		msg.Body = body
+		return
+	}
+	if cl == 0 {
+		return
+	}
+	if cl <= len(body) {
+		msg.Body = body[:cl]
+	} else {
+		msg.Body = body
+	}
+}
+
 // Parse parses a raw SIP message (request or response).
 func Parse(data []byte) (*Message, error) {
 	if len(data) == 0 {
 		return nil, errors.New("sip: empty message")
 	}
 
-	// Split into head and body at the blank line.
 	headEnd := bytes.Index(data, []byte("\r\n\r\n"))
 	var head, body []byte
 	if headEnd < 0 {
@@ -189,7 +240,6 @@ func Parse(data []byte) (*Message, error) {
 		body = data[headEnd+4:]
 	}
 
-	// Split head into lines.
 	lines := bytes.Split(head, []byte("\r\n"))
 	if len(lines) == 0 {
 		return nil, errors.New("sip: no start line")
@@ -201,35 +251,10 @@ func Parse(data []byte) (*Message, error) {
 	}
 
 	msg := &Message{}
-
-	// Determine if response or request.
-	if strings.HasPrefix(startLine, "SIP/2.0 ") {
-		// Response: "SIP/2.0 200 OK"
-		rest := startLine[8:] // after "SIP/2.0 "
-		spaceIdx := strings.IndexByte(rest, ' ')
-		if spaceIdx < 0 {
-			return nil, errors.New("sip: malformed status line")
-		}
-		code, err := strconv.Atoi(rest[:spaceIdx])
-		if err != nil {
-			return nil, errors.New("sip: invalid status code")
-		}
-		msg.StatusCode = code
-		msg.Reason = rest[spaceIdx+1:]
-	} else {
-		// Request: "INVITE sip:1002@pbx.local SIP/2.0"
-		parts := strings.SplitN(startLine, " ", 3)
-		if len(parts) < 3 {
-			return nil, errors.New("sip: malformed request line")
-		}
-		if parts[2] != "SIP/2.0" {
-			return nil, errors.New("sip: malformed request line")
-		}
-		msg.Method = parts[0]
-		msg.RequestURI = parts[1]
+	if err := parseStartLine(msg, startLine); err != nil {
+		return nil, err
 	}
 
-	// Parse headers.
 	for _, line := range lines[1:] {
 		s := string(line)
 		if s == "" {
@@ -239,26 +264,14 @@ func Parse(data []byte) (*Message, error) {
 		if colonIdx < 0 {
 			continue
 		}
-		name := s[:colonIdx]
-		value := strings.TrimSpace(s[colonIdx+1:])
-		msg.headers = append(msg.headers, header{Name: name, Value: value})
+		msg.headers = append(msg.headers, header{
+			Name:  s[:colonIdx],
+			Value: strings.TrimSpace(s[colonIdx+1:]),
+		})
 	}
 
-	// Body: use Content-Length if present, otherwise use remaining data.
-	if headEnd >= 0 && len(body) > 0 {
-		clStr := msg.Header("Content-Length")
-		if clStr != "" {
-			cl, err := strconv.Atoi(clStr)
-			if err == nil && cl > 0 && cl <= len(body) {
-				msg.Body = body[:cl]
-			} else if cl == 0 {
-				// Explicit zero-length body.
-			} else {
-				msg.Body = body
-			}
-		} else {
-			msg.Body = body
-		}
+	if headEnd >= 0 {
+		extractBody(msg, body)
 	}
 
 	return msg, nil

--- a/media.go
+++ b/media.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pion/rtp"
 	"github.com/x-phone/xphone-go/internal/media"
 	"github.com/x-phone/xphone-go/internal/rtcp"
+	"github.com/x-phone/xphone-go/internal/srtp"
 	"github.com/x-phone/xphone-go/internal/stun"
 )
 
@@ -90,6 +91,80 @@ func randUint32() uint32 {
 	return binary.BigEndian.Uint32(b[:])
 }
 
+// sendRTP marshals an RTP packet, optionally SRTP-protects it, and writes it
+// to the network. Also records the packet for RTCP stats and test hooks.
+func (s *mediaStream) sendRTP(pkt *rtp.Packet, stats *rtcp.Stats, sentCh chan *rtp.Packet, conn net.PacketConn, dst net.Addr, srtpOut *srtp.Context) {
+	stats.RecordRTPSent(len(pkt.Payload), pkt.Timestamp)
+	if sentCh != nil {
+		sendDropOldest(sentCh, pkt)
+	}
+	if conn == nil || dst == nil {
+		return
+	}
+	data, err := pkt.Marshal()
+	if err != nil {
+		return
+	}
+	if srtpOut != nil {
+		data, err = srtpOut.Protect(data)
+		if err != nil {
+			return
+		}
+	}
+	conn.WriteTo(data, dst)
+}
+
+// handleRTCPSend builds and sends an RTCP Sender Report, optionally SRTCP-protected.
+func handleRTCPSend(ssrc uint32, stats *rtcp.Stats, conn net.PacketConn, dst net.Addr, srtcpOut *srtp.Context) {
+	if conn == nil || dst == nil {
+		return
+	}
+	sr := rtcp.BuildSR(ssrc, stats)
+	if srtcpOut != nil {
+		var err error
+		sr, err = srtcpOut.ProtectRTCP(sr)
+		if err != nil {
+			return
+		}
+	}
+	conn.WriteTo(sr, dst)
+}
+
+// handleRTCPReceive decrypts (if SRTCP) and processes an inbound RTCP packet.
+func handleRTCPReceive(data []byte, stats *rtcp.Stats, srtcpIn *srtp.Context) {
+	if srtcpIn != nil {
+		var err error
+		data, err = srtcpIn.UnprotectRTCP(data)
+		if err != nil {
+			return
+		}
+	}
+	if pkt := rtcp.Parse(data); pkt != nil && pkt.IsSenderReport() {
+		stats.ProcessIncomingSR(pkt.NTPSec, pkt.NTPFrac)
+	}
+}
+
+// handleDTMF processes an inbound DTMF RTP packet (PT=101), deduplicating
+// end events by timestamp and dispatching to the onDTMF callback.
+func (s *mediaStream) handleDTMF(pkt *rtp.Packet) {
+	c := s.call
+	ev := DecodeDTMF(pkt.Payload)
+	if ev == nil || !ev.End {
+		return
+	}
+	if s.lastDTMFSeen && pkt.Timestamp == s.lastDTMFTimestamp {
+		return
+	}
+	s.lastDTMFTimestamp = pkt.Timestamp
+	s.lastDTMFSeen = true
+	c.mu.Lock()
+	mode := c.dtmfMode
+	c.mu.Unlock()
+	if mode != DtmfSipInfo {
+		c.fireOnDTMF(ev.Digit)
+	}
+}
+
 // run is the media pipeline goroutine for a single stream.
 // It handles: inbound RTP demux, jitter buffer, DTMF interception, codec encode/decode,
 // outbound RTP forwarding, RTCP, and media timeout.
@@ -165,18 +240,8 @@ func (s *mediaStream) run(jb *media.JitterBuffer, cp media.CodecProcessor, rtpCl
 			}
 			sendDropOldest(c.rtpRawReader, clonePacket(pkt))
 
-			// DTMF dispatch: intercept PT=101 before jitter buffer.
 			if pkt.PayloadType == DTMFPayloadType {
-				if ev := DecodeDTMF(pkt.Payload); ev != nil && ev.End && !(s.lastDTMFSeen && pkt.Timestamp == s.lastDTMFTimestamp) {
-					s.lastDTMFTimestamp = pkt.Timestamp
-					s.lastDTMFSeen = true
-					c.mu.Lock()
-					mode := c.dtmfMode
-					c.mu.Unlock()
-					if mode != DtmfSipInfo {
-						c.fireOnDTMF(ev.Digit)
-					}
-				}
+				s.handleDTMF(pkt)
 				resetTimer(timeout)
 				continue
 			}
@@ -202,21 +267,7 @@ func (s *mediaStream) run(jb *media.JitterBuffer, cp media.CodecProcessor, rtpCl
 			if muted {
 				continue
 			}
-			rtcpStats.RecordRTPSent(len(pkt.Payload), pkt.Timestamp)
-			if c.sentRTP != nil {
-				sendDropOldest(c.sentRTP, pkt)
-			}
-			if conn != nil && dst != nil {
-				if data, err := pkt.Marshal(); err == nil {
-					if srtpOut != nil {
-						data, err = srtpOut.Protect(data)
-						if err != nil {
-							continue
-						}
-					}
-					conn.WriteTo(data, dst)
-				}
-			}
+			s.sendRTP(pkt, rtcpStats, c.sentRTP, conn, dst, srtpOut)
 
 		case pcmFrame := <-c.pcmWriter:
 			if s.rtpWriterUsed || cp == nil {
@@ -243,52 +294,19 @@ func (s *mediaStream) run(jb *media.JitterBuffer, cp media.CodecProcessor, rtpCl
 			}
 			s.outSeq++
 			s.outTimestamp += cp.SamplesPerFrame()
-			rtcpStats.RecordRTPSent(len(outPkt.Payload), outPkt.Timestamp)
-			if c.sentRTP != nil {
-				sendDropOldest(c.sentRTP, outPkt)
-			}
-			if conn != nil && dst != nil {
-				if data, err := outPkt.Marshal(); err == nil {
-					if srtpOut != nil {
-						data, err = srtpOut.Protect(data)
-						if err != nil {
-							continue
-						}
-					}
-					conn.WriteTo(data, dst)
-				}
-			}
+			s.sendRTP(outPkt, rtcpStats, c.sentRTP, conn, dst, srtpOut)
 
 		case <-rtcpTick:
-			if rtcpConn != nil && rtcpRemoteAddr != nil {
-				c.mu.Lock()
-				srtcpOut := c.srtpOut
-				c.mu.Unlock()
-				sr := rtcp.BuildSR(s.outSSRC, rtcpStats)
-				if srtcpOut != nil {
-					var err error
-					sr, err = srtcpOut.ProtectRTCP(sr)
-					if err != nil {
-						continue
-					}
-				}
-				rtcpConn.WriteTo(sr, rtcpRemoteAddr)
-			}
+			c.mu.Lock()
+			srtcpOut := c.srtpOut
+			c.mu.Unlock()
+			handleRTCPSend(s.outSSRC, rtcpStats, rtcpConn, rtcpRemoteAddr, srtcpOut)
 
 		case data := <-rtcpInbound:
 			c.mu.Lock()
 			srtcpIn := c.srtpIn
 			c.mu.Unlock()
-			if srtcpIn != nil {
-				var err error
-				data, err = srtcpIn.UnprotectRTCP(data)
-				if err != nil {
-					continue
-				}
-			}
-			if pkt := rtcp.Parse(data); pkt != nil && pkt.IsSenderReport() {
-				rtcpStats.ProcessIncomingSR(pkt.NTPSec, pkt.NTPFrac)
-			}
+			handleRTCPReceive(data, rtcpStats, srtcpIn)
 
 		case d := <-c.mediaTimerReset:
 			resetTimer(d)
@@ -564,21 +582,7 @@ func (s *mediaStream) runVideo() {
 				outPkt.Header.Marker = i == len(payloads)-1
 				outPkt.Payload = payload
 				s.outSeq++
-				rtcpStats.RecordRTPSent(len(payload), outPkt.Timestamp)
-				if c.videoSentRTP != nil {
-					sendDropOldest(c.videoSentRTP, clonePacket(&outPkt))
-				}
-				if conn != nil && dst != nil {
-					if data, err := outPkt.Marshal(); err == nil {
-						if srtpOut != nil {
-							data, err = srtpOut.Protect(data)
-							if err != nil {
-								continue
-							}
-						}
-						conn.WriteTo(data, dst)
-					}
-				}
+				s.sendRTP(clonePacket(&outPkt), rtcpStats, c.videoSentRTP, conn, dst, srtpOut)
 			}
 
 		case pkt := <-c.videoRTPWriter:
@@ -591,52 +595,19 @@ func (s *mediaStream) runVideo() {
 			if muted {
 				continue
 			}
-			rtcpStats.RecordRTPSent(len(pkt.Payload), pkt.Timestamp)
-			if c.videoSentRTP != nil {
-				sendDropOldest(c.videoSentRTP, pkt)
-			}
-			if conn != nil && dst != nil {
-				if data, err := pkt.Marshal(); err == nil {
-					if srtpOut != nil {
-						data, err = srtpOut.Protect(data)
-						if err != nil {
-							continue
-						}
-					}
-					conn.WriteTo(data, dst)
-				}
-			}
+			s.sendRTP(pkt, rtcpStats, c.videoSentRTP, conn, dst, srtpOut)
 
 		case <-rtcpTick:
-			if rtcpConn != nil && rtcpRemoteAddr != nil {
-				c.mu.Lock()
-				srtcpOut := c.videoSrtpOut
-				c.mu.Unlock()
-				sr := rtcp.BuildSR(s.outSSRC, rtcpStats)
-				if srtcpOut != nil {
-					var err error
-					sr, err = srtcpOut.ProtectRTCP(sr)
-					if err != nil {
-						continue
-					}
-				}
-				rtcpConn.WriteTo(sr, rtcpRemoteAddr)
-			}
+			c.mu.Lock()
+			srtcpOut := c.videoSrtpOut
+			c.mu.Unlock()
+			handleRTCPSend(s.outSSRC, rtcpStats, rtcpConn, rtcpRemoteAddr, srtcpOut)
 
 		case data := <-rtcpInbound:
 			c.mu.Lock()
 			srtcpIn := c.videoSrtpIn
 			c.mu.Unlock()
-			if srtcpIn != nil {
-				var err error
-				data, err = srtcpIn.UnprotectRTCP(data)
-				if err != nil {
-					continue
-				}
-			}
-			if pkt := rtcp.Parse(data); pkt != nil && pkt.IsSenderReport() {
-				rtcpStats.ProcessIncomingSR(pkt.NTPSec, pkt.NTPFrac)
-			}
+			handleRTCPReceive(data, rtcpStats, srtcpIn)
 		}
 	}
 }

--- a/sipua.go
+++ b/sipua.go
@@ -311,84 +311,140 @@ func (s *sipUA) dialOnce(ctx context.Context, target string, opts DialOptions, o
 	}, "", nil
 }
 
-// startServer registers sipgo server handlers for inbound SIP requests.
-// Must be called after onDialogInvite is set.
-func (s *sipUA) startServer() {
-	s.server.OnInvite(func(req *sip.Request, tx sip.ServerTransaction) {
-		sess, err := s.ds.ReadInvite(req, tx)
-		if err != nil {
+// waitDialogConfirmed waits until a sipgo dialog reaches Confirmed state,
+// then terminates the transaction to avoid sipgo's 32-second timer_l delay.
+func waitDialogConfirmed(sess *sipgo.DialogServerSession, tx sip.ServerTransaction) {
+	stateCh := sess.StateRead()
+	for state := range stateCh {
+		if state >= sip.DialogStateConfirmed {
+			break
+		}
+	}
+	tx.Terminate()
+}
+
+// handleInvite processes an inbound INVITE, dispatching re-INVITEs to existing
+// calls or creating new inbound call dialogs.
+func (s *sipUA) handleInvite(req *sip.Request, tx sip.ServerTransaction) {
+	sess, err := s.ds.ReadInvite(req, tx)
+	if err != nil {
+		return
+	}
+
+	callID := ""
+	if h := req.CallID(); h != nil {
+		callID = h.Value()
+	}
+	sdpBody := string(req.Body())
+
+	// Check if this is a re-INVITE for an existing call.
+	s.mu.Lock()
+	reInvFn := s.onDialogReInvite
+	s.mu.Unlock()
+	if reInvFn != nil && callID != "" {
+		responder := &sipgoDialogUAS{
+			dialogBase: dialogBase{sess: sess, invite: req},
+		}
+		if reInvFn(callID, responder, sdpBody) {
+			waitDialogConfirmed(sess, tx)
 			return
 		}
+	}
 
-		// Extract Call-ID and SDP body.
+	// Not a re-INVITE — handle as new INVITE.
+	sess.Respond(100, "Trying", nil)
+
+	from := ""
+	if f := req.From(); f != nil {
+		from = f.Address.String()
+	}
+	to := ""
+	if t := req.To(); t != nil {
+		to = t.Address.String()
+	}
+
+	dlg := &sipgoDialogUAS{
+		dialogBase: dialogBase{sess: sess, invite: req},
+	}
+
+	s.mu.Lock()
+	fn := s.onDialogInvite
+	s.mu.Unlock()
+	if fn != nil {
+		go fn(dlg, from, to, sdpBody)
+		waitDialogConfirmed(sess, tx)
+	}
+}
+
+// handleNotify processes an inbound NOTIFY, dispatching to MWI, REFER, or
+// general SUBSCRIBE/NOTIFY handlers.
+func (s *sipUA) handleNotify(req *sip.Request, tx sip.ServerTransaction) {
+	res := sip.NewResponseFromRequest(req, 200, "OK", nil)
+	tx.Respond(res)
+
+	ct := ""
+	if h := req.ContentType(); h != nil {
+		ct = h.Value()
+	}
+	mediaType := ct
+	if semi := strings.IndexByte(ct, ';'); semi >= 0 {
+		mediaType = ct[:semi]
+	}
+	mediaType = strings.TrimSpace(mediaType)
+
+	// MWI dispatch.
+	if strings.EqualFold(mediaType, contentTypeMWI) {
+		s.mu.Lock()
+		fn := s.onMWINotify
+		s.mu.Unlock()
+		if fn != nil {
+			go fn(string(req.Body()))
+		}
+		return
+	}
+
+	// REFER progress (message/sipfrag).
+	code := parseSipfragStatus(string(req.Body()))
+	if code > 0 {
 		callID := ""
 		if h := req.CallID(); h != nil {
 			callID = h.Value()
 		}
-		sdpBody := string(req.Body())
-
-		// Check if this is a re-INVITE for an existing call.
 		s.mu.Lock()
-		reInvFn := s.onDialogReInvite
+		fn := s.onDialogNotify
 		s.mu.Unlock()
-		if reInvFn != nil && callID != "" {
-			responder := &sipgoDialogUAS{
-				dialogBase: dialogBase{sess: sess, invite: req},
-			}
-			if reInvFn(callID, responder, sdpBody) {
-				// Re-INVITE handled — wait for confirmed state.
-				stateCh := sess.StateRead()
-				for state := range stateCh {
-					if state >= sip.DialogStateConfirmed {
-						break
-					}
-				}
-				tx.Terminate()
-				return
-			}
+		if fn != nil && callID != "" {
+			go fn(callID, code)
 		}
+		return
+	}
 
-		// Not a re-INVITE — handle as new INVITE.
-		// Send 100 Trying immediately to stop INVITE retransmissions.
-		sess.Respond(100, "Trying", nil)
-
-		// Extract From/To.
+	// General NOTIFY dispatch (for SubscriptionManager).
+	s.mu.Lock()
+	generalFn := s.onNotify
+	s.mu.Unlock()
+	if generalFn != nil {
 		from := ""
 		if f := req.From(); f != nil {
 			from = f.Address.String()
 		}
-		to := ""
-		if t := req.To(); t != nil {
-			to = t.Address.String()
+		event := ""
+		if h := req.GetHeader("Event"); h != nil {
+			event = h.Value()
 		}
-
-		dlg := &sipgoDialogUAS{
-			dialogBase: dialogBase{
-				sess:   sess,
-				invite: req,
-			},
+		subState := ""
+		if h := req.GetHeader("Subscription-State"); h != nil {
+			subState = h.Value()
 		}
+		go generalFn(event, from, ct, string(req.Body()), subState)
+	}
+}
 
-		s.mu.Lock()
-		fn := s.onDialogInvite
-		s.mu.Unlock()
-		if fn != nil {
-			// Dispatch call handling in a goroutine so the user's OnIncoming
-			// callback isn't blocked by the SIP server handler.
-			go fn(dlg, from, to, sdpBody)
-
-			// Wait until the dialog reaches Confirmed (ACK received after 200 OK)
-			// or Ended. sipgo's Server calls tx.TerminateGracefully() after this
-			// handler returns. For UDP, that blocks for timer_l (32s). By waiting
-			// for Confirmed and then calling tx.Terminate(), we avoid the delay.
-			stateCh := sess.StateRead()
-			for state := range stateCh {
-				if state >= sip.DialogStateConfirmed {
-					break
-				}
-			}
-			tx.Terminate()
-		}
+// startServer registers sipgo server handlers for inbound SIP requests.
+// Must be called after onDialogInvite is set.
+func (s *sipUA) startServer() {
+	s.server.OnInvite(func(req *sip.Request, tx sip.ServerTransaction) {
+		s.handleInvite(req, tx)
 	})
 
 	s.server.OnAck(func(req *sip.Request, tx sip.ServerTransaction) {
@@ -475,69 +531,7 @@ func (s *sipUA) startServer() {
 	})
 
 	s.server.OnNotify(func(req *sip.Request, tx sip.ServerTransaction) {
-		// Always respond 200 OK to NOTIFY.
-		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
-		tx.Respond(res)
-
-		// Extract common headers for dispatch.
-		ct := ""
-		if h := req.ContentType(); h != nil {
-			ct = h.Value()
-		}
-		mediaType := ct
-		if semi := strings.IndexByte(ct, ';'); semi >= 0 {
-			mediaType = ct[:semi]
-		}
-		mediaType = strings.TrimSpace(mediaType)
-
-		event := ""
-		if h := req.GetHeader("Event"); h != nil {
-			event = h.Value()
-		}
-
-		// MWI dispatch (legacy dedicated handler).
-		if strings.EqualFold(mediaType, contentTypeMWI) {
-			s.mu.Lock()
-			fn := s.onMWINotify
-			s.mu.Unlock()
-			if fn != nil {
-				go fn(string(req.Body()))
-			}
-			return
-		}
-
-		// REFER progress (message/sipfrag) — parse status code and dispatch.
-		code := parseSipfragStatus(string(req.Body()))
-		if code > 0 {
-			callID := ""
-			if h := req.CallID(); h != nil {
-				callID = h.Value()
-			}
-			s.mu.Lock()
-			fn := s.onDialogNotify
-			s.mu.Unlock()
-			if fn != nil && callID != "" {
-				go fn(callID, code)
-			}
-			return
-		}
-
-		// General NOTIFY dispatch (for SubscriptionManager).
-		// Only reached for non-MWI, non-REFER NOTIFYs.
-		s.mu.Lock()
-		generalFn := s.onNotify
-		s.mu.Unlock()
-		if generalFn != nil {
-			from := ""
-			if f := req.From(); f != nil {
-				from = f.Address.String()
-			}
-			subState := ""
-			if h := req.GetHeader("Subscription-State"); h != nil {
-				subState = h.Value()
-			}
-			go generalFn(event, from, ct, string(req.Body()), subState)
-		}
+		s.handleNotify(req, tx)
 	})
 
 	s.server.OnMessage(func(req *sip.Request, tx sip.ServerTransaction) {


### PR DESCRIPTION
## Summary
- Extract helpers from `(*mediaStream).run()` (58→26): `sendRTP`, `handleDTMF`, `handleRTCPSend`, `handleRTCPReceive` — also eliminates duplication between audio and video pipelines
- Extract `parseAttribute` and `parseMediaLine` from `sdp.Parse()` (22→10)
- Extract `parseStartLine` and `extractBody` from `sip.Parse()` (20→8)
- Extract `handleInvite`, `handleNotify`, `waitDialogConfirmed` from `sipUA.startServer()`

Addresses all four gocyclo warnings on [Go Report Card](https://goreportcard.com/report/github.com/x-phone/xphone-go).

## Test plan
- [x] `make check` passes (fmt, build, test, vet, race)
- [ ] Re-run Go Report Card after merge