### PR TITLE
Release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.5.5
+
 ### Features
 - `WithDisplayName(name)` sets the display name in SIP Contact headers — helps PBXes identify the device (#75)
 


### PR DESCRIPTION
## Summary

- `WithDisplayName` for SIP Contact headers (#75)

## Changelog

See CHANGELOG.md for details.