### PR TITLE
feat: add WithNAT / Config.NAT for RFC 3581 rport support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking changes
 - `WithOutboundProxy` / `Config.OutboundProxy` now routes **all** outbound SIP requests (REGISTER, SUBSCRIBE, MESSAGE, INVITE) through the proxy, not just INVITE. Matches how Kamailio / OpenSIPS / Asterisk outbound-proxy deployments expect a single next-hop for all signaling. Migration: for most deployments no action is needed — the proxy was already the expected next-hop. Callers who genuinely needed the prior "INVITE via proxy, REGISTER direct" split can either drop `OutboundProxy` (all requests go direct to `Host`) or run two `Phone` instances, one for registration and one for outbound calls.
 
+### Features
+- `WithNAT()` PhoneOption (plus `Config.NAT` / `ServerConfig.NAT`) — enables RFC 3581 rport on outgoing UDP SIP requests so peers reply to the NAT-mapped source IP:port rather than the sent-by Via address. Required for phones/servers behind NAT (dev environments, containerized deployments) where the PBX would otherwise reply to an unreachable port.
+
 ## v0.5.12
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ func pcmToFloat32(frame []int16) []float32 {
 - Outbound proxy routing (`WithOutboundProxy`) — single next-hop for all signaling (REGISTER, SUBSCRIBE, MESSAGE, INVITE)
 - Separate outbound credentials (`WithOutboundCredentials`)
 - Separate digest auth identity (`WithAuthUsername`) — for PBXes like 3CX where the Authentication ID differs from the extension
+- RFC 3581 rport (`WithNAT`) — for phones behind NAT; PBX replies come back to the NAT-mapped source port
 - Custom headers on outbound INVITEs (`WithHeader`, `DialOptions.CustomHeaders`)
 - `Server.DialURI` — dial arbitrary SIP URIs without pre-configured peers
 - Transfer failure surfaced via `EndedByTransferFailed` end reason
@@ -468,6 +469,7 @@ phone := xphone.New(
     xphone.WithOutboundProxy("sip:proxy.example.com:5060"),   // single next-hop for all SIP signaling
     xphone.WithOutboundCredentials("trunk-user", "trunk-pass"), // separate INVITE auth
     xphone.WithAuthUsername("auth-id"),                         // 3CX-style: digest username != SIP AOR
+    xphone.WithNAT(),                                           // enable rport (RFC 3581) when behind NAT
     xphone.WithLogger(slog.Default()),
 )
 ```

--- a/fakepbx_test.go
+++ b/fakepbx_test.go
@@ -837,3 +837,30 @@ func TestFakePBX_OutboundProxy_RoutesRegister(t *testing.T) {
 	assert.Equal(t, registrarHost, last.Recipient.Host,
 		"Request-URI host must point at registrar, not proxy")
 }
+
+// F21: WithNAT enables RFC 3581 rport on outgoing Via. Models a phone behind
+// NAT that needs the PBX to reply to the NAT-mapped source IP:port rather
+// than the sent-by address.
+func TestFakePBX_Register_NAT_AddsRportToVia(t *testing.T) {
+	pbx := fakepbx.NewFakePBX(t, fakepbx.WithAuth("1001", "test"))
+	cfg := pbxConfig(t, pbx)
+	cfg.NAT = true
+	connectWithConfig(t, cfg)
+
+	assert.GreaterOrEqual(t, pbx.RegisterCount(), 1)
+	via := pbx.LastRegister().Via()
+	require.NotNil(t, via, "REGISTER must have a Via header")
+	assert.True(t, via.Params.Has("rport"), "Via must carry rport when NAT is enabled")
+}
+
+// F22: NAT off (default) — Via must NOT carry rport, preserving existing
+// behavior for deployments without NAT traversal needs.
+func TestFakePBX_Register_NATDisabled_OmitsRport(t *testing.T) {
+	pbx := fakepbx.NewFakePBX(t, fakepbx.WithAuth("1001", "test"))
+	connectPBX(t, pbx)
+
+	assert.GreaterOrEqual(t, pbx.RegisterCount(), 1)
+	via := pbx.LastRegister().Via()
+	require.NotNil(t, via)
+	assert.False(t, via.Params.Has("rport"), "Via must NOT carry rport when NAT is disabled")
+}

--- a/options.go
+++ b/options.go
@@ -47,6 +47,13 @@ type Config struct {
 	OutboundPassword string
 
 	NATKeepaliveInterval time.Duration
+	// NAT enables RFC 3581 rport on outgoing SIP requests. rport (response
+	// port) instructs the server to send SIP responses back to the source
+	// IP:port the request arrived on rather than the sent-by address in
+	// the Via header. Required when the phone sits behind NAT (most dev
+	// environments, containerized deployments) and the PBX would otherwise
+	// reply to an unreachable port. Applies only to UDP transports.
+	NAT bool
 
 	StunServer string
 	SRTP       bool
@@ -406,6 +413,16 @@ func WithAuthUsername(username string) PhoneOption {
 	}
 }
 
+// WithNAT enables RFC 3581 rport on outgoing SIP requests. See Config.NAT.
+// Use this when the phone sits behind NAT and the PBX must reply to the
+// source IP:port of the request (the NAT-mapped address) rather than the
+// sent-by address in the Via header.
+func WithNAT() PhoneOption {
+	return func(c *Config) {
+		c.NAT = true
+	}
+}
+
 // WithSRTP enables SRTP (Secure RTP) for media encryption.
 // When enabled, SDP offers use RTP/SAVP with AES_CM_128_HMAC_SHA1_80.
 func WithSRTP() PhoneOption {
@@ -475,6 +492,8 @@ type ServerConfig struct {
 	RTPAddress string
 	// SRTP enables SRTP media encryption (RTP/SAVP with AES_CM_128_HMAC_SHA1_80).
 	SRTP bool
+	// NAT enables RFC 3581 rport on outgoing SIP requests. See Config.NAT.
+	NAT bool
 	// CodecPrefs sets the codec preference order. Default: [PCMU].
 	CodecPrefs []Codec
 	// JitterBuffer sets the jitter buffer depth. Default: 50ms.

--- a/options_test.go
+++ b/options_test.go
@@ -125,3 +125,9 @@ func TestResolveRegisterAuthUsername_BothEmpty(t *testing.T) {
 	cfg := Config{}
 	assert.Empty(t, resolveRegisterAuthUsername(cfg))
 }
+
+func TestWithNAT_SetsConfig(t *testing.T) {
+	cfg := Config{}
+	WithNAT()(&cfg)
+	assert.True(t, cfg.NAT)
+}

--- a/server.go
+++ b/server.go
@@ -466,7 +466,11 @@ func (s *server) setupSipStack() error {
 		return fmt.Errorf("xphone: server create UA: %w", err)
 	}
 
-	client, err := sipgo.NewClient(ua, sipgo.WithClientHostname(s.localIP))
+	clientOpts := []sipgo.ClientOption{sipgo.WithClientHostname(s.localIP)}
+	if s.cfg.NAT {
+		clientOpts = append(clientOpts, sipgo.WithClientNAT())
+	}
+	client, err := sipgo.NewClient(ua, clientOpts...)
 	if err != nil {
 		ua.Close()
 		return fmt.Errorf("xphone: server create client: %w", err)

--- a/sipua.go
+++ b/sipua.go
@@ -135,7 +135,11 @@ func newSipUA(cfg Config, contactIP string) (*sipUA, error) {
 		return nil, fmt.Errorf("xphone: create UA: %w", err)
 	}
 
-	client, err := sipgo.NewClient(ua, sipgo.WithClientHostname(contactIP))
+	clientOpts := []sipgo.ClientOption{sipgo.WithClientHostname(contactIP)}
+	if cfg.NAT && strings.EqualFold(cfg.Transport, "udp") {
+		clientOpts = append(clientOpts, sipgo.WithClientNAT())
+	}
+	client, err := sipgo.NewClient(ua, clientOpts...)
 	if err != nil {
 		ua.Close()
 		return nil, fmt.Errorf("xphone: create client: %w", err)


### PR DESCRIPTION
## Summary
- New `WithNAT()` PhoneOption + `Config.NAT` + `ServerConfig.NAT` enable RFC 3581 rport on outgoing UDP SIP requests. Needed when a phone sits behind NAT and the PBX would otherwise reply to the sent-by Via address instead of the NAT-mapped source IP:port.
- Wired into both Phone and Server sipgo client construction via `sipgo.WithClientNAT()` (already shipped in upstream sipgo v1.2.1 — no library change needed).
- Phone-side gated on `cfg.Transport == "udp"` per RFC 3581 scope. Server is UDP-only by construction.

## Test plan
- [x] Unit test: `WithNAT` sets `Config.NAT = true`
- [x] fakepbx integration: REGISTER Via carries `;rport` when NAT enabled
- [x] fakepbx integration: REGISTER Via omits `;rport` by default (preserves existing behavior)
- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `gofmt -s -w` on all changed Go files

## Notes
- sipgo's client-level rport flag applies uniformly to REGISTER / SUBSCRIBE / MESSAGE / INVITE via `clientRequestCreateVia`. Testing REGISTER end-to-end verifies the wiring for all methods.
- No per-request overhead when `NAT=false` — single boolean check at construction time.