### PR TITLE
feat: add Config.AuthUsername to split digest identity from SIP AOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- `Config.AuthUsername` and `WithAuthUsername(username)` — default digest Authorization username used across REGISTER, SUBSCRIBE, MESSAGE, and outbound INVITE, separate from the SIP AOR carried in From/To/Contact. Needed for PBXes where the authentication identity differs from the extension (e.g. 3CX trunks with a distinct Authentication ID). More specific overrides still win (`OutboundUsername` for INVITE, per-call `WithAuth` for `Dial`). Falls back to `Username` when unset; behavior unchanged for existing setups.
+
 ## v0.5.11
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ func pcmToFloat32(frame []int16) []float32 {
 - `ReplaceAudioWriter` — atomic audio source swap (e.g., music on hold)
 - Outbound proxy routing (`WithOutboundProxy`)
 - Separate outbound credentials (`WithOutboundCredentials`)
+- Separate digest auth identity (`WithAuthUsername`) — for PBXes like 3CX where the Authentication ID differs from the extension
 - Custom headers on outbound INVITEs (`WithHeader`, `DialOptions.CustomHeaders`)
 - `Server.DialURI` — dial arbitrary SIP URIs without pre-configured peers
 - Transfer failure surfaced via `EndedByTransferFailed` end reason
@@ -466,6 +467,7 @@ phone := xphone.New(
     xphone.WithTurnCredentials("user", "pass"),
     xphone.WithOutboundProxy("sip:proxy.example.com:5060"),   // route INVITEs via proxy
     xphone.WithOutboundCredentials("trunk-user", "trunk-pass"), // separate INVITE auth
+    xphone.WithAuthUsername("auth-id"),                         // 3CX-style: digest username != SIP AOR
     xphone.WithLogger(slog.Default()),
 )
 ```

--- a/fakepbx_test.go
+++ b/fakepbx_test.go
@@ -776,3 +776,39 @@ func TestFakePBX_OutboundProxy(t *testing.T) {
 
 	c.End()
 }
+
+// F20: AuthUsername splits digest identity from the SIP AOR. The PBX expects
+// digest username "auth-id" while the phone presents SIP identity "1001" in
+// From/To/Contact headers. Models 3CX-style trunks where the Authentication
+// ID is distinct from the extension number.
+func TestFakePBX_Register_AuthUsernameSplitIdentity(t *testing.T) {
+	pbx := fakepbx.NewFakePBX(t, fakepbx.WithAuth("auth-id", "secret"))
+	cfg := pbxConfig(t, pbx)
+	cfg.Username = "1001"
+	cfg.Password = "secret"
+	cfg.AuthUsername = "auth-id"
+	p := connectWithConfig(t, cfg)
+
+	assert.Equal(t, PhoneStateRegistered, p.State())
+	assert.GreaterOrEqual(t, pbx.RegisterCount(), 1)
+
+	last := pbx.LastRegister()
+	require.NotNil(t, last, "PBX should have recorded at least one REGISTER")
+
+	// SIP identity headers carry Username, not AuthUsername.
+	from := last.From()
+	require.NotNil(t, from)
+	assert.Equal(t, "1001", from.Address.User, "From must carry Username")
+	to := last.To()
+	require.NotNil(t, to)
+	assert.Equal(t, "1001", to.Address.User, "To must carry Username")
+	contact := last.Contact()
+	require.NotNil(t, contact)
+	assert.Equal(t, "1001", contact.Address.User, "Contact must carry Username")
+
+	// Authorization header carries AuthUsername for the digest challenge.
+	authHdr := last.GetHeader("Authorization")
+	require.NotNil(t, authHdr, "REGISTER retry must include Authorization header")
+	assert.Contains(t, authHdr.Value(), `username="auth-id"`,
+		"digest username must use AuthUsername, not Username")
+}

--- a/options.go
+++ b/options.go
@@ -18,6 +18,15 @@ type Config struct {
 	Transport string
 	TLSConfig *tls.Config
 
+	// AuthUsername is the default digest Authorization username. Applies to
+	// REGISTER, SUBSCRIBE, MESSAGE, and outbound INVITE when no more specific
+	// override is set (OutboundUsername for INVITE, per-call WithAuth for Dial).
+	// When empty, Username is used. Set this when the PBX's auth identity
+	// differs from the SIP AOR — for example, 3CX trunks where the
+	// Authentication ID is not the extension. The SIP From/To/Contact headers
+	// always use Username regardless.
+	AuthUsername string
+
 	RegisterExpiry   time.Duration
 	RegisterRetry    time.Duration
 	RegisterMaxRetry int
@@ -380,6 +389,15 @@ func WithOutboundCredentials(username, password string) PhoneOption {
 	return func(c *Config) {
 		c.OutboundUsername = username
 		c.OutboundPassword = password
+	}
+}
+
+// WithAuthUsername sets Config.AuthUsername — the default digest Authorization
+// username applied to REGISTER, SUBSCRIBE, MESSAGE, and outbound INVITE when
+// no more specific override is set. See the field doc for precedence details.
+func WithAuthUsername(username string) PhoneOption {
+	return func(c *Config) {
+		c.AuthUsername = username
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -78,3 +78,50 @@ func TestResolveAuthCredentials_PerCallOnlyNoConfig(t *testing.T) {
 	assert.Equal(t, "call-user", user)
 	assert.Equal(t, "call-pass", pass)
 }
+
+func TestWithAuthUsername_SetsConfig(t *testing.T) {
+	cfg := Config{}
+	WithAuthUsername("auth-id")(&cfg)
+	assert.Equal(t, "auth-id", cfg.AuthUsername)
+}
+
+func TestResolveAuthCredentials_AuthUsernameFallbackForInvite(t *testing.T) {
+	cfg := Config{
+		Username:     "1001",
+		Password:     "secret",
+		AuthUsername: "auth-id",
+	}
+	opts := DialOptions{}
+	user, pass := resolveAuthCredentials(opts, cfg)
+	assert.Equal(t, "auth-id", user, "INVITE digest should use AuthUsername when OutboundUsername is unset")
+	assert.Equal(t, "secret", pass)
+}
+
+func TestResolveAuthCredentials_OutboundUsernameBeatsAuthUsername(t *testing.T) {
+	cfg := Config{
+		Username:         "1001",
+		Password:         "secret",
+		AuthUsername:     "auth-id",
+		OutboundUsername: "outbound-user",
+		OutboundPassword: "outbound-pass",
+	}
+	opts := DialOptions{}
+	user, pass := resolveAuthCredentials(opts, cfg)
+	assert.Equal(t, "outbound-user", user, "OutboundUsername must take precedence over AuthUsername")
+	assert.Equal(t, "outbound-pass", pass)
+}
+
+func TestResolveRegisterAuthUsername_UsesAuthUsername(t *testing.T) {
+	cfg := Config{Username: "1001", AuthUsername: "auth-id"}
+	assert.Equal(t, "auth-id", resolveRegisterAuthUsername(cfg))
+}
+
+func TestResolveRegisterAuthUsername_FallsBackToUsername(t *testing.T) {
+	cfg := Config{Username: "1001"}
+	assert.Equal(t, "1001", resolveRegisterAuthUsername(cfg))
+}
+
+func TestResolveRegisterAuthUsername_BothEmpty(t *testing.T) {
+	cfg := Config{}
+	assert.Empty(t, resolveRegisterAuthUsername(cfg))
+}

--- a/sipua.go
+++ b/sipua.go
@@ -170,11 +170,16 @@ func newSipUA(cfg Config, contactIP string) (*sipUA, error) {
 const maxRedirects = 3
 
 // resolveAuthCredentials returns the SIP digest credentials to use for an
-// outbound INVITE. Precedence: per-call WithAuth > config OutboundCredentials > registration credentials.
+// outbound INVITE. Precedence for username: per-call WithAuth >
+// cfg.OutboundUsername > cfg.AuthUsername > cfg.Username. Password chain:
+// per-call WithAuth > cfg.OutboundPassword > cfg.Password.
 func resolveAuthCredentials(opts DialOptions, cfg Config) (string, string) {
 	user := opts.AuthUsername
 	if user == "" {
 		user = cfg.OutboundUsername
+	}
+	if user == "" {
+		user = cfg.AuthUsername
 	}
 	if user == "" {
 		user = cfg.Username
@@ -187,6 +192,16 @@ func resolveAuthCredentials(opts DialOptions, cfg Config) (string, string) {
 		pass = cfg.Password
 	}
 	return user, pass
+}
+
+// resolveRegisterAuthUsername returns the digest username for REGISTER and
+// other non-INVITE requests. Falls back to cfg.Username when AuthUsername
+// is unset. The counterpart for INVITE is resolveAuthCredentials.
+func resolveRegisterAuthUsername(cfg Config) string {
+	if cfg.AuthUsername != "" {
+		return cfg.AuthUsername
+	}
+	return cfg.Username
 }
 
 // dialWithOpts establishes an outbound SIP dialog with DialOptions.
@@ -620,7 +635,7 @@ func (s *sipUA) doWithAuth(ctx context.Context, req *sip.Request, opts ...sipgo.
 	}
 	if res.StatusCode == 401 || res.StatusCode == 407 {
 		authRes, err := s.client.DoDigestAuth(ctx, req, res, sipgo.DigestAuth{
-			Username: s.cfg.Username,
+			Username: resolveRegisterAuthUsername(s.cfg),
 			Password: s.cfg.Password,
 		})
 		if err != nil {


### PR DESCRIPTION
## Summary
- New `Config.AuthUsername` + `WithAuthUsername(username)` PhoneOption let callers present a digest Authorization username distinct from the SIP AOR in From/To/Contact — required for PBXes like 3CX where the Authentication ID is not the extension.
- Applies to REGISTER, SUBSCRIBE, MESSAGE, and outbound INVITE (as a fallback after per-call `WithAuth` and `OutboundUsername`). Falls back to `Username` when unset, so existing setups are unchanged.
- Helper `resolveRegisterAuthUsername` added next to `resolveAuthCredentials` for symmetry between REGISTER-side and INVITE-side digest resolution.

## Precedence
- **REGISTER / SUBSCRIBE / MESSAGE:** `cfg.AuthUsername` → `cfg.Username`
- **Outbound INVITE:** `opts.AuthUsername` (per-call `WithAuth`) → `cfg.OutboundUsername` → `cfg.AuthUsername` → `cfg.Username`

## Test plan
- [x] Unit tests: `resolveRegisterAuthUsername` (3 cases: happy path, fallback, both-empty)
- [x] Unit tests: `resolveAuthCredentials` new tier (`AuthUsername` fallback for INVITE; `OutboundUsername` beats `AuthUsername`)
- [x] `WithAuthUsername` setter test
- [x] fakepbx integration test: REGISTER retry carries `username="auth-id"` in Authorization while From/To/Contact carry `Username`
- [x] `go test ./...` green; `go vet ./...` clean
- [x] `gofmt -s -w` on all changed Go files