### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Separate outbound credentials: `WithOutboundCredentials("trunk-user", "trunk-pass")` for INVITE auth
 - `WithHeader()` / `DialOptions.CustomHeaders` now applied to outbound INVITEs (previously ignored)
 
+## v0.4.2
+
 ### Bug fixes
 - Server mode: include listening port in SIP Contact header — fixes ACK routing to non-default ports (e.g., 5080)
 


### PR DESCRIPTION
## Summary

- Move Contact header port fix from Unreleased to v0.4.2 changelog section

## Changes in v0.4.2

- Server mode: include listening port in SIP Contact header — fixes ACK routing to non-default ports (e.g., 5080)