### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.2
+
 ### Bug fixes
 - `WithRTPAddress` no longer rewrites the SIP Contact/Via host when `Config.NAT` is also set. Previously the override replaced both the SDP `c=` line (media) and the Contact URI (signaling), but the SIP client's bound UDP port is ephemeral — advertising a reachable-looking Contact host while the signaling port is not publishable caused the PBX to target an unpublished port and drop inbound INVITEs (Docker-bridge local dev, Kubernetes NAT). With the fix, Contact/Via fall back to the real bind interface IP when `Config.NAT` is set, so rport (RFC 3581) + REGISTER keepalive continue to drive the PBX's NAT learning. Deployments without `Config.NAT` (direct public VPS) are unaffected. (#109)
 


### PR DESCRIPTION
## Summary

Patch release — single bug fix addressing a regression introduced in v0.6.1.

## Bug fixes

- **`WithRTPAddress` no longer rewrites SIP Contact/Via when `Config.NAT` is set.** In v0.6.1, the override replaced both SDP `c=` (media) and the SIP Contact URI (signaling). Because sipgo binds an ephemeral UDP port for the SIP client, advertising a reachable-looking Contact host while the SIP port isn't publishable caused PBXes to target an unpublished port and drop inbound INVITEs (Docker-bridge local dev, Kubernetes-NAT deployments). Fix: when `Config.NAT` is set alongside the override, Contact/Via fall back to the real bind interface IP so rport (RFC 3581) + REGISTER keepalive continue to drive NAT learning. Deployments without `Config.NAT` (direct public VPS) are unaffected. (#109)

## SemVer rationale

Patch bump (`v0.6.1` → `v0.6.2`): no API changes, no new public surface. Fixes a regression introduced in v0.6.1; deployments that hit the broken case get corrected behavior, all others see no change.

## Closes

- Closes #109.

## Post-merge

Tag `v0.6.2` on main, push tag, force pkg.go.dev / proxy / checksum DB index per standard release runbook.

## Test plan
- [x] `go test ./...` passes
- [x] `gofmt -s -w` applied
- [x] CHANGELOG moved from Unreleased to v0.6.2
- [ ] Tag pushed and indexed
- [ ] voiceapp bumps dep to `v0.6.2` and verifies INVITE delivery against LAN 3CX with `XPHONE_PHONE_RTP_ADDRESS` + `Config.NAT=true`