### PR TITLE
feat!: route all outbound SIP requests through OutboundProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Breaking changes
+- `WithOutboundProxy` / `Config.OutboundProxy` now routes **all** outbound SIP requests (REGISTER, SUBSCRIBE, MESSAGE, INVITE) through the proxy, not just INVITE. Matches how Kamailio / OpenSIPS / Asterisk outbound-proxy deployments expect a single next-hop for all signaling. Migration: for most deployments no action is needed — the proxy was already the expected next-hop. Callers who genuinely needed the prior "INVITE via proxy, REGISTER direct" split can either drop `OutboundProxy` (all requests go direct to `Host`) or run two `Phone` instances, one for registration and one for outbound calls.
+
 ## v0.5.12
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ func pcmToFloat32(frame []int16) []float32 {
 - 302 redirect following
 - Early media (183 Session Progress)
 - `ReplaceAudioWriter` — atomic audio source swap (e.g., music on hold)
-- Outbound proxy routing (`WithOutboundProxy`)
+- Outbound proxy routing (`WithOutboundProxy`) — single next-hop for all signaling (REGISTER, SUBSCRIBE, MESSAGE, INVITE)
 - Separate outbound credentials (`WithOutboundCredentials`)
 - Separate digest auth identity (`WithAuthUsername`) — for PBXes like 3CX where the Authentication ID differs from the extension
 - Custom headers on outbound INVITEs (`WithHeader`, `DialOptions.CustomHeaders`)
@@ -465,7 +465,7 @@ phone := xphone.New(
     xphone.WithICE(true),                                   // ICE-Lite
     xphone.WithTurnServer("turn.example.com:3478"),
     xphone.WithTurnCredentials("user", "pass"),
-    xphone.WithOutboundProxy("sip:proxy.example.com:5060"),   // route INVITEs via proxy
+    xphone.WithOutboundProxy("sip:proxy.example.com:5060"),   // single next-hop for all SIP signaling
     xphone.WithOutboundCredentials("trunk-user", "trunk-pass"), // separate INVITE auth
     xphone.WithAuthUsername("auth-id"),                         // 3CX-style: digest username != SIP AOR
     xphone.WithLogger(slog.Default()),

--- a/fakepbx_test.go
+++ b/fakepbx_test.go
@@ -812,3 +812,28 @@ func TestFakePBX_Register_AuthUsernameSplitIdentity(t *testing.T) {
 	assert.Contains(t, authHdr.Value(), `username="auth-id"`,
 		"digest username must use AuthUsername, not Username")
 }
+
+// F23: OutboundProxy routes REGISTER through the proxy, not directly to the
+// registrar. Matches how Kamailio/OpenSIPS/Asterisk expect a single next-hop
+// for all signaling. The proxy sees the REGISTER; the registrar does not.
+func TestFakePBX_OutboundProxy_RoutesRegister(t *testing.T) {
+	// Registrar with auth — would challenge if REGISTER reached it directly.
+	registrar := fakepbx.NewFakePBX(t, fakepbx.WithAuth("1001", "test"))
+	// Proxy with no auth — accepts REGISTER unconditionally.
+	proxy := fakepbx.NewFakePBX(t)
+
+	cfg := pbxConfig(t, registrar)
+	cfg.OutboundProxy = "sip:" + proxy.Addr()
+	connectWithConfig(t, cfg)
+
+	assert.GreaterOrEqual(t, proxy.RegisterCount(), 1, "proxy should receive REGISTER")
+	assert.Equal(t, 0, registrar.RegisterCount(), "registrar should NOT receive REGISTER directly")
+
+	// The Request-URI on the REGISTER still targets the registrar host —
+	// only the next-hop transport is the proxy.
+	last := proxy.LastRegister()
+	require.NotNil(t, last)
+	registrarHost, _, _ := net.SplitHostPort(registrar.Addr())
+	assert.Equal(t, registrarHost, last.Recipient.Host,
+		"Request-URI host must point at registrar, not proxy")
+}

--- a/options.go
+++ b/options.go
@@ -31,9 +31,13 @@ type Config struct {
 	RegisterRetry    time.Duration
 	RegisterMaxRetry int
 
-	// OutboundProxy is the SIP URI to route outbound INVITEs through (e.g. "sip:proxy.example.com:5060").
-	// When set, the initial INVITE is sent to this address instead of Host.
-	// Registration still goes to Host. In-dialog requests use the route set from Record-Route.
+	// OutboundProxy is the SIP URI to route outbound requests through
+	// (e.g. "sip:proxy.example.com:5060"). When set, REGISTER, SUBSCRIBE,
+	// MESSAGE, and the initial INVITE are all sent to this address; the
+	// Request-URI keeps pointing at Host so registration still targets the
+	// registrar logically. In-dialog requests use the route set from
+	// Record-Route. This matches how Kamailio / OpenSIPS / Asterisk
+	// outbound-proxy deployments expect a single next-hop for all signaling.
 	OutboundProxy string
 	// OutboundUsername is the SIP digest username for outbound INVITE auth (401/407).
 	// Falls back to Username if empty.
@@ -366,9 +370,10 @@ func WithICE(enabled bool) PhoneOption {
 	}
 }
 
-// WithOutboundProxy sets the SIP URI to route outbound INVITEs through.
-// Registration still goes to the configured Host. In-dialog requests
-// (re-INVITE, BYE) use the route set established via Record-Route.
+// WithOutboundProxy sets the SIP URI to route all outbound requests
+// through (REGISTER, SUBSCRIBE, MESSAGE, initial INVITE). In-dialog
+// requests (re-INVITE, BYE) use the route set established via
+// Record-Route. See Config.OutboundProxy for details.
 // Example: "sip:proxy.example.com:5060"
 func WithOutboundProxy(uri string) PhoneOption {
 	return func(c *Config) {

--- a/sipua.go
+++ b/sipua.go
@@ -204,6 +204,23 @@ func resolveRegisterAuthUsername(cfg Config) string {
 	return cfg.Username
 }
 
+// outboundProxyRouteHeader returns a loose-routing Route header pointing at
+// the configured outbound proxy, or nil when no proxy is configured. Per
+// RFC 3261 §8.1.2 this forces requests through the proxy while keeping the
+// Request-URI pointing at its logical target. ;lr is enforced here as a
+// safety net — WithOutboundProxy normalises it, but callers setting
+// Config.OutboundProxy directly still get a compliant Route.
+func (s *sipUA) outboundProxyRouteHeader() sip.Header {
+	uri := s.cfg.OutboundProxy
+	if uri == "" {
+		return nil
+	}
+	if !hasURIParam(uri, "lr") {
+		uri += ";lr"
+	}
+	return sip.NewHeader("Route", "<"+uri+">")
+}
+
 // dialWithOpts establishes an outbound SIP dialog with DialOptions.
 // It delegates to dial, passing through video options for SDP construction.
 func (s *sipUA) dialWithOpts(ctx context.Context, target string, opts DialOptions, onResponse func(code int, reason string)) (dialog, error) {
@@ -688,6 +705,14 @@ func (s *sipUA) SendRequest(ctx context.Context, method string, headers map[stri
 		req.AppendHeader(sip.NewHeader(k, v))
 	}
 
+	// Prepend the outbound-proxy Route so it is the topmost Route header —
+	// sipgo picks the first Route for next-hop selection, so prepending
+	// guarantees the proxy wins even if a caller supplies their own Route
+	// via `headers`.
+	if h := s.outboundProxyRouteHeader(); h != nil {
+		req.PrependHeader(h)
+	}
+
 	// Determine request build options.
 	var opts []sipgo.ClientRequestOption
 	if method == "REGISTER" {
@@ -743,6 +768,11 @@ func (s *sipUA) buildOutboundRequest(method sip.RequestMethod, uri string, heade
 
 	for k, v := range headers {
 		req.AppendHeader(sip.NewHeader(k, v))
+	}
+
+	// Prepend the outbound-proxy Route so it is the topmost Route header.
+	if h := s.outboundProxyRouteHeader(); h != nil {
+		req.PrependHeader(h)
 	}
 	return req
 }


### PR DESCRIPTION
## Summary

`WithOutboundProxy` / `Config.OutboundProxy` now routes **all** outbound SIP requests (REGISTER, SUBSCRIBE, MESSAGE, INVITE) through the proxy, not just INVITE. This matches how Kamailio / OpenSIPS / Asterisk outbound-proxy deployments expect a single next-hop for all signaling, and mirrors the ongoing scope-broadening in xphone-rust.

## Breaking change

The prior godoc explicitly guaranteed *"Registration still goes to Host"*. That's no longer true. For most deployments this is the expected behavior and no action is needed. Callers who genuinely needed the prior "INVITE via proxy, REGISTER direct" split can either drop `OutboundProxy` (all requests go direct to `Host`) or run two `Phone` instances — one for registration, one for outbound calls. Documented in CHANGELOG.

## Implementation

- New `(s *sipUA) outboundProxyRouteHeader()` helper centralises Route-header construction, enforces `;lr` even when `Config.OutboundProxy` is set directly (bypassing `WithOutboundProxy`'s normalization), and returns a nil-safe `sip.Header`.
- Uses `PrependHeader` so the proxy Route is always the **topmost** Route — sipgo selects the first Route for next-hop, so prepending guarantees the proxy wins even if a caller supplies their own `Route` via `headers`.
- INVITE path was already correct and is unchanged.

## Test plan
- [x] New `TestFakePBX_OutboundProxy_RoutesRegister`: two fakepbx instances (registrar with auth, proxy without); asserts proxy sees REGISTER, registrar does not, and Request-URI host still points at registrar.
- [x] Existing `TestFakePBX_OutboundProxy` (INVITE-via-proxy) still green.
- [x] Full `go test ./...` green.
- [x] `go vet ./...` clean.
- [x] `gofmt -s -w` on all changed Go files.

## Review applied
Findings from `/review` (Codex + Claude agents):
- `;lr` safety net in helper for direct `Config.OutboundProxy` assignments
- `PrependHeader` to guarantee proxy Route is topmost
- Test-comment numbering renamed F21→F23 to avoid collision with #97
- Strengthened CHANGELOG migration guidance