### PR TITLE
fix: decouple SIP Contact from WithRTPAddress when Config.NAT is set (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug fixes
+- `WithRTPAddress` no longer rewrites the SIP Contact/Via host when `Config.NAT` is also set. Previously the override replaced both the SDP `c=` line (media) and the Contact URI (signaling), but the SIP client's bound UDP port is ephemeral — advertising a reachable-looking Contact host while the signaling port is not publishable caused the PBX to target an unpublished port and drop inbound INVITEs (Docker-bridge local dev, Kubernetes NAT). With the fix, Contact/Via fall back to the real bind interface IP when `Config.NAT` is set, so rport (RFC 3581) + REGISTER keepalive continue to drive the PBX's NAT learning. Deployments without `Config.NAT` (direct public VPS) are unaffected. (#109)
+
 ## v0.6.1
 
 ### Features

--- a/options.go
+++ b/options.go
@@ -58,14 +58,21 @@ type Config struct {
 	StunServer string
 	SRTP       bool
 
-	// RTPAddress is the IPv4 literal to advertise in SIP Contact headers, the
-	// SDP c= line, and the ICE host candidate. When set to a valid IPv4, it
-	// overrides auto-detection (localIPFor) and skips STUN discovery entirely.
+	// RTPAddress is the IPv4 literal to advertise as the media endpoint
+	// (SDP c= line and ICE host candidate). When set, it overrides
+	// auto-detection (localIPFor) and skips STUN discovery.
+	//
+	// It also overrides SIP Contact/Via by default — EXCEPT when cfg.NAT is
+	// also set, in which case Contact/Via are left at the bind interface IP
+	// so rport (RFC 3581) + REGISTER keepalive can drive the PBX's NAT
+	// learning for inbound signaling. This matters in Docker-bridge setups
+	// where the host-mapped port range covers RTP but the SIP client's
+	// ephemeral UDP port is not publishable — advertising the host LAN IP
+	// in Contact would cause the PBX to target an unreachable port.
+	//
 	// Non-IPv4 values (IPv6, hostnames, garbage) are rejected at construction
-	// with a log warning and treated as unset. Useful for local dev against a
-	// LAN PBX where the auto-detected interface isn't routable from the peer
-	// (Docker container IP, VPN interface, multi-homed host, WSL2 vEthernet).
-	// Parallel to ServerConfig.RTPAddress on the trunk side.
+	// with a log warning and treated as unset. Parallel to ServerConfig.RTPAddress
+	// on the trunk side.
 	RTPAddress string
 
 	// TurnServer is the TURN server address (host:port) for relay allocation.
@@ -352,15 +359,19 @@ func WithNATKeepalive(d time.Duration) PhoneOption {
 	}
 }
 
-// WithRTPAddress sets the IPv4 literal to advertise in SIP Contact headers,
-// the SDP c= line, and the ICE host candidate. Overrides auto-detection and
-// skips STUN discovery. Mirrors ServerConfig.RTPAddress on the Server side.
+// WithRTPAddress sets the IPv4 literal to advertise as the media endpoint
+// (SDP c= line and ICE host candidate). Overrides auto-detection and skips
+// STUN discovery. Mirrors ServerConfig.RTPAddress on the Server side.
+//
+// By default the override also applies to SIP Contact/Via. Use WithNAT
+// alongside this option to gate the signaling half of the override on rport
+// (RFC 3581) + REGISTER keepalive — required in Docker-bridge local dev
+// where the host-mapped port range covers RTP but the SIP client's
+// ephemeral UDP port is not publishable. See Config.RTPAddress for details.
+//
 // Non-IPv4 values (IPv6, hostnames, whitespace) are rejected with a log
-// warning and treated as unset. Use this when the kernel's outbound interface
-// lookup picks an IP that isn't routable from the peer (Docker container IP,
-// VPN tunnel, multi-homed host, WSL2 vEthernet). Example:
-// WithRTPAddress("10.27.1.137") on a Mac with Docker port-forwarding the RTP
-// range back to the container.
+// warning and treated as unset. Example: WithRTPAddress("10.27.1.137") on a
+// Mac with Docker port-forwarding the RTP range back to the container.
 func WithRTPAddress(ip string) PhoneOption {
 	return func(c *Config) {
 		c.RTPAddress = ip

--- a/phone_test.go
+++ b/phone_test.go
@@ -129,7 +129,20 @@ func TestNew_WithRTPAddress_OverridesLocalIP(t *testing.T) {
 	ph := p.(*phone)
 	assert.Equal(t, "10.27.1.137", ph.cfg.RTPAddress)
 	assert.Equal(t, "10.27.1.137", ph.localIP,
-		"RTPAddress override should flow into phone.localIP (SDP c= / SIP Contact)")
+		"RTPAddress override should flow into phone.localIP (SDP c=, default Contact)")
+}
+
+func TestNew_WithRTPAddress_PopulatesInterfaceIP(t *testing.T) {
+	// interfaceIP must always hold the real bind IP, even when the override
+	// is active — it's the fallback for NAT-mode Contact (see #109).
+	// Using TEST-NET-3 (RFC 5737) so the override is guaranteed not to
+	// collide with any host interface IP under test.
+	const rfc5737Override = "203.0.113.137"
+	p := New(WithRTPAddress(rfc5737Override))
+	ph := p.(*phone)
+	assert.NotEmpty(t, ph.interfaceIP, "interfaceIP must be populated from localIPFor()")
+	assert.NotEqual(t, rfc5737Override, ph.interfaceIP,
+		"interfaceIP must not be overwritten by RTPAddress — otherwise NAT-mode Contact fallback has nowhere to fall back to")
 }
 
 func TestNew_WithRTPAddress_AlignsHostIPForICE(t *testing.T) {
@@ -176,6 +189,76 @@ func TestNew_WithoutRTPAddress_UsesAutoDetect(t *testing.T) {
 	ph := p.(*phone)
 	assert.Empty(t, ph.cfg.RTPAddress)
 	assert.NotEmpty(t, ph.localIP, "localIP should fall back to localIPFor(host)")
+}
+
+func TestPhone_ResolveContactIP(t *testing.T) {
+	cases := []struct {
+		name         string
+		nat          bool
+		rtpAddress   string
+		localIP      string
+		interfaceIP  string
+		wantContact  string
+		wantCarveOut bool // true when contactIP != localIP (NAT fallback triggered)
+	}{
+		{
+			name:         "no override, no NAT: localIP",
+			localIP:      "192.168.1.50",
+			interfaceIP:  "192.168.1.50",
+			wantContact:  "192.168.1.50",
+			wantCarveOut: false,
+		},
+		{
+			name:         "override without NAT: localIP (override)",
+			rtpAddress:   "10.27.1.137",
+			localIP:      "10.27.1.137",
+			interfaceIP:  "172.17.0.3",
+			wantContact:  "10.27.1.137",
+			wantCarveOut: false,
+		},
+		{
+			name:         "NAT without override: localIP (unchanged)",
+			nat:          true,
+			localIP:      "172.17.0.3",
+			interfaceIP:  "172.17.0.3",
+			wantContact:  "172.17.0.3",
+			wantCarveOut: false,
+		},
+		{
+			name:         "NAT with override: interfaceIP (#109 carve-out)",
+			nat:          true,
+			rtpAddress:   "10.27.1.137",
+			localIP:      "10.27.1.137",
+			interfaceIP:  "172.17.0.3",
+			wantContact:  "172.17.0.3",
+			wantCarveOut: true,
+		},
+		{
+			name:         "NAT with invalid override: localIP (no carve-out, invalid treated as unset)",
+			nat:          true,
+			rtpAddress:   "not-an-ip",
+			localIP:      "172.17.0.3",
+			interfaceIP:  "172.17.0.3",
+			wantContact:  "172.17.0.3",
+			wantCarveOut: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &phone{
+				cfg:         Config{NAT: tc.nat, RTPAddress: tc.rtpAddress},
+				localIP:     tc.localIP,
+				interfaceIP: tc.interfaceIP,
+			}
+			got := p.resolveContactIP()
+			assert.Equal(t, tc.wantContact, got)
+			if tc.wantCarveOut {
+				assert.NotEqual(t, p.localIP, got, "carve-out should divert contactIP from localIP")
+			} else {
+				assert.Equal(t, p.localIP, got, "no carve-out should pass localIP through unchanged")
+			}
+		})
+	}
 }
 
 func TestEffectiveRTPAddress(t *testing.T) {

--- a/xphone.go
+++ b/xphone.go
@@ -52,8 +52,9 @@ type phone struct {
 	logger      *slog.Logger
 	tr          sipTransport
 	reg         *registry
-	localIP     string // cached localIPFor(cfg.Host), or STUN-mapped IP after Connect
-	hostIP      string // real local interface IP (pre-STUN, for ICE host candidate)
+	localIP     string // advertised IP — SDP c=, default SIP Contact/Via. Override, STUN, or localIPFor(cfg.Host).
+	hostIP      string // ICE host candidate IP (= override when set, else localIPFor(cfg.Host))
+	interfaceIP string // real bind interface IP — fallback for SIP Contact when cfg.NAT is set with an RTPAddress override, so rport + REGISTER keepalive can drive NAT learning.
 	codecPrefs  []int  // cached codecPrefsToInts(cfg.CodecPrefs), set at construction
 	state       PhoneState
 	incomingFns []func(Call)
@@ -98,6 +99,21 @@ func codecPrefsToInts(codecs []Codec) []int {
 	return pts
 }
 
+// resolveContactIP returns the IP to advertise in SIP Contact/Via. By default
+// this is p.localIP (which already accounts for STUN discovery and RTPAddress
+// override). Carve-out for Docker-bridge and similar setups: when cfg.NAT is
+// set AND an RTPAddress override is active, Contact/Via fall back to the
+// real bind interface IP so rport (RFC 3581) + REGISTER keepalive can drive
+// the PBX's NAT learning. Rewriting Contact to a reachable-looking host
+// while the SIP port is ephemeral (sipgo binds a random UDP port) would
+// trick the PBX into targeting an unpublished port. See #109.
+func (p *phone) resolveContactIP() string {
+	if p.cfg.NAT && effectiveRTPAddress(p.cfg.RTPAddress) != "" {
+		return p.interfaceIP
+	}
+	return p.localIP
+}
+
 // effectiveRTPAddress returns s if it parses as an IPv4 literal, else "".
 // The stack's media path is IPv4-only (udp4 sockets, SDP "IN IP4"), so IPv6
 // literals and non-IP strings (hostnames, whitespace, CRLF injection) are
@@ -114,13 +130,15 @@ func effectiveRTPAddress(s string) string {
 }
 
 func newPhone(cfg Config) *phone {
-	hostIP := localIPFor(cfg.Host)
-	localIP := hostIP
+	interfaceIP := localIPFor(cfg.Host)
+	localIP := interfaceIP
+	hostIP := interfaceIP
 	// When RTPAddress is a valid IPv4 literal, use it for BOTH the advertised
-	// IP (SDP c=, SIP Contact) AND the ICE host candidate — otherwise ICE
-	// would emit a high-priority host candidate at the auto-detected IP and
-	// a lower-priority srflx at the override, leading peers to probe the
-	// unroutable address first.
+	// IP (SDP c=) AND the ICE host candidate — otherwise ICE would emit a
+	// high-priority host candidate at the auto-detected IP and a lower-priority
+	// srflx at the override, leading peers to probe the unroutable address
+	// first. interfaceIP stays at the real bind IP so Contact can fall back
+	// to it when cfg.NAT is set (see Connect).
 	if override := effectiveRTPAddress(cfg.RTPAddress); override != "" {
 		localIP = override
 		hostIP = override
@@ -130,13 +148,14 @@ func newPhone(cfg Config) *phone {
 		logger.Warn("xphone: WithRTPAddress ignored, not an IPv4 literal", "value", cfg.RTPAddress)
 	}
 	return &phone{
-		cfg:        cfg,
-		logger:     logger,
-		localIP:    localIP,
-		hostIP:     hostIP,
-		codecPrefs: codecPrefsToInts(cfg.CodecPrefs),
-		state:      PhoneStateDisconnected,
-		calls:      make(map[string]*call),
+		cfg:         cfg,
+		logger:      logger,
+		localIP:     localIP,
+		hostIP:      hostIP,
+		interfaceIP: interfaceIP,
+		codecPrefs:  codecPrefsToInts(cfg.CodecPrefs),
+		state:       PhoneStateDisconnected,
+		calls:       make(map[string]*call),
 	}
 }
 
@@ -349,7 +368,11 @@ func (p *phone) Connect(ctx context.Context) error {
 		}
 	}
 
-	contactIP := p.localIP
+	contactIP := p.resolveContactIP()
+	if contactIP != p.localIP {
+		p.logger.Debug("NAT mode with RTPAddress: keeping Contact/Via at interface IP for rport NAT learning",
+			"interface_ip", p.interfaceIP, "rtp_address", p.cfg.RTPAddress)
+	}
 	p.mu.Unlock()
 
 	tr, err := newSipUA(p.cfg, contactIP)


### PR DESCRIPTION
## Summary

Fixes a defect introduced in v0.6.1: `WithRTPAddress` also rewrote the SIP Contact/Via host, which breaks REGISTER-behind-NAT when the SIP client port is ephemeral.

Closes #109.

## The bug

`WithRTPAddress` overrode both:
1. SDP `c=` line (**media endpoint**) — the publishable RTP port range, works fine.
2. SIP Contact URI (**signaling endpoint**) — the ephemeral UDP port sipgo binds, **not publishable**.

In a Docker-bridge topology:

**Before the override**: Contact advertised the container IP (unreachable). PBX fell back to the NAT-observed source address from REGISTER (rport + keepalive). Signaling worked.

**After the override (v0.6.1)**: Contact advertised the host's LAN IP (looked reachable → PBX trusted it → sent INVITEs directly to `hostLanIP:ephemeralPort`). But the ephemeral port isn't published by Docker. INVITEs dropped. No incoming calls.

## The fix

When `Config.NAT` is set alongside `WithRTPAddress`, Contact/Via now fall back to the real bind interface IP instead of the override. SDP `c=` and the ICE host candidate still use the override. This lets rport (RFC 3581) + REGISTER keepalive continue to drive NAT learning for signaling, while media flows via the port-forwarded RTP range.

### Implementation

- **New field `phone.interfaceIP`** — the real bind IP, populated once at `newPhone`, never mutated by override or STUN. Authoritative answer to "where is the socket actually bound."
- **New method `(p *phone) resolveContactIP()`** — encapsulates the carve-out logic. Returns `p.interfaceIP` only when `cfg.NAT && effectiveRTPAddress(cfg.RTPAddress) != \"\"`, else `p.localIP` (preserves existing STUN + override behavior).
- **`Connect()` calls `resolveContactIP()`** instead of reading `p.localIP` directly. Emits a debug log when the carve-out fires.
- Updated doc comments on `Config.RTPAddress` and `WithRTPAddress` to describe NAT-mode semantics.

## Backward compatibility

| Setup | Behavior |
|---|---|
| No `Config.NAT` | Unchanged. Contact still uses override as before. |
| `Config.NAT = true` without `WithRTPAddress` | Unchanged. Contact uses auto-detected IP + rport. |
| `Config.NAT = true` with `WithRTPAddress`, public VPS | Interface IP == public IP, so Contact falls back to the same value — no functional change. |
| `Config.NAT = true` with `WithRTPAddress`, behind NAT (Docker-bridge, home) | **Fix active** — Contact uses interface IP, rport + keepalive drives NAT learning, INVITEs arrive. |

No API breakage; the behavior change is only in the previously-broken case.

## Test plan

- [x] `go test ./...` passes (new table-driven coverage for `resolveContactIP` + field population).
- [x] `gofmt -s -w` applied.
- [x] CHANGELOG updated under `## Unreleased` / Bug fixes.
- [ ] voiceapp bumps dep to v0.6.2 (once tagged) and verifies INVITE delivery against LAN 3CX with `XPHONE_PHONE_RTP_ADDRESS=<Mac LAN IP>` + `Config.NAT = true`.

## Follow-up

Per #109, two stronger alternatives exist (pin the SIP listen port, or split the API into `WithRTPAddress` + `WithContactAddress`). This PR takes the minimal-change path — gating on `Config.NAT` — because it unblocks voiceapp immediately without growing the API surface. If Docker-bridge setups want to advertise a reachable Contact *and* pin the SIP port for external firewall rules, that's a separate feature request.