### PR TITLE
Move AttendedTransfer from Phone to Call interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+- `Call.AttendedTransfer(other Call)` — attended transfer now lives on the Call interface, works for both Phone and Server calls (#67)
+- `Phone.AttendedTransfer(callA, callB)` remains as a thin delegate (non-breaking)
+
 ## v0.5.2
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ call.Hold()
 call.Resume()
 
 call.BlindTransfer("sip:1003@pbx.example.com")
-phone.AttendedTransfer(callA, callB)
+callA.AttendedTransfer(callB)
 
 call.Mute()
 call.Unmute()

--- a/call.go
+++ b/call.go
@@ -117,6 +117,7 @@ type Call interface {
 	UnmuteAudio() error
 	SendDTMF(digit string) error
 	BlindTransfer(target string) error
+	AttendedTransfer(other Call) error
 	RTPRawReader() <-chan *rtp.Packet
 	RTPReader() <-chan *rtp.Packet
 	RTPWriter() chan<- *rtp.Packet
@@ -1367,6 +1368,86 @@ func (c *call) BlindTransfer(target string) error {
 			c.endWithReason(EndedByTransferFailed)
 		}
 	})
+	return nil
+}
+
+// AttendedTransfer performs an attended (consultative) transfer.
+// This call's dialog sends a REFER with a Replaces header built from the
+// other call's dialog identifiers. On NOTIFY 200, both calls end with
+// EndedByTransfer; on failure (NOTIFY >= 300), both end with EndedByTransferFailed.
+// Both calls must be Active or OnHold.
+func (c *call) AttendedTransfer(other Call) error {
+	if other == nil {
+		return fmt.Errorf("xphone: other call is nil")
+	}
+	b, ok := other.(*call)
+	if !ok {
+		return fmt.Errorf("xphone: unsupported Call implementation")
+	}
+	if b == c {
+		return fmt.Errorf("xphone: cannot transfer a call to itself")
+	}
+	// Validate both call states before touching dialog internals.
+	if s := other.State(); s != StateActive && s != StateOnHold {
+		return ErrInvalidState
+	}
+	c.mu.Lock()
+	if c.state != StateActive && c.state != StateOnHold {
+		c.mu.Unlock()
+		return ErrInvalidState
+	}
+	c.mu.Unlock()
+
+	// Extract other call's dialog identifiers for the Replaces header.
+	// Read from b without holding c.mu to avoid lock ordering issues.
+	bCallID, bLocalTag, bRemoteTag := b.dialogID()
+	if bCallID == "" || bLocalTag == "" || bRemoteTag == "" {
+		return fmt.Errorf("xphone: attended transfer: other call dialog missing call-id or tags")
+	}
+
+	// Build remote party URI from other call's headers.
+	var remoteURI string
+	if other.Direction() == DirectionOutbound {
+		if vals := b.dlg.Header("To"); len(vals) > 0 {
+			remoteURI = sipHeaderURI(vals[0])
+		}
+	} else {
+		if vals := b.dlg.Header("From"); len(vals) > 0 {
+			remoteURI = sipHeaderURI(vals[0])
+		}
+	}
+	if remoteURI == "" {
+		return fmt.Errorf("xphone: attended transfer: cannot determine other call remote URI")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state != StateActive && c.state != StateOnHold {
+		return ErrInvalidState
+	}
+
+	// Build Refer-To with Replaces parameter (RFC 3891).
+	referTo := remoteURI + "?Replaces=" +
+		uriEncode(bCallID) + "%3Bto-tag%3D" +
+		uriEncode(bRemoteTag) + "%3Bfrom-tag%3D" +
+		uriEncode(bLocalTag)
+
+	// Send REFER, then wire NOTIFY handler on success.
+	if err := c.dlg.SendRefer(referTo); err != nil {
+		return err
+	}
+
+	// Wire NOTIFY handler: end both calls on success (200) or failure (>=300).
+	c.dlg.OnNotify(func(code int) {
+		if code == 200 {
+			c.endWithReason(EndedByTransfer)
+			b.endWithReason(EndedByTransfer)
+		} else if code >= 300 {
+			c.endWithReason(EndedByTransferFailed)
+			b.endWithReason(EndedByTransferFailed)
+		}
+	})
+
 	return nil
 }
 

--- a/call_test.go
+++ b/call_test.go
@@ -491,6 +491,24 @@ func TestCall_BlindTransferWhenNotActiveReturnsInvalidState(t *testing.T) {
 	assert.ErrorIs(t, call.BlindTransfer("sip:1003@pbx"), ErrInvalidState)
 }
 
+// --- AttendedTransfer (on Call) ---
+
+func TestCall_AttendedTransfer_RejectsInactiveCall(t *testing.T) {
+	callA := testInboundCall(t)
+	callB := testInboundCall(t)
+	callB.Accept()
+
+	assert.ErrorIs(t, callA.AttendedTransfer(callB), ErrInvalidState)
+}
+
+func TestCall_AttendedTransfer_RejectsInactiveOther(t *testing.T) {
+	callA := testInboundCall(t)
+	callA.Accept()
+	callB := testInboundCall(t)
+
+	assert.ErrorIs(t, callA.AttendedTransfer(callB), ErrInvalidState)
+}
+
 // --- ReplaceAudioWriter ---
 
 func TestCall_ReplaceAudioWriter_BasicSwap(t *testing.T) {

--- a/mock_call.go
+++ b/mock_call.go
@@ -414,6 +414,15 @@ func (c *MockCall) BlindTransfer(target string) error {
 	return nil
 }
 
+func (c *MockCall) AttendedTransfer(other Call) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state != StateActive && c.state != StateOnHold {
+		return ErrInvalidState
+	}
+	return nil
+}
+
 func (c *MockCall) RTPRawReader() <-chan *rtp.Packet { return c.rtpRawReader }
 func (c *MockCall) RTPReader() <-chan *rtp.Packet    { return c.rtpReader }
 func (c *MockCall) RTPWriter() chan<- *rtp.Packet    { return c.rtpWriter }

--- a/mock_phone.go
+++ b/mock_phone.go
@@ -188,13 +188,7 @@ func (p *MockPhone) wireCallCallbacks(c *MockCall) {
 }
 
 func (p *MockPhone) AttendedTransfer(callA Call, callB Call) error {
-	if s := callA.State(); s != StateActive && s != StateOnHold {
-		return ErrInvalidState
-	}
-	if s := callB.State(); s != StateActive && s != StateOnHold {
-		return ErrInvalidState
-	}
-	return nil
+	return callA.AttendedTransfer(callB)
 }
 
 func (p *MockPhone) Calls() []Call {

--- a/xphone.go
+++ b/xphone.go
@@ -515,72 +515,9 @@ func (p *phone) Calls() []Call {
 }
 
 // AttendedTransfer performs an attended (consultative) transfer.
-// Call A's dialog sends a REFER with a Replaces header built from Call B's
-// dialog identifiers. On NOTIFY 200, both calls end with EndedByTransfer;
-// on failure (NOTIFY >= 300), both end with EndedByTransferFailed.
-// Both calls must be Active or OnHold.
+// Delegates to callA.AttendedTransfer(callB). See Call.AttendedTransfer.
 func (p *phone) AttendedTransfer(callA Call, callB Call) error {
-	// Validate states.
-	if s := callA.State(); s != StateActive && s != StateOnHold {
-		return ErrInvalidState
-	}
-	if s := callB.State(); s != StateActive && s != StateOnHold {
-		return ErrInvalidState
-	}
-
-	a, ok := callA.(*call)
-	if !ok {
-		return fmt.Errorf("xphone: callA is not an *call")
-	}
-	b, ok := callB.(*call)
-	if !ok {
-		return fmt.Errorf("xphone: callB is not an *call")
-	}
-
-	// Extract Call B's dialog identifiers for the Replaces header.
-	bCallID, bLocalTag, bRemoteTag := b.dialogID()
-	if bCallID == "" || bLocalTag == "" || bRemoteTag == "" {
-		return fmt.Errorf("xphone: attended transfer: call B dialog missing call-id or tags")
-	}
-
-	// Build remote party URI from Call B's headers.
-	var remoteURI string
-	if callB.Direction() == DirectionOutbound {
-		if vals := b.dlg.Header("To"); len(vals) > 0 {
-			remoteURI = sipHeaderURI(vals[0])
-		}
-	} else {
-		if vals := b.dlg.Header("From"); len(vals) > 0 {
-			remoteURI = sipHeaderURI(vals[0])
-		}
-	}
-	if remoteURI == "" {
-		return fmt.Errorf("xphone: attended transfer: cannot determine call B remote URI")
-	}
-
-	// Build Refer-To with Replaces parameter (RFC 3891).
-	referTo := remoteURI + "?Replaces=" +
-		uriEncode(bCallID) + "%3Bto-tag%3D" +
-		uriEncode(bRemoteTag) + "%3Bfrom-tag%3D" +
-		uriEncode(bLocalTag)
-
-	// Send REFER, then wire NOTIFY handler on success.
-	if err := a.dlg.SendRefer(referTo); err != nil {
-		return err
-	}
-
-	// Wire NOTIFY handler: end both calls on success (200) or failure (>=300).
-	a.dlg.OnNotify(func(code int) {
-		if code == 200 {
-			a.endWithReason(EndedByTransfer)
-			b.endWithReason(EndedByTransfer)
-		} else if code >= 300 {
-			a.endWithReason(EndedByTransferFailed)
-			b.endWithReason(EndedByTransferFailed)
-		}
-	})
-
-	return nil
+	return callA.AttendedTransfer(callB)
 }
 
 // FindCall returns an active call by its SIP Call-ID, or nil if not found.


### PR DESCRIPTION
## Summary

- Move `AttendedTransfer` logic from `Phone` to `Call` interface — consistent with `BlindTransfer`
- `Phone.AttendedTransfer(callA, callB)` remains as a thin delegate (non-breaking)
- Works for any call source: Phone, Server, or future call creators
- Guards against self-transfer, nil other, and lock ordering issues

## Design

Follows the Rust agent's approach (x-phone/xphone-rust#45): `call_a.attended_transfer(&call_b)` — one implementation, no duplication, same pattern as `BlindTransfer`.

## Test plan

- [x] `TestCall_AttendedTransfer_RejectsInactiveCall` — rejects when self is not Active/OnHold
- [x] `TestCall_AttendedTransfer_RejectsInactiveOther` — rejects when other is not Active/OnHold
- [x] All existing `Phone.AttendedTransfer` tests pass (delegation works)
- [x] All tests pass (`go test ./...`)

Closes #67