### PR TITLE
feat: WithRTPAddress + IPv4 validation for Phone and Server (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## Unreleased
 
 ### Features
-- `WithRTPAddress(ip)` PhoneOption (plus `Config.RTPAddress`) — overrides the IPv4 literal advertised in SIP Contact headers, the SDP `c=` line, and the ICE host candidate. Takes precedence over STUN discovery and `localIPFor()` auto-detection. Mirrors the existing `ServerConfig.RTPAddress` on the trunk side. Required for local dev against a LAN PBX when the kernel's outbound interface lookup picks an IP that isn't routable from the peer — Docker container IP, VPN tunnel, multi-homed host, or WSL2 vEthernet. Non-IPv4 input (IPv6, hostnames, whitespace, CRLF) is rejected with a log warning and treated as unset, preventing header/SDP injection. (#105)
+- `WithRTPAddress(ip)` PhoneOption (plus `Config.RTPAddress`) — overrides the IPv4 literal advertised in SIP Contact headers, the SDP `c=` line, and the ICE host candidate. Takes precedence over STUN discovery and `localIPFor()` auto-detection. Mirrors the existing `ServerConfig.RTPAddress` on the trunk side. Required for local dev against a LAN PBX when the kernel's outbound interface lookup picks an IP that isn't routable from the peer — Docker container IP, VPN tunnel, multi-homed host, or WSL2 vEthernet. (#105)
+
+### Bug fixes
+- `Config.RTPAddress`, `ServerConfig.RTPAddress`, and `PeerConfig.RTPAddress` now validate their input as IPv4 literals at construction. Non-IPv4 values (IPv6, hostnames, whitespace, embedded CRLF) are rejected with a log warning and treated as unset. Previously, unvalidated strings flowed verbatim into SDP `c=` lines and SIP Contact headers, exposing a CRLF header-injection surface. Applies symmetrically to both Phone and Server configs.
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- `WithRTPAddress(ip)` PhoneOption (plus `Config.RTPAddress`) — overrides the IP advertised in SIP Contact headers and the SDP `c=` line, taking precedence over STUN discovery and `localIPFor()` auto-detection. Mirrors the existing `ServerConfig.RTPAddress` on the trunk side. Required for local dev against a LAN PBX when the kernel's outbound interface lookup picks an IP that isn't routable from the peer — Docker container IP, VPN tunnel, multi-homed host, or WSL2 vEthernet. (#105)
+
 ## v0.6.0
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Features
-- `WithRTPAddress(ip)` PhoneOption (plus `Config.RTPAddress`) — overrides the IP advertised in SIP Contact headers and the SDP `c=` line, taking precedence over STUN discovery and `localIPFor()` auto-detection. Mirrors the existing `ServerConfig.RTPAddress` on the trunk side. Required for local dev against a LAN PBX when the kernel's outbound interface lookup picks an IP that isn't routable from the peer — Docker container IP, VPN tunnel, multi-homed host, or WSL2 vEthernet. (#105)
+- `WithRTPAddress(ip)` PhoneOption (plus `Config.RTPAddress`) — overrides the IPv4 literal advertised in SIP Contact headers, the SDP `c=` line, and the ICE host candidate. Takes precedence over STUN discovery and `localIPFor()` auto-detection. Mirrors the existing `ServerConfig.RTPAddress` on the trunk side. Required for local dev against a LAN PBX when the kernel's outbound interface lookup picks an IP that isn't routable from the peer — Docker container IP, VPN tunnel, multi-homed host, or WSL2 vEthernet. Non-IPv4 input (IPv6, hostnames, whitespace, CRLF) is rejected with a log warning and treated as unset, preventing header/SDP injection. (#105)
 
 ## v0.6.0
 

--- a/options.go
+++ b/options.go
@@ -58,6 +58,14 @@ type Config struct {
 	StunServer string
 	SRTP       bool
 
+	// RTPAddress is the IP to advertise in SIP Contact headers and the SDP c=
+	// line. When set, it overrides the auto-detected local IP (localIPFor) and
+	// STUN-discovered IP — useful for local dev against a LAN PBX where the
+	// auto-detected interface isn't routable from the PBX (Docker container IP,
+	// VPN interface, multi-homed host, WSL2 vEthernet). Parallel to
+	// ServerConfig.RTPAddress on the trunk side.
+	RTPAddress string
+
 	// TurnServer is the TURN server address (host:port) for relay allocation.
 	// When set with TurnUsername/TurnPassword, the phone allocates a TURN relay
 	// during call setup for symmetric NAT traversal.
@@ -339,6 +347,19 @@ func WithMediaTimeout(d time.Duration) PhoneOption {
 func WithNATKeepalive(d time.Duration) PhoneOption {
 	return func(c *Config) {
 		c.NATKeepaliveInterval = d
+	}
+}
+
+// WithRTPAddress sets the IP to advertise in SIP Contact headers and the SDP
+// c= line, overriding auto-detection and STUN discovery. Mirrors
+// ServerConfig.RTPAddress on the Server side. Use this when the kernel's
+// outbound interface lookup picks an IP that isn't routable from the peer
+// (Docker container IP, VPN tunnel, multi-homed host, WSL2 vEthernet).
+// Example: WithRTPAddress("10.27.1.137") on a Mac with Docker port-forwarding
+// the RTP range back to the container.
+func WithRTPAddress(ip string) PhoneOption {
+	return func(c *Config) {
+		c.RTPAddress = ip
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -512,8 +512,10 @@ type ServerConfig struct {
 	RTPPortMin int
 	// RTPPortMax is the maximum RTP port to allocate. 0 means OS-assigned.
 	RTPPortMax int
-	// RTPAddress is the public IP to advertise in SDP when listening on 0.0.0.0.
-	// If empty, the listen address or auto-detected local IP is used.
+	// RTPAddress is the IPv4 literal to advertise in SDP when listening on
+	// 0.0.0.0. If empty, the listen address or auto-detected local IP is
+	// used. Non-IPv4 values (IPv6, hostnames, whitespace, CRLF) are rejected
+	// at newServer() with a log warning and treated as unset.
 	RTPAddress string
 	// SRTP enables SRTP media encryption (RTP/SAVP with AES_CM_128_HMAC_SHA1_80).
 	SRTP bool
@@ -547,9 +549,11 @@ type PeerConfig struct {
 	Port int
 	// Auth enables SIP digest authentication for this peer.
 	Auth *PeerAuthConfig
-	// RTPAddress overrides the server-level RTPAddress for this peer.
-	// Use when this peer needs to see a different IP in SDP (e.g. different
-	// network interface). Empty means use the server-level setting.
+	// RTPAddress overrides the server-level RTPAddress for this peer. Must be
+	// an IPv4 literal. Use when this peer needs to see a different IP in SDP
+	// (e.g. different network interface). Empty or non-IPv4 values fall back
+	// to the server-level setting (non-IPv4 values are warned about at
+	// newServer() and treated as unset).
 	RTPAddress string
 	// Codecs restricts the codecs offered/accepted for this peer.
 	// Empty means accept any codec from the server-level CodecPrefs.

--- a/options.go
+++ b/options.go
@@ -58,12 +58,14 @@ type Config struct {
 	StunServer string
 	SRTP       bool
 
-	// RTPAddress is the IP to advertise in SIP Contact headers and the SDP c=
-	// line. When set, it overrides the auto-detected local IP (localIPFor) and
-	// STUN-discovered IP — useful for local dev against a LAN PBX where the
-	// auto-detected interface isn't routable from the PBX (Docker container IP,
-	// VPN interface, multi-homed host, WSL2 vEthernet). Parallel to
-	// ServerConfig.RTPAddress on the trunk side.
+	// RTPAddress is the IPv4 literal to advertise in SIP Contact headers, the
+	// SDP c= line, and the ICE host candidate. When set to a valid IPv4, it
+	// overrides auto-detection (localIPFor) and skips STUN discovery entirely.
+	// Non-IPv4 values (IPv6, hostnames, garbage) are rejected at construction
+	// with a log warning and treated as unset. Useful for local dev against a
+	// LAN PBX where the auto-detected interface isn't routable from the peer
+	// (Docker container IP, VPN interface, multi-homed host, WSL2 vEthernet).
+	// Parallel to ServerConfig.RTPAddress on the trunk side.
 	RTPAddress string
 
 	// TurnServer is the TURN server address (host:port) for relay allocation.
@@ -350,13 +352,15 @@ func WithNATKeepalive(d time.Duration) PhoneOption {
 	}
 }
 
-// WithRTPAddress sets the IP to advertise in SIP Contact headers and the SDP
-// c= line, overriding auto-detection and STUN discovery. Mirrors
-// ServerConfig.RTPAddress on the Server side. Use this when the kernel's
-// outbound interface lookup picks an IP that isn't routable from the peer
-// (Docker container IP, VPN tunnel, multi-homed host, WSL2 vEthernet).
-// Example: WithRTPAddress("10.27.1.137") on a Mac with Docker port-forwarding
-// the RTP range back to the container.
+// WithRTPAddress sets the IPv4 literal to advertise in SIP Contact headers,
+// the SDP c= line, and the ICE host candidate. Overrides auto-detection and
+// skips STUN discovery. Mirrors ServerConfig.RTPAddress on the Server side.
+// Non-IPv4 values (IPv6, hostnames, whitespace) are rejected with a log
+// warning and treated as unset. Use this when the kernel's outbound interface
+// lookup picks an IP that isn't routable from the peer (Docker container IP,
+// VPN tunnel, multi-homed host, WSL2 vEthernet). Example:
+// WithRTPAddress("10.27.1.137") on a Mac with Docker port-forwarding the RTP
+// range back to the container.
 func WithRTPAddress(ip string) PhoneOption {
 	return func(c *Config) {
 		c.RTPAddress = ip

--- a/options_test.go
+++ b/options_test.go
@@ -131,3 +131,9 @@ func TestWithNAT_SetsConfig(t *testing.T) {
 	WithNAT()(&cfg)
 	assert.True(t, cfg.NAT)
 }
+
+func TestWithRTPAddress_SetsConfig(t *testing.T) {
+	cfg := Config{}
+	WithRTPAddress("10.27.1.137")(&cfg)
+	assert.Equal(t, "10.27.1.137", cfg.RTPAddress)
+}

--- a/phone_test.go
+++ b/phone_test.go
@@ -132,11 +132,71 @@ func TestNew_WithRTPAddress_OverridesLocalIP(t *testing.T) {
 		"RTPAddress override should flow into phone.localIP (SDP c= / SIP Contact)")
 }
 
+func TestNew_WithRTPAddress_AlignsHostIPForICE(t *testing.T) {
+	// When RTPAddress is set, phone.hostIP must also be aligned — otherwise
+	// ICE emits a high-priority host candidate at the auto-detected IP and
+	// a lower-priority srflx at the override, causing peers to probe the
+	// unroutable address first.
+	p := New(WithRTPAddress("10.27.1.137"))
+	ph := p.(*phone)
+	assert.Equal(t, "10.27.1.137", ph.hostIP,
+		"RTPAddress override should also align phone.hostIP (ICE host candidate)")
+	assert.Equal(t, ph.localIP, ph.hostIP,
+		"localIP and hostIP should match when RTPAddress is set, so ICE emits a single host candidate")
+}
+
+func TestNew_WithRTPAddress_RejectsInvalidInput(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"hostname", "example.com"},
+		{"crlf injection", "10.0.0.1\r\nBad-Header: injected"},
+		{"ipv6", "2001:db8::1"},
+		{"garbage", "not-an-ip"},
+		{"whitespace", " 10.0.0.1 "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := New(WithRTPAddress(tc.input))
+			ph := p.(*phone)
+			// Invalid input is preserved on Config (for observability) but
+			// never propagated into localIP / hostIP.
+			assert.Equal(t, tc.input, ph.cfg.RTPAddress)
+			assert.NotEqual(t, tc.input, ph.localIP,
+				"invalid RTPAddress must not flow into advertised IP")
+			assert.NotEqual(t, tc.input, ph.hostIP,
+				"invalid RTPAddress must not flow into ICE host candidate")
+		})
+	}
+}
+
 func TestNew_WithoutRTPAddress_UsesAutoDetect(t *testing.T) {
 	p := New()
 	ph := p.(*phone)
 	assert.Empty(t, ph.cfg.RTPAddress)
 	assert.NotEmpty(t, ph.localIP, "localIP should fall back to localIPFor(host)")
+}
+
+func TestEffectiveRTPAddress(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"10.27.1.137", "10.27.1.137"},
+		{"0.0.0.0", "0.0.0.0"},     // syntactically valid IPv4, caller's responsibility
+		{"127.0.0.1", "127.0.0.1"}, // loopback is valid syntax
+		{"2001:db8::1", ""},        // IPv6 rejected — stack is IPv4-only
+		{"example.com", ""},
+		{"10.0.0.1\r\nX-Hdr: x", ""},
+		{" 10.0.0.1", ""},
+		{"10.0.0.1 ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, effectiveRTPAddress(tc.in))
+		})
+	}
 }
 
 func TestNew_WithCodecs(t *testing.T) {

--- a/phone_test.go
+++ b/phone_test.go
@@ -124,6 +124,21 @@ func TestNew_WithRTPPorts(t *testing.T) {
 	assert.Equal(t, 20000, ph.cfg.RTPPortMax)
 }
 
+func TestNew_WithRTPAddress_OverridesLocalIP(t *testing.T) {
+	p := New(WithRTPAddress("10.27.1.137"))
+	ph := p.(*phone)
+	assert.Equal(t, "10.27.1.137", ph.cfg.RTPAddress)
+	assert.Equal(t, "10.27.1.137", ph.localIP,
+		"RTPAddress override should flow into phone.localIP (SDP c= / SIP Contact)")
+}
+
+func TestNew_WithoutRTPAddress_UsesAutoDetect(t *testing.T) {
+	p := New()
+	ph := p.(*phone)
+	assert.Empty(t, ph.cfg.RTPAddress)
+	assert.NotEmpty(t, ph.localIP, "localIP should fall back to localIPFor(host)")
+}
+
 func TestNew_WithCodecs(t *testing.T) {
 	p := New(WithCodecs(CodecPCMU, CodecPCMA, CodecG722))
 	ph := p.(*phone)

--- a/server.go
+++ b/server.go
@@ -89,9 +89,19 @@ func NewServer(cfg ServerConfig) Server {
 }
 
 func newServer(cfg ServerConfig) *server {
+	logger := resolveLogger(cfg.Logger)
+	if cfg.RTPAddress != "" && effectiveRTPAddress(cfg.RTPAddress) == "" {
+		logger.Warn("xphone: ServerConfig.RTPAddress ignored, not an IPv4 literal", "value", cfg.RTPAddress)
+	}
+	for i := range cfg.Peers {
+		peer := &cfg.Peers[i]
+		if peer.RTPAddress != "" && effectiveRTPAddress(peer.RTPAddress) == "" {
+			logger.Warn("xphone: PeerConfig.RTPAddress ignored, not an IPv4 literal", "peer", peer.Name, "value", peer.RTPAddress)
+		}
+	}
 	return &server{
 		cfg:           cfg,
-		logger:        resolveLogger(cfg.Logger),
+		logger:        logger,
 		codecPrefs:    codecPrefsToInts(cfg.CodecPrefs),
 		peerMatchers:  buildPeerMatchers(cfg.Peers),
 		state:         ServerStateStopped,
@@ -441,8 +451,8 @@ func (s *server) listenAddr() string {
 
 // resolveLocalIP determines the IP to advertise in SDP.
 func (s *server) resolveLocalIP() string {
-	if s.cfg.RTPAddress != "" {
-		return s.cfg.RTPAddress
+	if override := effectiveRTPAddress(s.cfg.RTPAddress); override != "" {
+		return override
 	}
 	host, _, err := net.SplitHostPort(s.listenAddr())
 	if err == nil && host != "" && host != "0.0.0.0" && host != "::" {
@@ -940,10 +950,14 @@ func (s *server) findPeer(name string) *PeerConfig {
 }
 
 // resolveRTPAddressForPeer returns the IP to use in SDP for a given peer.
-// Prefers peer-level RTPAddress, falls back to server-level.
+// Prefers peer-level RTPAddress (if a valid IPv4 literal), falls back to
+// server-level. Invalid peer overrides are ignored — they were warned about
+// at newServer().
 func (s *server) resolveRTPAddressForPeer(p *PeerConfig) string {
-	if p != nil && p.RTPAddress != "" {
-		return p.RTPAddress
+	if p != nil {
+		if override := effectiveRTPAddress(p.RTPAddress); override != "" {
+			return override
+		}
 	}
 	return s.localIP
 }

--- a/server_test.go
+++ b/server_test.go
@@ -326,6 +326,35 @@ func TestServer_ResolveRTPAddressForPeer(t *testing.T) {
 	}
 }
 
+func TestServer_ResolveRTPAddressForPeer_InvalidPeerOverrideFallsBack(t *testing.T) {
+	// Invalid peer-level RTPAddress must not be propagated — it falls back
+	// to the server-level IP so we never advertise an unparseable string.
+	s := &server{localIP: "203.0.113.1"}
+	cases := []string{
+		"example.com",
+		"10.0.0.1\r\nBad-Header: x",
+		"2001:db8::1",
+		" 10.0.0.1 ",
+		"garbage",
+	}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			peer := &PeerConfig{Name: "bad", RTPAddress: input}
+			if got := s.resolveRTPAddressForPeer(peer); got != "203.0.113.1" {
+				t.Errorf("invalid peer RTPAddress %q should fall back to server localIP, got %q", input, got)
+			}
+		})
+	}
+}
+
+func TestNewServer_InvalidRTPAddressIgnored(t *testing.T) {
+	// Non-IPv4 ServerConfig.RTPAddress must not flow into resolveLocalIP.
+	s := &server{cfg: ServerConfig{RTPAddress: "example.com", Listen: "0.0.0.0:5080"}}
+	if got := s.resolveLocalIP(); got == "example.com" {
+		t.Errorf("invalid RTPAddress %q must not be returned from resolveLocalIP", got)
+	}
+}
+
 func TestServer_PeerCodecsConfig(t *testing.T) {
 	srv := NewServer(ServerConfig{
 		CodecPrefs: []Codec{CodecPCMU, CodecPCMA, CodecG722},

--- a/xphone.go
+++ b/xphone.go
@@ -100,10 +100,14 @@ func codecPrefsToInts(codecs []Codec) []int {
 
 func newPhone(cfg Config) *phone {
 	hostIP := localIPFor(cfg.Host)
+	localIP := hostIP
+	if cfg.RTPAddress != "" {
+		localIP = cfg.RTPAddress
+	}
 	return &phone{
 		cfg:        cfg,
 		logger:     resolveLogger(cfg.Logger),
-		localIP:    hostIP,
+		localIP:    localIP,
 		hostIP:     hostIP,
 		codecPrefs: codecPrefsToInts(cfg.CodecPrefs),
 		state:      PhoneStateDisconnected,
@@ -309,7 +313,8 @@ func (p *phone) Connect(ctx context.Context) error {
 	// STUN discovery: if configured, try to discover our NAT-mapped IP.
 	// On success, override the localIP used for Contact headers and SDP.
 	// On failure, log a warning and keep the existing localIPFor() result.
-	if p.cfg.StunServer != "" {
+	// Skipped when cfg.RTPAddress is set — explicit override wins over discovery.
+	if p.cfg.StunServer != "" && p.cfg.RTPAddress == "" {
 		ip, _, err := stun.MappedAddr(p.cfg.StunServer, stun.DefaultTimeout)
 		if err != nil {
 			p.logger.Warn("STUN discovery failed, using local IP", "err", err, "fallback", p.localIP)

--- a/xphone.go
+++ b/xphone.go
@@ -98,15 +98,40 @@ func codecPrefsToInts(codecs []Codec) []int {
 	return pts
 }
 
+// effectiveRTPAddress returns s if it parses as an IPv4 literal, else "".
+// The stack's media path is IPv4-only (udp4 sockets, SDP "IN IP4"), so IPv6
+// literals and non-IP strings (hostnames, whitespace, CRLF injection) are
+// rejected rather than propagated into SIP Contact / SDP.
+func effectiveRTPAddress(s string) string {
+	if s == "" {
+		return ""
+	}
+	ip := net.ParseIP(s)
+	if ip == nil || ip.To4() == nil {
+		return ""
+	}
+	return s
+}
+
 func newPhone(cfg Config) *phone {
 	hostIP := localIPFor(cfg.Host)
 	localIP := hostIP
-	if cfg.RTPAddress != "" {
-		localIP = cfg.RTPAddress
+	// When RTPAddress is a valid IPv4 literal, use it for BOTH the advertised
+	// IP (SDP c=, SIP Contact) AND the ICE host candidate — otherwise ICE
+	// would emit a high-priority host candidate at the auto-detected IP and
+	// a lower-priority srflx at the override, leading peers to probe the
+	// unroutable address first.
+	if override := effectiveRTPAddress(cfg.RTPAddress); override != "" {
+		localIP = override
+		hostIP = override
+	}
+	logger := resolveLogger(cfg.Logger)
+	if cfg.RTPAddress != "" && effectiveRTPAddress(cfg.RTPAddress) == "" {
+		logger.Warn("xphone: WithRTPAddress ignored, not an IPv4 literal", "value", cfg.RTPAddress)
 	}
 	return &phone{
 		cfg:        cfg,
-		logger:     resolveLogger(cfg.Logger),
+		logger:     logger,
 		localIP:    localIP,
 		hostIP:     hostIP,
 		codecPrefs: codecPrefsToInts(cfg.CodecPrefs),
@@ -313,8 +338,8 @@ func (p *phone) Connect(ctx context.Context) error {
 	// STUN discovery: if configured, try to discover our NAT-mapped IP.
 	// On success, override the localIP used for Contact headers and SDP.
 	// On failure, log a warning and keep the existing localIPFor() result.
-	// Skipped when cfg.RTPAddress is set — explicit override wins over discovery.
-	if p.cfg.StunServer != "" && p.cfg.RTPAddress == "" {
+	// Skipped when a valid cfg.RTPAddress is set — explicit override wins.
+	if p.cfg.StunServer != "" && effectiveRTPAddress(p.cfg.RTPAddress) == "" {
 		ip, _, err := stun.MappedAddr(p.cfg.StunServer, stun.DefaultTimeout)
 		if err != nil {
 			p.logger.Warn("STUN discovery failed, using local IP", "err", err, "fallback", p.localIP)


### PR DESCRIPTION
## Summary

- Adds `Config.RTPAddress` + `WithRTPAddress(ip)` PhoneOption — a phone-level override for the IP advertised in SIP Contact, SDP `c=`, and the ICE host candidate. Mirrors the existing `ServerConfig.RTPAddress`.
- Validates `Config.RTPAddress`, `ServerConfig.RTPAddress`, and `PeerConfig.RTPAddress` as IPv4 literals. Non-IPv4 input is logged and ignored, closing a CRLF header-injection surface that existed on the server fields before this PR and would have existed on the new phone field.
- Skips STUN discovery when a valid override is set — saves a ~1s network round-trip in `Connect()`.
- Aligns `phone.hostIP` with `phone.localIP` when `RTPAddress` is set, so ICE doesn't emit a high-priority host candidate at an unroutable auto-detected IP.

Closes #105.

## Motivation

Downstream voiceapp needs this for local-dev against LAN 3CX. The kernel's outbound-interface lookup picks the Docker container IP (unroutable from 3CX), and `WithStunServer` doesn't help on LAN. The parallel `XPHONE_TRUNK_RTP_ADDRESS` was already wired through `ServerConfig.RTPAddress` in production — this PR adds the phone-side equivalent (`XPHONE_PHONE_RTP_ADDRESS=10.27.1.137` → SDP `c=10.27.1.137` → Docker port-forward).

## Scope notes

- **Phone-level override only.** Per-call `DialOptions.RTPAddress` is deferred; voiceapp's use case is a static env-var. File a follow-up issue if per-call override becomes needed.
- **IPv4-only.** The media stack is `udp4` + SDP `IN IP4` hardcoded. Accepting IPv6 in `RTPAddress` would advertise addresses the stack can't serve, so the validator rejects IPv6 literals explicitly. Aligning the stack with IPv6 is a separate, much larger effort.
- **STUN-under-lock deferred.** Surfaced by review but preexisting and requires state-machine refactor. Tracked in #106.

## Changes

### Phone
- `Config.RTPAddress` field, `WithRTPAddress(ip)` PhoneOption (`options.go`).
- `effectiveRTPAddress(s)` helper validates IPv4, rejects IPv6/hostnames/whitespace/CRLF (`xphone.go`).
- `newPhone` aligns both `localIP` and `hostIP` to the override (prevents ICE candidate priority inversion).
- `Connect()` short-circuits STUN when a valid override is present.
- Log warning when an invalid value is passed — never silently piped into SDP.

### Server
- `newServer()` warns on invalid `ServerConfig.RTPAddress` and any invalid `PeerConfig.RTPAddress`.
- `resolveLocalIP()` and `resolveRTPAddressForPeer()` use `effectiveRTPAddress()` so invalid overrides fall through to listen-address / auto-detect / server-level instead of being returned.
- Doc comments updated on both config fields to document the IPv4 constraint.

### Tests
- `TestWithRTPAddress_SetsConfig` — builder sets field.
- `TestNew_WithRTPAddress_OverridesLocalIP` — override flows into `phone.localIP`.
- `TestNew_WithRTPAddress_AlignsHostIPForICE` — override also aligns `phone.hostIP`.
- `TestNew_WithRTPAddress_RejectsInvalidInput` — table-driven: hostname, CRLF, IPv6, garbage, whitespace.
- `TestEffectiveRTPAddress` — unit table for the validation helper.
- `TestServer_ResolveRTPAddressForPeer_InvalidPeerOverrideFallsBack` — same table against the peer path.
- `TestNewServer_InvalidRTPAddressIgnored` — server-level override validation.

## Test plan

- [x] \`gofmt -s -w\` on all touched \`.go\` files.
- [x] \`go test ./...\` passes locally.
- [x] CHANGELOG updated under \`## Unreleased\` with both Features and Bug fixes sections.
- [ ] End-to-end verification in voiceapp local dev: `XPHONE_PHONE_RTP_ADDRESS=<Mac LAN IP>` in `.env`, Docker port-forwarding the RTP range, call from LAN 3CX → inbound audio + DTMF flow.
- [ ] Production/sandbox smoke test of an existing deployment (no `WithRTPAddress` set) to confirm behavior unchanged when the feature isn't used.