### PR TITLE
ci: exempt release/* branches from CHANGELOG-updated check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   changelog:
-    if: github.event_name == 'pull_request'
+    # Release PRs are exempt: their job is to move content out of
+    # `## Unreleased` into a new `## vX.Y.Z` section, not add new entries.
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Internal
+- CI: exempt `release/*` branches from the CHANGELOG-updated check. Release PRs move content out of `## Unreleased` into a new versioned section rather than adding entries, so the check was a guaranteed false-positive on every release PR.
+
 ## v0.6.2
 
 ### Bug fixes


### PR DESCRIPTION
## Summary

Release PRs by design move content out of `## Unreleased` into a new versioned section — they don't *add* new entries. The existing `changelog` job flagged this as a failure on every release PR (most recently #111 for v0.6.2), which has to be bypassed or ignored. This PR teaches the check to skip `release/*` branches so release PRs go green by default.

## Change

```yaml
if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/')
```

One-line addition. All other PRs (`feat/*`, `fix/*`, etc.) still get the existing enforcement — no weakening of the CHANGELOG discipline for actual library changes.

## Alternatives considered

Option 2 from the original discussion — teaching the check to accept *either* "added to `## Unreleased`" *or* "new `## vX.Y.Z` section" — would also work, but it's more script surface and the first rule is genuinely simpler and matches intent. If we ever land non-release PRs that only rename sections, we can revisit.

## Notes

- Introduces an `### Internal` section in CHANGELOG.md under `## Unreleased` for CI/tooling-only changes that aren't user-visible library changes.
- Same branch-name convention (`release/vX.Y.Z`) that the project already uses for the release-cut flow.

## Test plan
- [x] This PR's CI run should pass the `changelog` job (because `fix/*` branch, CHANGELOG.md updated).
- [ ] Next release PR (e.g. `release/v0.6.3`) should see the `changelog` job **skipped**, not failed.