### PR TITLE
Add WithDisplayName option for Phone registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Features
-- `WithDisplayName(name)` sets the display name in SIP Contact/From headers and User-Agent — helps PBXes identify the device (#75)
+- `WithDisplayName(name)` sets the display name in SIP Contact headers — helps PBXes identify the device (#75)
 
 ## v0.5.4
 

--- a/options.go
+++ b/options.go
@@ -61,7 +61,7 @@ type Config struct {
 	// Example: "sip:*97@pbx.local". When set, the phone auto-subscribes on connect.
 	VoicemailURI string
 
-	// DisplayName is included in SIP Contact/From headers and User-Agent.
+	// DisplayName is included in SIP Contact headers.
 	// Helps PBXes identify the device (e.g., "VoiceApp/1.0").
 	DisplayName string
 
@@ -404,7 +404,7 @@ func WithVoicemailURI(uri string) PhoneOption {
 	}
 }
 
-// WithDisplayName sets the display name for SIP Contact/From headers and User-Agent.
+// WithDisplayName sets the display name for SIP Contact headers.
 // Helps PBXes identify the device (e.g., "VoiceApp/1.0").
 func WithDisplayName(name string) PhoneOption {
 	return func(c *Config) {

--- a/sipua.go
+++ b/sipua.go
@@ -120,12 +120,8 @@ func newSipUA(cfg Config, contactIP string) (*sipUA, error) {
 		return nil, fmt.Errorf("xphone: unsupported protocol %q", cfg.Transport)
 	}
 
-	userAgent := cfg.Username
-	if cfg.DisplayName != "" {
-		userAgent = cfg.DisplayName
-	}
 	ua, err := sipgo.NewUA(
-		sipgo.WithUserAgent(userAgent),
+		sipgo.WithUserAgent(cfg.Username),
 		sipgo.WithUserAgentHostname(cfg.Host),
 	)
 	if err != nil {
@@ -639,7 +635,8 @@ func (s *sipUA) SendRequest(ctx context.Context, method string, headers map[stri
 	// Add Contact for REGISTER.
 	if method == "REGISTER" {
 		contact := sip.ContactHeader{
-			Address: sip.Uri{Scheme: "sip", User: s.cfg.Username, Host: s.localIP},
+			DisplayName: s.cfg.DisplayName,
+			Address:     sip.Uri{Scheme: "sip", User: s.cfg.Username, Host: s.localIP},
 		}
 		req.AppendHeader(&contact)
 	}


### PR DESCRIPTION
## Summary

- Add `WithDisplayName(name)` phone option
- Sets display name in SIP Contact header and User-Agent header
- PBXes can now identify the device instead of showing "Unknown device"

## Usage

```go
phone := xp.New(
    xp.WithCredentials("1004", "pass", "pbx.example.com"),
    xp.WithDisplayName("VoiceApp/1.0"),
)
```

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: verify PBX shows display name after registration

Closes #75