### PR TITLE
fix: surface REGISTER failure details via typed error (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug fixes
+- REGISTER failure now surfaces the last observed SIP response code and reason via a typed `*RegistrationFailedError{Code, Reason, TransportErr}` returned from `Phone.Connect()` and delivered to `Phone.OnError`. The final error log includes `last_code`, `last_reason`, and `last_err` (omitted when nil) — previously the library logged only `registration failed` with no actionable detail, forcing tcpdump-level diagnosis. Per-attempt retries now log at debug level with attempt number, code, and reason. (#96)
+  - `errors.Is(err, ErrRegistrationFailed)` and `errors.Is(err, regErr.TransportErr)` both still match via `Unwrap() []error`.
+  - Minor compatibility note: callers that relied on **direct equality** (`err == ErrRegistrationFailed`) or `errors.Unwrap(err)` returning the sentinel must switch to `errors.Is`. `errors.Is` has been the recommended form since Go 1.13.
+
 ### Breaking changes
 - `WithOutboundProxy` / `Config.OutboundProxy` now routes **all** outbound SIP requests (REGISTER, SUBSCRIBE, MESSAGE, INVITE) through the proxy, not just INVITE. Matches how Kamailio / OpenSIPS / Asterisk outbound-proxy deployments expect a single next-hop for all signaling. Migration: for most deployments no action is needed — the proxy was already the expected next-hop. Callers who genuinely needed the prior "INVITE via proxy, REGISTER direct" split can either drop `OutboundProxy` (all requests go direct to `Host`) or run two `Phone` instances, one for registration and one for outbound calls.
 

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,9 @@
 package xphone
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Sentinel errors returned by Phone and Call methods.
 var (
@@ -51,3 +54,46 @@ var (
 	// ErrPeerRejected is returned when an incoming request fails peer authentication.
 	ErrPeerRejected = errors.New("xphone: peer authentication failed")
 )
+
+// RegistrationFailedError wraps ErrRegistrationFailed with the last observed
+// SIP response on the failing REGISTER transaction. Callers can inspect Code
+// and Reason to distinguish transient failures (5xx, transport error) from
+// permanent ones (401/403 — bad credentials). Unwraps to the sentinel error
+// ErrRegistrationFailed, so errors.Is(err, ErrRegistrationFailed) keeps working.
+//
+// Code and Reason come from the SIP response on the last retry attempt. When
+// the last attempt failed at the transport layer before any response (timeout,
+// network error), Code is 0 and TransportErr carries the transport error.
+type RegistrationFailedError struct {
+	// Code is the SIP status code on the last REGISTER response (e.g. 401, 403).
+	// Zero when no response was received on the last attempt.
+	Code int
+	// Reason is the SIP reason phrase on the last REGISTER response.
+	Reason string
+	// TransportErr is the transport-layer error on the last attempt, if any.
+	// Non-nil only when Code == 0.
+	TransportErr error
+}
+
+func (e *RegistrationFailedError) Error() string {
+	base := ErrRegistrationFailed.Error()
+	switch {
+	case e.TransportErr != nil && e.Code != 0:
+		return fmt.Sprintf("%s: last response %d %q, transport error %v", base, e.Code, e.Reason, e.TransportErr)
+	case e.TransportErr != nil:
+		return fmt.Sprintf("%s: %v", base, e.TransportErr)
+	case e.Reason != "":
+		return fmt.Sprintf("%s: last response %d %s", base, e.Code, e.Reason)
+	default:
+		return fmt.Sprintf("%s: last response %d", base, e.Code)
+	}
+}
+
+// Unwrap lets errors.Is(err, ErrRegistrationFailed) match, and errors.Is on
+// TransportErr match its underlying error when present.
+func (e *RegistrationFailedError) Unwrap() []error {
+	if e.TransportErr != nil {
+		return []error{ErrRegistrationFailed, e.TransportErr}
+	}
+	return []error{ErrRegistrationFailed}
+}

--- a/registry.go
+++ b/registry.go
@@ -153,8 +153,12 @@ func (r *registry) State() PhoneState {
 // Auth challenges (401/407) are handled by the transport layer (sipUA uses DoDigestAuth).
 // Retries up to RegisterMaxRetry times with RegisterRetry delay between attempts.
 // On success, transitions to Registered and fires OnRegistered.
-// On exhausting retries, fires OnError(ErrRegistrationFailed).
+// On exhausting retries, fires OnError with a *RegistrationFailedError carrying
+// the last observed status code / reason / transport error.
 func (r *registry) register(ctx context.Context) error {
+	var lastCode int
+	var lastReason string
+	var lastErr error
 	for attempt := 0; attempt < r.cfg.RegisterMaxRetry; attempt++ {
 		if attempt > 0 {
 			select {
@@ -164,8 +168,10 @@ func (r *registry) register(ctx context.Context) error {
 			}
 		}
 
-		code, _, err := r.tr.SendRequest(ctx, "REGISTER", nil)
+		code, reason, err := r.tr.SendRequest(ctx, "REGISTER", nil)
+		lastCode, lastReason, lastErr = code, reason, err
 		if err != nil {
+			r.logger.Debug("register attempt failed", "attempt", attempt+1, "err", err)
 			continue
 		}
 
@@ -180,6 +186,7 @@ func (r *registry) register(ctx context.Context) error {
 			}
 			return nil
 		}
+		r.logger.Debug("register rejected", "attempt", attempt+1, "code", code, "reason", reason)
 	}
 
 	// All retries exhausted.
@@ -187,11 +194,16 @@ func (r *registry) register(ctx context.Context) error {
 	r.state = PhoneStateRegistrationFailed
 	errFn := r.onError
 	r.mu.Unlock()
-	r.logger.Error("registration failed")
-	if errFn != nil {
-		go errFn(ErrRegistrationFailed)
+	regErr := &RegistrationFailedError{Code: lastCode, Reason: lastReason, TransportErr: lastErr}
+	logAttrs := []any{"last_code", lastCode, "last_reason", lastReason}
+	if lastErr != nil {
+		logAttrs = append(logAttrs, "last_err", lastErr)
 	}
-	return ErrRegistrationFailed
+	r.logger.Error("registration failed", logAttrs...)
+	if errFn != nil {
+		go errFn(regErr)
+	}
+	return regErr
 }
 
 // handleDrop is called by the transport when the connection drops.

--- a/registry_test.go
+++ b/registry_test.go
@@ -2,6 +2,7 @@ package xphone
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -246,4 +247,89 @@ func TestRegistry_NATKeepalivesSentOnInterval(t *testing.T) {
 	time.Sleep(70 * time.Millisecond)
 
 	assert.GreaterOrEqual(t, tr.CountSentKeepalives(), 2)
+}
+
+// Regression: #96 — REGISTER failure must surface last_code + last_reason so
+// operators can diagnose "registration failed" without tcpdump. The typed
+// error also unwraps to ErrRegistrationFailed for backward compatibility.
+func TestRegistry_FailureErrorCarriesLastResponseCodeAndReason(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.RespondSequence(
+		testutil.Response{Code: 401, Header: "Unauthorized"},
+		testutil.Response{Code: 403, Header: "Forbidden"},
+	)
+
+	cfg := testConfig()
+	cfg.RegisterMaxRetry = 2
+
+	r := newRegistry(tr, cfg)
+	errFired := make(chan error, 1)
+	r.OnError(func(err error) { errFired <- err })
+	r.Start(context.Background())
+
+	select {
+	case err := <-errFired:
+		assert.ErrorIs(t, err, ErrRegistrationFailed)
+		var regErr *RegistrationFailedError
+		require.True(t, errors.As(err, &regErr), "error must be *RegistrationFailedError")
+		assert.Equal(t, 403, regErr.Code, "Code should be the last response code")
+		assert.Equal(t, "Forbidden", regErr.Reason)
+		assert.Nil(t, regErr.TransportErr)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnError never fired")
+	}
+}
+
+// When the last retry fails at the transport layer, Code is 0 and
+// TransportErr carries the underlying error.
+func TestRegistry_FailureErrorCarriesTransportError(t *testing.T) {
+	tr := testutil.NewMockTransport()
+	tr.FailNext(99)
+
+	cfg := testConfig()
+	cfg.RegisterMaxRetry = 2
+
+	r := newRegistry(tr, cfg)
+	errFired := make(chan error, 1)
+	r.OnError(func(err error) { errFired <- err })
+	r.Start(context.Background())
+
+	select {
+	case err := <-errFired:
+		assert.ErrorIs(t, err, ErrRegistrationFailed)
+		var regErr *RegistrationFailedError
+		require.True(t, errors.As(err, &regErr))
+		assert.Equal(t, 0, regErr.Code)
+		assert.Empty(t, regErr.Reason)
+		require.NotNil(t, regErr.TransportErr)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("OnError never fired")
+	}
+}
+
+func TestRegistrationFailedError_ErrorString(t *testing.T) {
+	e1 := &RegistrationFailedError{Code: 403, Reason: "Forbidden"}
+	assert.Contains(t, e1.Error(), "403")
+	assert.Contains(t, e1.Error(), "Forbidden")
+	assert.Contains(t, e1.Error(), "registration failed")
+
+	e2 := &RegistrationFailedError{TransportErr: errors.New("conn refused")}
+	assert.Contains(t, e2.Error(), "conn refused")
+	assert.Contains(t, e2.Error(), "registration failed")
+
+	// Empty reason shouldn't produce a trailing space.
+	e3 := &RegistrationFailedError{Code: 500}
+	assert.Equal(t, "xphone: registration failed: last response 500", e3.Error())
+}
+
+// errors.Is must match the underlying TransportErr through the multi-error
+// Unwrap chain — not just ErrRegistrationFailed. This lets callers
+// distinguish transient network failures (net.OpError, context.DeadlineExceeded)
+// from permanent rejections.
+func TestRegistrationFailedError_ErrorsIsMatchesTransportErr(t *testing.T) {
+	netErr := errors.New("dial tcp: connection refused")
+	regErr := &RegistrationFailedError{TransportErr: netErr}
+
+	assert.ErrorIs(t, regErr, ErrRegistrationFailed)
+	assert.ErrorIs(t, regErr, netErr)
 }


### PR DESCRIPTION
Closes #96.

## Summary

REGISTER failure now surfaces the last observed SIP response code/reason via a typed `*RegistrationFailedError{Code, Reason, TransportErr}` returned from `Phone.Connect()` and delivered to `Phone.OnError`. Previously the library logged only `registration failed` with no actionable detail, making 3CX-style auth debugging impossible without tcpdump.

## Log output

Before:
\`\`\`
ERROR registration failed
\`\`\`

After:
\`\`\`
ERROR registration failed last_code=403 last_reason=Forbidden
\`\`\`

Or on a transport failure:
\`\`\`
ERROR registration failed last_code=0 last_reason= last_err=\"dial tcp: connection refused\"
\`\`\`

## Error inspection

\`\`\`go
var regErr *xphone.RegistrationFailedError
if errors.As(err, &regErr) {
    log.Printf(\"register failed %d %q\", regErr.Code, regErr.Reason)
    if regErr.TransportErr != nil {
        // transport-level failure — retryable
    }
}

// Sentinel match still works
errors.Is(err, xphone.ErrRegistrationFailed)  // true

// Underlying transport error also matches through multi-error Unwrap
errors.Is(err, regErr.TransportErr)  // true
\`\`\`

## Minor compatibility note

Callers relying on **direct equality** (\`err == xphone.ErrRegistrationFailed\`) or \`errors.Unwrap(err) == ErrRegistrationFailed\` must switch to \`errors.Is(err, ErrRegistrationFailed)\`, which has been the recommended form since Go 1.13. Documented in CHANGELOG.

## Test plan
- [x] Unit tests cover: last response Code/Reason after 401→403, transport-error case (Code=0 + TransportErr set), `errors.Is` through multi-error Unwrap, `Error()` format for all four branches.
- [x] Existing `TestRegistry_StopsAfterMaxRetryExceeded` still passes — the typed error unwraps to the sentinel.
- [x] Full `go test ./...` green.
- [x] `go vet ./...` clean.
- [x] `gofmt -s -w` on all changed Go files.

## Out of scope (noted for follow-ups)
- \`423 Min-Expires\` handling (pre-existing RFC 3261 §10.2.8 gap)
- `Unregister()` / refresh paths still don't log reason phrase
- \`ctx\` cancellation mid-retry doesn't fire `OnError` (pre-existing)