### PR TITLE
Add ReplaceAudioWriter for clean audio source swapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features
+- `ReplaceAudioWriter(newSrc <-chan []int16)` atomically swaps the audio input channel on an active call — enables in-app music on hold without audio bleed (#58)
 - Outbound proxy support: `WithOutboundProxy("sip:proxy.example.com:5060")` routes INVITEs through a proxy
 - Separate outbound credentials: `WithOutboundCredentials("trunk-user", "trunk-pass")` for INVITE auth
 - `WithHeader()` / `DialOptions.CustomHeaders` now applied to outbound INVITEs (previously ignored)

--- a/call.go
+++ b/call.go
@@ -123,6 +123,7 @@ type Call interface {
 	PCMReader() <-chan []int16
 	PCMWriter() chan<- []int16
 	PacedPCMWriter() chan<- []int16
+	ReplaceAudioWriter(newSrc <-chan []int16) error
 	OnDTMF(func(digit string))
 	OnHold(func())
 	OnResume(func())
@@ -218,6 +219,8 @@ type call struct {
 	pcmReader       chan []int16
 	pcmWriter       chan []int16
 	pacedPCMWriter  chan []int16       // paced PCM: accepts arbitrary-length buffers, auto-framed at 20ms
+	audioSrc        <-chan []int16     // swappable audio input (protected by mu); nil = paused
+	audioSwap       chan struct{}      // signals media goroutine to re-read audioSrc
 	sentRTP         chan *rtp.Packet   // test hook: outbound packets copied here
 	mediaTimerReset chan time.Duration // signals the media goroutine to reset the timeout
 	callbackCh      chan func()        // single dispatch goroutine for all callbacks
@@ -313,6 +316,7 @@ func newInboundCall(d dialog) *call {
 		pcmReader:      make(chan []int16, 256),
 		pcmWriter:      make(chan []int16, 256),
 		pacedPCMWriter: make(chan []int16, 256),
+		audioSwap:      make(chan struct{}, 1),
 		callbackCh:     make(chan func(), 16),
 	}
 	c.audioStream = &mediaStream{call: c, outSSRC: randUint32()}
@@ -336,6 +340,7 @@ func newOutboundCall(d dialog, dialOpts ...DialOption) *call {
 		pcmReader:      make(chan []int16, 256),
 		pcmWriter:      make(chan []int16, 256),
 		pacedPCMWriter: make(chan []int16, 256),
+		audioSwap:      make(chan struct{}, 1),
 		callbackCh:     make(chan func(), 16),
 	}
 	c.audioStream = &mediaStream{call: c, outSSRC: randUint32()}
@@ -1396,6 +1401,22 @@ func (c *call) RTPWriter() chan<- *rtp.Packet    { return c.rtpWriter }
 func (c *call) PCMReader() <-chan []int16        { return c.pcmReader }
 func (c *call) PCMWriter() chan<- []int16        { return c.pcmWriter }
 func (c *call) PacedPCMWriter() chan<- []int16   { return c.pacedPCMWriter }
+
+func (c *call) ReplaceAudioWriter(newSrc <-chan []int16) error {
+	c.mu.Lock()
+	if c.state == StateEnded {
+		c.mu.Unlock()
+		return ErrInvalidState
+	}
+	c.audioSrc = newSrc
+	c.mu.Unlock()
+	// Non-blocking signal to media goroutine to re-read audioSrc.
+	select {
+	case c.audioSwap <- struct{}{}:
+	default:
+	}
+	return nil
+}
 
 func (c *call) HasVideo() bool {
 	c.mu.Lock()

--- a/call_test.go
+++ b/call_test.go
@@ -491,6 +491,45 @@ func TestCall_BlindTransferWhenNotActiveReturnsInvalidState(t *testing.T) {
 	assert.ErrorIs(t, call.BlindTransfer("sip:1003@pbx"), ErrInvalidState)
 }
 
+// --- ReplaceAudioWriter ---
+
+func TestCall_ReplaceAudioWriter_BasicSwap(t *testing.T) {
+	call := testInboundCall(t)
+	call.Accept()
+
+	src := make(chan []int16, 1)
+	err := call.ReplaceAudioWriter(src)
+	require.NoError(t, err)
+}
+
+func TestCall_ReplaceAudioWriter_NilPauses(t *testing.T) {
+	call := testInboundCall(t)
+	call.Accept()
+
+	err := call.ReplaceAudioWriter(nil)
+	require.NoError(t, err)
+}
+
+func TestCall_ReplaceAudioWriter_ErrorOnEndedCall(t *testing.T) {
+	call := testInboundCall(t)
+	call.Accept()
+	call.End()
+	time.Sleep(50 * time.Millisecond)
+
+	err := call.ReplaceAudioWriter(make(chan []int16))
+	assert.ErrorIs(t, err, ErrInvalidState)
+}
+
+func TestCall_ReplaceAudioWriter_DoubleSwap(t *testing.T) {
+	call := testInboundCall(t)
+	call.Accept()
+
+	src1 := make(chan []int16, 1)
+	src2 := make(chan []int16, 1)
+	require.NoError(t, call.ReplaceAudioWriter(src1))
+	require.NoError(t, call.ReplaceAudioWriter(src2))
+}
+
 // --- sipHeaderTag ---
 
 func TestSipHeaderTag(t *testing.T) {

--- a/media.go
+++ b/media.go
@@ -341,6 +341,11 @@ func (s *mediaStream) run(jb *media.JitterBuffer, cp media.CodecProcessor, rtpCl
 		frameSize = int(cp.SamplesPerFrame())
 	}
 
+	// Swappable audio source (ReplaceAudioWriter).
+	c.mu.Lock()
+	userAudioCh := c.audioSrc
+	c.mu.Unlock()
+
 	for {
 		select {
 		case <-done:
@@ -426,6 +431,35 @@ func (s *mediaStream) run(jb *media.JitterBuffer, cp media.CodecProcessor, rtpCl
 			frame := pacerQueue[0]
 			pacerQueue = pacerQueue[1:]
 			s.encodePCMAndSend(frame, cp, rtcpStats, conn)
+
+		case <-c.audioSwap:
+			// Drain residual frames from old channel (non-blocking).
+			if userAudioCh != nil {
+			drain:
+				for {
+					select {
+					case _, ok := <-userAudioCh:
+						if !ok {
+							break drain
+						}
+					default:
+						break drain
+					}
+				}
+			}
+			c.mu.Lock()
+			userAudioCh = c.audioSrc
+			c.mu.Unlock()
+
+		case pcmFrame, ok := <-userAudioCh:
+			if !ok {
+				userAudioCh = nil
+				continue
+			}
+			if s.rtpWriterUsed || cp == nil {
+				continue
+			}
+			s.encodePCMAndSend(pcmFrame, cp, rtcpStats, conn)
 
 		case <-rtcpTick:
 			c.mu.Lock()

--- a/mock_call.go
+++ b/mock_call.go
@@ -52,6 +52,7 @@ type MockCall struct {
 	pcmReader      chan []int16
 	pcmWriter      chan []int16
 	pacedPCMWriter chan []int16
+	audioSrc       <-chan []int16
 
 	hasVideo       bool
 	videoCodecType VideoCodec
@@ -419,6 +420,16 @@ func (c *MockCall) RTPWriter() chan<- *rtp.Packet    { return c.rtpWriter }
 func (c *MockCall) PCMReader() <-chan []int16        { return c.pcmReader }
 func (c *MockCall) PCMWriter() chan<- []int16        { return c.pcmWriter }
 func (c *MockCall) PacedPCMWriter() chan<- []int16   { return c.pacedPCMWriter }
+
+func (c *MockCall) ReplaceAudioWriter(newSrc <-chan []int16) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state == StateEnded {
+		return ErrInvalidState
+	}
+	c.audioSrc = newSrc
+	return nil
+}
 
 func (c *MockCall) OnDTMF(fn func(string)) {
 	c.mu.Lock()


### PR DESCRIPTION
## Summary

- Add `ReplaceAudioWriter(newSrc <-chan []int16)` to `Call` interface — atomically swaps the audio input channel for the media goroutine
- Media goroutine drains residual frames from old source on swap (handles closed channels safely)
- Passing `nil` pauses outbound audio (nil channel disables select case)
- Non-breaking for existing users — `AudioWriter()` / `PCMWriter()` / `PacedPCMWriter()` unchanged

## Design

Single-writer model preserved. No mux, no second queue. The media goroutine holds a local `userAudioCh` variable, re-read on swap signal via capacity-1 `audioSwap` channel. Sub-frame swap latency.

## Test plan

- [x] `TestCall_ReplaceAudioWriter_BasicSwap` — swap succeeds on active call
- [x] `TestCall_ReplaceAudioWriter_NilPauses` — nil source accepted
- [x] `TestCall_ReplaceAudioWriter_ErrorOnEndedCall` — returns ErrInvalidState after End()
- [x] `TestCall_ReplaceAudioWriter_DoubleSwap` — consecutive swaps work
- [x] All existing tests pass (`go test ./...`)
- [x] Race detector clean

Closes #58