### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.5.2
+
 ### Features
 - `Server.DialURI(ctx, uri, from, opts...)` initiates outbound calls to arbitrary SIP URIs without requiring a pre-configured peer (#64)
 


### PR DESCRIPTION
## Summary

- `Server.DialURI` for dialing arbitrary SIP URIs without peer config (#64)

## Changelog

See CHANGELOG.md for details.