### PR TITLE
Deduplicate shared logic, fix server video SRTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 - Separate outbound credentials: `WithOutboundCredentials("trunk-user", "trunk-pass")` for INVITE auth
 - `WithHeader()` / `DialOptions.CustomHeaders` now applied to outbound INVITEs (previously ignored)
 
+### Bug fixes
+- Server mode: SRTP now covers video streams (previously only audio contexts were initialized)
+- `hasURIParam` is now case-insensitive per RFC 3261 §19.1.1
+
+### Internal
+- Extract `mediaStream.reset()` to deduplicate field-reset blocks in `startMedia`/`startVideoMedia`
+- Extract `startRTCPReader()` helper from duplicated RTCP reader goroutines in audio/video pipelines
+- Extract `startRTPReaderFor()` to unify `startRTPReader`/`startVideoRTPReader` (~40 lines deduped)
+- Extract `wireCallCallbacks()` free function shared by phone and server modes
+- Extract `extractHostPort()` to unify `normalizeHost`/`normalizePeerHost`
+- Unify `setupSRTP` as a `call` method shared by phone and server modes
+
 ## v0.4.2
 
 ### Bug fixes

--- a/call.go
+++ b/call.go
@@ -241,6 +241,64 @@ type call struct {
 	closeVideoChOnce  sync.Once        // ensures video output channels are closed exactly once
 }
 
+// wireCallCallbacks hooks phone/server-level callbacks (OnCallState, OnCallEnded,
+// OnCallDTMF) onto a call's internal callback fields. The Call interface is
+// captured via closure so the callback receives the correct public type.
+func wireCallCallbacks(c *call, onState func(Call, CallState), onEnded func(Call, EndReason), onDTMF func(Call, string)) {
+	if onState != nil {
+		fn := onState
+		c.onStatePhone = func(state CallState) { fn(c, state) }
+	}
+	if onEnded != nil {
+		fn := onEnded
+		c.onEndedPhone = func(reason EndReason) { fn(c, reason) }
+	}
+	if onDTMF != nil {
+		fn := onDTMF
+		c.onDTMFPhone = func(digit string) { fn(c, digit) }
+	}
+}
+
+// setupSRTP initializes SRTP contexts on a call.
+// Audio and video get separate contexts because srtp.Context has mutable state
+// (ROC, sequence tracking, HMAC) that would corrupt under concurrent access.
+func (c *call) setupSRTP(logger *slog.Logger, localKey, remoteKey string) {
+	outCtx, err := srtp.FromSDESInline(localKey)
+	if err != nil {
+		logger.Error("SRTP outbound context setup failed", "err", err)
+		return
+	}
+	inCtx, err := srtp.FromSDESInline(remoteKey)
+	if err != nil {
+		logger.Error("SRTP inbound context setup failed", "err", err)
+		return
+	}
+	c.mu.Lock()
+	c.srtpLocalKey = localKey
+	c.srtpOut = outCtx
+	c.srtpIn = inCtx
+	hasVideo := c.hasVideo
+	c.mu.Unlock()
+
+	if hasVideo {
+		videoOutCtx, err := srtp.FromSDESInline(localKey)
+		if err != nil {
+			logger.Error("SRTP video outbound context setup failed", "err", err)
+			return
+		}
+		videoInCtx, err := srtp.FromSDESInline(remoteKey)
+		if err != nil {
+			logger.Error("SRTP video inbound context setup failed", "err", err)
+			return
+		}
+		c.mu.Lock()
+		c.videoSrtpOut = videoOutCtx
+		c.videoSrtpIn = videoInCtx
+		c.mu.Unlock()
+	}
+	logger.Info("SRTP enabled for call", "id", c.id)
+}
+
 func newInboundCall(d dialog) *call {
 	c := &call{
 		id:             newCallID(),

--- a/media.go
+++ b/media.go
@@ -54,6 +54,25 @@ type mediaStream struct {
 	rtcpSendErrCount  int
 }
 
+// reset zeroes all goroutine-local pipeline state on a mediaStream.
+// Must be called (with c.mu held) before launching run/runVideo.
+func (s *mediaStream) reset(conn net.PacketConn, rtcpConn net.PacketConn, rtcpRemoteAddr net.Addr, done chan struct{}) {
+	s.conn = conn
+	s.rtcpConn = rtcpConn
+	s.rtcpRemoteAddr = rtcpRemoteAddr
+	s.done = done
+	s.outSeq = 0
+	s.outTimestamp = 0
+	s.rtpWriterUsed = false
+	s.inboundCount = 0
+	s.lastDTMFTimestamp = 0
+	s.lastDTMFSeen = false
+	s.sendErrLogged = false
+	s.rtcpSendErrLogged = false
+	s.sendErrCount = 0
+	s.rtcpSendErrCount = 0
+}
+
 // clonePacket returns a deep copy of an RTP packet so taps are independent.
 func clonePacket(pkt *rtp.Packet) *rtp.Packet {
 	clone := &rtp.Packet{Header: pkt.Header}
@@ -242,6 +261,34 @@ func (s *mediaStream) handleDTMF(pkt *rtp.Packet) {
 	}
 }
 
+// startRTCPReader launches a goroutine that reads RTCP packets from conn and
+// feeds them into the returned channel. The goroutine exits when conn is closed.
+func startRTCPReader(conn net.PacketConn) <-chan []byte {
+	ch := make(chan []byte, 16)
+	if conn == nil {
+		return ch
+	}
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, _, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			if n < 8 {
+				continue
+			}
+			cp := make([]byte, n)
+			copy(cp, buf[:n])
+			select {
+			case ch <- cp:
+			default:
+			}
+		}
+	}()
+	return ch
+}
+
 // run is the media pipeline goroutine for a single stream.
 // It handles: inbound RTP demux, jitter buffer, DTMF interception, codec encode/decode,
 // outbound RTP forwarding, RTCP, and media timeout.
@@ -270,28 +317,7 @@ func (s *mediaStream) run(jb *media.JitterBuffer, cp media.CodecProcessor, rtpCl
 		defer rtcpTicker.Stop()
 	}
 
-	// RTCP reader goroutine.
-	rtcpInbound := make(chan []byte, 16)
-	if rtcpConn != nil {
-		go func() {
-			buf := make([]byte, 1500)
-			for {
-				n, _, err := rtcpConn.ReadFrom(buf)
-				if err != nil {
-					return
-				}
-				if n < 8 {
-					continue
-				}
-				cp := make([]byte, n)
-				copy(cp, buf[:n])
-				select {
-				case rtcpInbound <- cp:
-				default:
-				}
-			}
-		}()
-	}
+	rtcpInbound := startRTCPReader(rtcpConn)
 
 	resetTimer := func(d time.Duration) {
 		if !mediaTimer.Stop() {
@@ -428,17 +454,17 @@ func (s *mediaStream) run(jb *media.JitterBuffer, cp media.CodecProcessor, rtpCl
 	}
 }
 
-// startRTPReader launches a goroutine that reads RTP packets from the
-// network socket (rtpConn) and feeds them into the media pipeline's
-// rtpInbound channel. The goroutine exits when rtpConn is closed.
-func (c *call) startRTPReader() {
-	c.mu.Lock()
-	conn := c.rtpConn
-	iceAgent := c.iceAgent // immutable after call setup
-	c.mu.Unlock()
+// startRTPReaderFor launches a goroutine that reads RTP packets from conn,
+// decrypts with the SRTP context returned by getSRTP (re-read each packet to
+// handle re-INVITE key changes), and feeds parsed packets into dest.
+// The goroutine exits when conn is closed.
+func (c *call) startRTPReaderFor(conn net.PacketConn, getSRTP func() *srtp.Context, dest chan *rtp.Packet) {
 	if conn == nil {
 		return
 	}
+	c.mu.Lock()
+	iceAgent := c.iceAgent // immutable after call setup
+	c.mu.Unlock()
 
 	go func() {
 		buf := make([]byte, 1500)
@@ -447,7 +473,6 @@ func (c *call) startRTPReader() {
 			if err != nil {
 				return // socket closed
 			}
-			// Copy before unmarshal since we reuse the read buffer.
 			cp := make([]byte, n)
 			copy(cp, buf[:n])
 
@@ -455,14 +480,10 @@ func (c *call) startRTPReader() {
 				continue
 			}
 
-			// Re-read srtpIn each iteration so a re-INVITE key change takes effect.
-			c.mu.Lock()
-			srtpIn := c.srtpIn
-			c.mu.Unlock()
-			if srtpIn != nil {
+			if srtpIn := getSRTP(); srtpIn != nil {
 				cp, err = srtpIn.Unprotect(cp)
 				if err != nil {
-					continue // auth failed or malformed — drop
+					continue
 				}
 			}
 
@@ -470,9 +491,21 @@ func (c *call) startRTPReader() {
 			if err := pkt.Unmarshal(cp); err != nil {
 				continue
 			}
-			sendDropOldest(c.rtpInbound, pkt)
+			sendDropOldest(dest, pkt)
 		}
 	}()
+}
+
+// startRTPReader launches the audio RTP reader goroutine.
+func (c *call) startRTPReader() {
+	c.mu.Lock()
+	conn := c.rtpConn
+	c.mu.Unlock()
+	c.startRTPReaderFor(conn, func() *srtp.Context {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.srtpIn
+	}, c.rtpInbound)
 }
 
 // startMedia initializes the media pipeline (jitter buffer, RTP demux,
@@ -518,22 +551,8 @@ func (c *call) startMedia() {
 	}
 
 	s := c.audioStream
-	// Set pipeline config on stream and reset goroutine-local state.
+	s.reset(conn, rtcpConn, rtcpRemoteAddr, done)
 	s.timeout = timeout
-	s.conn = conn
-	s.rtcpConn = rtcpConn
-	s.rtcpRemoteAddr = rtcpRemoteAddr
-	s.done = done
-	s.outSeq = 0
-	s.outTimestamp = 0
-	s.rtpWriterUsed = false
-	s.inboundCount = 0
-	s.lastDTMFTimestamp = 0
-	s.lastDTMFSeen = false
-	s.sendErrLogged = false
-	s.rtcpSendErrLogged = false
-	s.sendErrCount = 0
-	s.rtcpSendErrCount = 0
 	c.mu.Unlock()
 
 	jb := media.NewJitterBuffer(jitterDepth)
@@ -607,28 +626,7 @@ func (s *mediaStream) runVideo() {
 		defer rtcpTicker.Stop()
 	}
 
-	// RTCP reader goroutine.
-	rtcpInbound := make(chan []byte, 16)
-	if rtcpConn != nil {
-		go func() {
-			buf := make([]byte, 1500)
-			for {
-				n, _, err := rtcpConn.ReadFrom(buf)
-				if err != nil {
-					return
-				}
-				if n < 8 {
-					continue
-				}
-				cp := make([]byte, n)
-				copy(cp, buf[:n])
-				select {
-				case rtcpInbound <- cp:
-				default:
-				}
-			}
-		}()
-	}
+	rtcpInbound := startRTCPReader(rtcpConn)
 
 	for {
 		select {
@@ -745,18 +743,7 @@ func (c *call) startVideoMedia() {
 	}
 
 	s := c.videoStream
-	s.conn = conn
-	s.rtcpConn = c.videoRTCPConn
-	s.rtcpRemoteAddr = rtcpRemoteAddr
-	s.done = done
-	s.outSeq = 0
-	s.outTimestamp = 0
-	s.rtpWriterUsed = false
-	s.inboundCount = 0
-	s.sendErrLogged = false
-	s.rtcpSendErrLogged = false
-	s.sendErrCount = 0
-	s.rtcpSendErrCount = 0
+	s.reset(conn, c.videoRTCPConn, rtcpRemoteAddr, done)
 	videoFn := c.onVideoFn
 	c.videoWg.Add(1) // must be under lock so stopVideoPipeline.Wait() can't race
 	c.mu.Unlock()
@@ -775,43 +762,12 @@ func (c *call) startVideoMedia() {
 func (c *call) startVideoRTPReader() {
 	c.mu.Lock()
 	conn := c.videoRTPConn
-	iceAgent := c.iceAgent // immutable after call setup
 	c.mu.Unlock()
-	if conn == nil {
-		return
-	}
-
-	go func() {
-		buf := make([]byte, 1500)
-		for {
-			n, from, err := conn.ReadFrom(buf)
-			if err != nil {
-				return // socket closed
-			}
-			cp := make([]byte, n)
-			copy(cp, buf[:n])
-
-			if handleSTUNDemux(conn, iceAgent, cp, from, c.logger, c.id) {
-				continue
-			}
-
-			c.mu.Lock()
-			srtpIn := c.videoSrtpIn
-			c.mu.Unlock()
-			if srtpIn != nil {
-				cp, err = srtpIn.Unprotect(cp)
-				if err != nil {
-					continue
-				}
-			}
-
-			pkt := &rtp.Packet{}
-			if err := pkt.Unmarshal(cp); err != nil {
-				continue
-			}
-			sendDropOldest(c.videoRTPInbound, pkt)
-		}
-	}()
+	c.startRTPReaderFor(conn, func() *srtp.Context {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.videoSrtpIn
+	}, c.videoRTPInbound)
 }
 
 // stopMedia tears down the media pipeline and releases RTP ports.

--- a/options.go
+++ b/options.go
@@ -181,42 +181,48 @@ func New(opts ...PhoneOption) Phone {
 	return newPhone(cfg)
 }
 
-// hasURIParam checks if a SIP URI contains a specific parameter.
-// Matches ";param" at end of string or followed by ";", ">", or "?".
+// hasURIParam checks if a SIP URI contains a specific parameter (case-insensitive
+// per RFC 3261 §19.1.1). Matches ";param" at end of string or followed by ";", ">", or "?".
 func hasURIParam(uri, param string) bool {
-	target := ";" + param
-	idx := strings.Index(uri, target)
+	lower := strings.ToLower(uri)
+	target := ";" + strings.ToLower(param)
+	idx := strings.Index(lower, target)
 	if idx < 0 {
 		return false
 	}
 	end := idx + len(target)
-	if end == len(uri) {
-		return true // ";param" at end of string
+	if end == len(lower) {
+		return true
 	}
-	next := uri[end]
+	next := lower[end]
 	return next == ';' || next == '>' || next == '?'
+}
+
+// extractHostPort splits an embedded "host:port" string into separate host and
+// port values. If the port is valid and *port is still zero, it is set.
+// The host string is always updated if splitting succeeds.
+func extractHostPort(host *string, port *int) {
+	if *host == "" {
+		return
+	}
+	h, portStr, err := net.SplitHostPort(*host)
+	if err != nil {
+		return
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil || p <= 0 || p > 65535 {
+		return
+	}
+	*host = h
+	if *port == 0 {
+		*port = p
+	}
 }
 
 // normalizeHost splits an embedded port from cfg.Host (e.g. "10.0.0.7:5060")
 // into the separate Host and Port fields. Only applies when Port is still at
 // the zero value — an explicit Port setting takes precedence.
-func normalizeHost(cfg *Config) {
-	if cfg.Host == "" {
-		return
-	}
-	host, portStr, err := net.SplitHostPort(cfg.Host)
-	if err != nil {
-		return // no embedded port — leave unchanged
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil || port <= 0 || port > 65535 {
-		return // invalid port — leave unchanged
-	}
-	cfg.Host = host
-	if cfg.Port == 0 {
-		cfg.Port = port
-	}
-}
+func normalizeHost(cfg *Config) { extractHostPort(&cfg.Host, &cfg.Port) }
 
 // applyDefaults fills zero-value Config fields with sensible defaults.
 func applyDefaults(cfg *Config) {
@@ -458,25 +464,8 @@ type PeerAuthConfig struct {
 	Password string
 }
 
-// normalizePeerHost splits an embedded port from PeerConfig.Host (e.g. "10.0.0.1:5080")
-// into the separate Host and Port fields. Same logic as normalizeHost for Config.
-func normalizePeerHost(p *PeerConfig) {
-	if p.Host == "" {
-		return
-	}
-	host, portStr, err := net.SplitHostPort(p.Host)
-	if err != nil {
-		return
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil || port <= 0 || port > 65535 {
-		return
-	}
-	p.Host = host
-	if p.Port == 0 {
-		p.Port = port
-	}
-}
+// normalizePeerHost splits an embedded port from PeerConfig.Host.
+func normalizePeerHost(p *PeerConfig) { extractHostPort(&p.Host, &p.Port) }
 
 // applyServerDefaults fills zero-value ServerConfig fields with sensible defaults.
 func applyServerDefaults(cfg *ServerConfig) {

--- a/phone_test.go
+++ b/phone_test.go
@@ -167,6 +167,15 @@ func TestWithOutboundProxy_AlreadyHasLR(t *testing.T) {
 	assert.Equal(t, "sip:proxy.example.com:5060;lr", p.cfg.OutboundProxy)
 }
 
+func TestWithOutboundProxy_CaseInsensitiveLR(t *testing.T) {
+	p := New(
+		WithCredentials("1001", "secret", "pbx.example.com"),
+		WithOutboundProxy("sip:proxy.example.com:5060;LR"),
+	).(*phone)
+	// RFC 3261 §19.1.1: URI parameters are case-insensitive.
+	assert.Equal(t, "sip:proxy.example.com:5060;LR", p.cfg.OutboundProxy)
+}
+
 func TestWithOutboundProxy_LRNotConfusedByPrefix(t *testing.T) {
 	p := New(
 		WithCredentials("1001", "secret", "pbx.example.com"),

--- a/server.go
+++ b/server.go
@@ -862,18 +862,7 @@ func (s *server) findCall(callID string) *call {
 
 // wireCallCallbacks hooks server-level callbacks onto a call. Must be called with s.mu held.
 func (s *server) wireCallCallbacks(c *call) {
-	if s.onCallStateFn != nil {
-		fn := s.onCallStateFn
-		c.onStatePhone = func(state CallState) { fn(c, state) }
-	}
-	if s.onCallEndedFn != nil {
-		fn := s.onCallEndedFn
-		c.onEndedPhone = func(reason EndReason) { fn(c, reason) }
-	}
-	if s.onCallDTMFFn != nil {
-		fn := s.onCallDTMFFn
-		c.onDTMFPhone = func(digit string) { fn(c, digit) }
-	}
+	wireCallCallbacks(c, s.onCallStateFn, s.onCallEndedFn, s.onCallDTMFFn)
 }
 
 // applyCallConfig threads server-level config into a new call.
@@ -885,24 +874,9 @@ func (s *server) applyCallConfig(c *call) {
 	c.dtmfMode = s.cfg.DtmfMode
 }
 
-// setupSRTP initializes SRTP contexts on a call (same as phone.setupSRTP).
+// setupSRTP is a convenience wrapper calling call.setupSRTP with the server logger.
 func (s *server) setupSRTP(c *call, localKey, remoteKey string) {
-	outCtx, err := srtp.FromSDESInline(localKey)
-	if err != nil {
-		s.logger.Error("SRTP outbound context setup failed", "err", err)
-		return
-	}
-	inCtx, err := srtp.FromSDESInline(remoteKey)
-	if err != nil {
-		s.logger.Error("SRTP inbound context setup failed", "err", err)
-		return
-	}
-	c.mu.Lock()
-	c.srtpLocalKey = localKey
-	c.srtpOut = outCtx
-	c.srtpIn = inCtx
-	c.mu.Unlock()
-	s.logger.Info("SRTP enabled for call", "id", c.id)
+	c.setupSRTP(s.logger, localKey, remoteKey)
 }
 
 // runReaper periodically cleans up stale calls that never completed setup

--- a/xphone.go
+++ b/xphone.go
@@ -115,61 +115,12 @@ func newPhone(cfg Config) *phone {
 // OnCallDTMF) onto a call's internal callback fields so they coexist with
 // user-set per-call callbacks. Must be called with p.mu held.
 func (p *phone) wireCallCallbacks(c *call) {
-	if p.onCallStateFn != nil {
-		fn := p.onCallStateFn
-		c.onStatePhone = func(state CallState) { fn(c, state) }
-	}
-	if p.onCallEndedFn != nil {
-		fn := p.onCallEndedFn
-		c.onEndedPhone = func(reason EndReason) { fn(c, reason) }
-	}
-	if p.onCallDTMFFn != nil {
-		fn := p.onCallDTMFFn
-		c.onDTMFPhone = func(digit string) { fn(c, digit) }
-	}
+	wireCallCallbacks(c, p.onCallStateFn, p.onCallEndedFn, p.onCallDTMFFn)
 }
 
-// setupSRTP initializes SRTP contexts on a call.
-// localKey is the base64 inline key for outbound encryption.
-// remoteKey is the base64 inline key from the remote SDP for inbound decryption.
-// Audio and video get separate contexts because srtp.Context has mutable state
-// (ROC, sequence tracking, HMAC) that would corrupt under concurrent access.
+// setupSRTP is a convenience wrapper calling call.setupSRTP with the phone logger.
 func (p *phone) setupSRTP(c *call, localKey, remoteKey string) {
-	outCtx, err := srtp.FromSDESInline(localKey)
-	if err != nil {
-		p.logger.Error("SRTP outbound context setup failed", "err", err)
-		return
-	}
-	inCtx, err := srtp.FromSDESInline(remoteKey)
-	if err != nil {
-		p.logger.Error("SRTP inbound context setup failed", "err", err)
-		return
-	}
-	c.mu.Lock()
-	c.srtpLocalKey = localKey
-	c.srtpOut = outCtx
-	c.srtpIn = inCtx
-	hasVideo := c.hasVideo
-	c.mu.Unlock()
-
-	// Video needs its own contexts — independent ROC/seq/HMAC state.
-	if hasVideo {
-		videoOutCtx, err := srtp.FromSDESInline(localKey)
-		if err != nil {
-			p.logger.Error("SRTP video outbound context setup failed", "err", err)
-			return
-		}
-		videoInCtx, err := srtp.FromSDESInline(remoteKey)
-		if err != nil {
-			p.logger.Error("SRTP video inbound context setup failed", "err", err)
-			return
-		}
-		c.mu.Lock()
-		c.videoSrtpOut = videoOutCtx
-		c.videoSrtpIn = videoInCtx
-		c.mu.Unlock()
-	}
-	p.logger.Info("SRTP enabled for call", "id", c.id)
+	c.setupSRTP(p.logger, localKey, remoteKey)
 }
 
 // applyCallConfig threads phone-level config into a new call.


### PR DESCRIPTION
## Summary

- Extract 6 shared helpers to eliminate ~120 lines of copy-pasted code across phone/server and audio/video paths
- Fix server-mode video SRTP: `setupSRTP` was missing video context initialization (diverged copy from phone path)
- Fix `hasURIParam` case sensitivity: SIP URI params are case-insensitive per RFC 3261 §19.1.1

## Changes

| Helper | Replaces | Lines saved |
|--------|----------|-------------|
| `mediaStream.reset()` | Field-reset blocks in `startMedia`/`startVideoMedia` | ~15 |
| `startRTCPReader()` | Identical RTCP reader goroutines in `run`/`runVideo` | ~20 |
| `startRTPReaderFor()` | `startRTPReader`/`startVideoRTPReader` | ~30 |
| `wireCallCallbacks()` | Identical methods on `phone` and `server` | ~20 |
| `extractHostPort()` | `normalizeHost`/`normalizePeerHost` | ~15 |
| `call.setupSRTP()` | Diverged methods on `phone` and `server` | ~20 |

## Test plan

- [x] `make check` passes (fmt, build, test, vet, race)
- [x] New test: `TestWithOutboundProxy_CaseInsensitiveLR` verifies RFC 3261 compliance
- [x] All existing tests pass — pure refactor with no behavioral change (except video SRTP bug fix)