### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.0
+
 ### Bug fixes
 - REGISTER failure now surfaces the last observed SIP response code and reason via a typed `*RegistrationFailedError{Code, Reason, TransportErr}` returned from `Phone.Connect()` and delivered to `Phone.OnError`. The final error log includes `last_code`, `last_reason`, and `last_err` (omitted when nil) — previously the library logged only `registration failed` with no actionable detail, forcing tcpdump-level diagnosis. Per-attempt retries now log at debug level with attempt number, code, and reason. (#96)
   - `errors.Is(err, ErrRegistrationFailed)` and `errors.Is(err, regErr.TransportErr)` both still match via `Unwrap() []error`.


### PR DESCRIPTION
Minor bump — breaking change to `WithOutboundProxy` semantics (pre-1.0 series).

## What's in v0.6.0

### Breaking
- `WithOutboundProxy` now routes **all** outbound SIP requests (REGISTER, SUBSCRIBE, MESSAGE, INVITE) through the proxy — previously INVITE-only. Matches Kamailio / OpenSIPS / Asterisk deployments. (#98)

### Features
- `WithNAT()` / `Config.NAT` / `ServerConfig.NAT` — RFC 3581 rport on outgoing UDP requests for NAT'd phones/servers. (#97)

### Bug fixes
- REGISTER failure now surfaces last observed SIP code/reason via typed `*RegistrationFailedError{Code, Reason, TransportErr}` on `Phone.OnError` and structured log fields. (#96, #99)

## Test plan
- [x] CHANGELOG diff — single `Unreleased → v0.6.0` heading move
- [x] All three feature/fix PRs already green on main