### PR TITLE
Reduce un-REGISTER timeout to fix hot-reload registration failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug fixes
+- Reduce un-REGISTER timeout from 3s to 500ms — fixes registration failure on hot-reload where pending un-REGISTER transaction raced with transport teardown
+
 ## v0.5.5
 
 ### Features

--- a/registry.go
+++ b/registry.go
@@ -81,8 +81,9 @@ func (r *registry) Stop() error {
 }
 
 // unregisterTimeout is how long to wait for the un-REGISTER response before
-// giving up. Disconnect must not block indefinitely on a failing registrar.
-const unregisterTimeout = 3 * time.Second
+// giving up. Keep short to avoid delaying shutdown or racing with transport
+// teardown during hot-reload cycles.
+const unregisterTimeout = 500 * time.Millisecond
 
 // Unregister sends a REGISTER with Expires: 0 to remove our contact from the
 // registrar (RFC 3261 §10.2.2). It waits up to unregisterTimeout for a


### PR DESCRIPTION
## Summary

Reduce un-REGISTER timeout from 3s to 500ms. The 3-second window allowed the pending un-REGISTER transaction to race with transport teardown during hot-reload cycles, causing sipgo UDP "ref went negative" and "hard close" errors that broke subsequent registration.

## Root cause

On hot-reload: `Disconnect()` sends un-REGISTER (3s timeout) → `Stop()` → `Close()`. If the registrar is slow, the transaction is still pending when the transport closes, corrupting sipgo's connection reference count. The next `Connect()` inherits a broken transport state.

## Fix

500ms is plenty for a LAN registrar response. If it times out, shutdown proceeds — the registrar will expire the contact naturally.

## Test plan

- [x] All existing tests pass
- [ ] Manual: hot-reload with `air` no longer causes registration failure

Fixes the regression introduced in v0.5.4 (#70).