### PR TITLE
Include listening port in server-mode SIP Contact header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Separate outbound credentials: `WithOutboundCredentials("trunk-user", "trunk-pass")` for INVITE auth
 - `WithHeader()` / `DialOptions.CustomHeaders` now applied to outbound INVITEs (previously ignored)
 
+### Bug fixes
+- Server mode: include listening port in SIP Contact header — fixes ACK routing to non-default ports (e.g., 5080)
+
 ## v0.4.1
 
 ### Bug fixes

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -364,8 +365,14 @@ func (s *server) setupSipStack() error {
 		return fmt.Errorf("xphone: server create server: %w", err)
 	}
 
+	contactPort := 0
+	if _, p, err := net.SplitHostPort(s.cfg.Listen); err == nil {
+		if pn, err := strconv.Atoi(p); err == nil && pn != sip.DefaultUdpPort {
+			contactPort = pn
+		}
+	}
 	contactHDR := sip.ContactHeader{
-		Address: sip.Uri{Scheme: "sip", Host: s.localIP},
+		Address: sip.Uri{Scheme: "sip", Host: s.localIP, Port: contactPort},
 	}
 	dc := sipgo.NewDialogClientCache(client, contactHDR)
 	ds := sipgo.NewDialogServerCache(client, contactHDR)


### PR DESCRIPTION
## Summary

- Include the listening port in the SIP Contact header when the server listens on a non-default port (not 5060)

## Root Cause

`setupSipStack()` constructed the Contact header with only the IP, omitting the port:
```go
contactHDR := sip.ContactHeader{
    Address: sip.Uri{Scheme: "sip", Host: s.localIP},
}
```

When listening on port 5080, responses contained `Contact: <sip:66.175.215.97>`. Per RFC 3261 §19.1.1, the remote peer (Twilio) sent ACK to the default port 5060, which never reached the server on 5080. sipgo retransmitted the 200 OK for 32 seconds (64*T1) waiting for the ACK, then timed out.

## Test plan

- [x] `make check` passes (fmt, build, test, vet, race)
- [x] Verified on production Linux with Twilio — ACK arrives, call completes instantly

Closes #46