### PR TITLE
Fix Hold/Resume re-INVITE: send ACK after 200 OK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+- Fix Hold/Resume re-INVITE: send ACK after 200 OK per RFC 3261 §13.2.2.4 — previously the client transaction was destroyed before the 200 OK arrived, leaving the dialog in an undefined state (#61)
+- Hold() and Resume() now return errors from the re-INVITE instead of silently ignoring failures
+
 ## v0.5.0
 
 ### Features

--- a/call.go
+++ b/call.go
@@ -1214,8 +1214,13 @@ func (c *call) Hold() error {
 	if c.state != StateActive {
 		return ErrInvalidState
 	}
+	prevSDP := c.localSDP
 	c.localSDP = c.buildLocalSDP(sdp.DirSendOnly)
-	c.dlg.SendReInvite([]byte(c.localSDP))
+	if err := c.dlg.SendReInvite([]byte(c.localSDP)); err != nil {
+		c.localSDP = prevSDP
+		c.logger.Warn("hold re-INVITE failed", "id", c.id, "error", err)
+		return err
+	}
 	c.state = StateOnHold
 	c.fireOnState(StateOnHold)
 	c.signalMediaTimerReset(defaultHoldMediaTimeout)
@@ -1229,8 +1234,13 @@ func (c *call) Resume() error {
 	if c.state != StateOnHold {
 		return ErrInvalidState
 	}
+	prevSDP := c.localSDP
 	c.localSDP = c.buildLocalSDP(sdp.DirSendRecv)
-	c.dlg.SendReInvite([]byte(c.localSDP))
+	if err := c.dlg.SendReInvite([]byte(c.localSDP)); err != nil {
+		c.localSDP = prevSDP
+		c.logger.Warn("resume re-INVITE failed", "id", c.id, "error", err)
+		return err
+	}
 	c.state = StateActive
 	c.fireOnState(StateActive)
 	c.signalMediaTimerReset(c.effectiveMediaTimeout())

--- a/sipgo_dialog.go
+++ b/sipgo_dialog.go
@@ -2,6 +2,7 @@ package xphone
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -67,8 +68,21 @@ func (d *dialogBase) SendReInvite(sdpBody []byte) error {
 		req.AppendHeader(sip.NewHeader("Content-Type", contentTypeSDP))
 	}
 	req.SetBody(sdpBody)
-	_, err := d.sess.Do(ctx, req)
-	return err
+	res, err := d.sess.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+	if res == nil || !res.IsSuccess() {
+		return fmt.Errorf("re-INVITE rejected: %d", res.StatusCode)
+	}
+	// ACK the 2xx response per RFC 3261 §13.2.2.4.
+	// Do() terminates the client transaction on return, but the ACK for a
+	// 2xx INVITE is sent directly by the TU, not via a transaction.
+	ack := sip.NewRequest(sip.ACK, d.remoteTarget())
+	if err := d.sess.WriteRequest(ack); err != nil {
+		return fmt.Errorf("send ACK: %w", err)
+	}
+	return nil
 }
 
 func (d *dialogBase) SendRefer(target string) error {

--- a/sipgo_dialog_test.go
+++ b/sipgo_dialog_test.go
@@ -149,6 +149,10 @@ func TestSipgoDialogUAC_SendReInvite(t *testing.T) {
 	require.NotNil(t, sess.doReq, "Do should have been called")
 	assert.Equal(t, sip.INVITE, sess.doReq.Method, "request method should be INVITE")
 	assert.Equal(t, sdpBody, sess.doReq.Body(), "request body should be the SDP")
+
+	// ACK must be sent after 200 OK.
+	require.NotNil(t, sess.writeReq, "WriteRequest should have been called for ACK")
+	assert.Equal(t, sip.ACK, sess.writeReq.Method, "ACK should be sent after 200 OK")
 }
 
 func TestSipgoDialogUAC_SendRefer(t *testing.T) {

--- a/sipgo_dialog_uas_test.go
+++ b/sipgo_dialog_uas_test.go
@@ -190,6 +190,10 @@ func TestSipgoDialogUAS_SendReInvite(t *testing.T) {
 	require.NotNil(t, sess.doReq, "Do should have been called")
 	assert.Equal(t, sip.INVITE, sess.doReq.Method, "request method should be INVITE")
 	assert.Equal(t, sdpBody, sess.doReq.Body(), "request body should be the SDP")
+
+	// ACK must be sent after 200 OK.
+	require.NotNil(t, sess.writeReq, "WriteRequest should have been called for ACK")
+	assert.Equal(t, sip.ACK, sess.writeReq.Method, "ACK should be sent after 200 OK")
 }
 
 func TestSipgoDialogUAS_SendReInvite_Error(t *testing.T) {


### PR DESCRIPTION
## Summary

- Send ACK after receiving 200 OK for re-INVITE per RFC 3261 §13.2.2.4 — previously the client transaction was destroyed and the 200 OK was never acknowledged
- Hold() and Resume() now check and return errors from SendReInvite instead of silently ignoring failures
- Revert `localSDP` on SendReInvite failure to prevent state corruption
- Return error on non-2xx re-INVITE response (previously silently swallowed)

## Test plan

- [x] `TestSipgoDialogUAS_SendReInvite` — verifies ACK is sent after 200 OK
- [x] `TestSipgoDialogUAC_SendReInvite` — same for UAC path
- [x] `TestSipgoDialogUAS_SendReInvite_Error` — verifies no ACK on error
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual test: Hold/Resume on inbound trunk call, verify ACK in SIP trace

Fixes #61