### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.1
+
 ### Features
 - `WithRTPAddress(ip)` PhoneOption (plus `Config.RTPAddress`) — overrides the IPv4 literal advertised in SIP Contact headers, the SDP `c=` line, and the ICE host candidate. Takes precedence over STUN discovery and `localIPFor()` auto-detection. Mirrors the existing `ServerConfig.RTPAddress` on the trunk side. Required for local dev against a LAN PBX when the kernel's outbound interface lookup picks an IP that isn't routable from the peer — Docker container IP, VPN tunnel, multi-homed host, or WSL2 vEthernet. (#105)
 


### PR DESCRIPTION
## Summary

Patch release: `WithRTPAddress` phone-side override + IPv4 validation across Phone/Server/Peer configs.

## Highlights

### Features
- **`WithRTPAddress(ip)` PhoneOption** — overrides the IPv4 advertised in SIP Contact, SDP `c=`, and the ICE host candidate. Mirrors the existing `ServerConfig.RTPAddress`. Unblocks local-dev against LAN PBXes where the auto-detected interface isn't routable (Docker, VPN, WSL2, multi-homed hosts). (#105)

### Bug fixes
- **IPv4 validation on all `RTPAddress` fields** — `Config.RTPAddress`, `ServerConfig.RTPAddress`, and `PeerConfig.RTPAddress` now reject non-IPv4 input (IPv6, hostnames, whitespace, embedded CRLF) with a log warning. Previously unvalidated strings flowed verbatim into SDP and SIP headers, exposing a CRLF header-injection surface.

## SemVer rationale

Patch bump (`v0.6.0` → `v0.6.1`):
- No breaking changes to existing API.
- New additive public surface (`WithRTPAddress`, `Config.RTPAddress`).
- Bug fix changes behavior only for callers who were previously passing invalid strings (which were broken anyway — now they're logged and ignored).

## Closes / references

- Closes #105.
- Related: #106 (STUN-under-lock, deferred).

## Post-merge

Tag `v0.6.1` on main, push tag, force pkg.go.dev / proxy / checksum DB index per standard release runbook.

## Test plan
- [x] `go test ./...` passes
- [x] `gofmt -s -w` applied
- [x] CHANGELOG moved from Unreleased to v0.6.1
- [ ] Tag pushed and indexed on pkg.go.dev
- [ ] voiceapp bumps dep to `v0.6.1` and verifies DTMF + inbound audio against LAN 3CX