### PR TITLE
fix(media): drop per-Pop sort in JitterBuffer (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug fixes
+- `internal/media.JitterBuffer.Pop` and `Flush` no longer re-sort the full entry slice on every call. The buffer now maintains sequence order on insertion (fast path on in-order arrivals, linear walk from the tail on out-of-order packets), so the 5 ms drain ticker — which runs ~200 times/sec per active media stream — pays O(1) per Pop instead of O(N log N) plus the `sort.Slice` reflect/closure overhead. On the ticker-drain hot path (buffer holds a handful of not-yet-aged packets) Pop drops from ~103 ns/op with 3 allocations to ~20 ns/op with zero allocations, matching the ~20% production CPU reduction reported in the issue. (#114)
+
 ### Internal
 - CI: exempt `release/*` branches from the CHANGELOG-updated check. Release PRs move content out of `## Unreleased` into a new versioned section rather than adding entries, so the check was a guaranteed false-positive on every release PR.
 

--- a/internal/media/jitterbuffer.go
+++ b/internal/media/jitterbuffer.go
@@ -1,7 +1,7 @@
 package media
 
 import (
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -9,7 +9,11 @@ import (
 )
 
 // seqLess compares two 16-bit RTP sequence numbers with wraparound
-// per RFC 3550. Returns true if a comes before b.
+// per RFC 3550. Returns true if a comes before b. Not a total order
+// across the full 16-bit range — at the 2^15 antipode (b-a == 0x8000)
+// it returns false in both directions. The jitter buffer relies on
+// concurrently-held sequences spanning less than 2^15, which holds
+// in any realistic media session.
 func seqLess(a, b uint16) bool {
 	diff := b - a
 	return diff > 0 && diff < 0x8000
@@ -21,6 +25,11 @@ type jitterEntry struct {
 }
 
 // JitterBuffer reorders and deduplicates incoming RTP packets.
+//
+// Entries are kept in sequence order at all times: Push inserts at the right
+// position (fast path on in-order arrivals; linear walk from the tail
+// otherwise), so Pop and Flush are O(1) / O(N) without re-sorting on every
+// call.
 type JitterBuffer struct {
 	mu      sync.Mutex
 	depth   time.Duration
@@ -36,7 +45,8 @@ func NewJitterBuffer(depth time.Duration) *JitterBuffer {
 	}
 }
 
-// Push adds an RTP packet to the buffer. Duplicates are dropped.
+// Push adds an RTP packet to the buffer in sequence order. Duplicates are
+// dropped.
 func (jb *JitterBuffer) Push(pkt *rtp.Packet) {
 	jb.mu.Lock()
 	defer jb.mu.Unlock()
@@ -46,7 +56,30 @@ func (jb *JitterBuffer) Push(pkt *rtp.Packet) {
 		return
 	}
 	jb.seen[seq] = true
-	jb.entries = append(jb.entries, jitterEntry{pkt: pkt, arrival: time.Now()})
+
+	entry := jitterEntry{pkt: pkt, arrival: time.Now()}
+	n := len(jb.entries)
+	if n == 0 {
+		jb.entries = append(jb.entries, entry)
+		return
+	}
+
+	// Fast path: in-order arrival (the common case).
+	if seqLess(jb.entries[n-1].pkt.Header.SequenceNumber, seq) {
+		jb.entries = append(jb.entries, entry)
+		return
+	}
+
+	// Out-of-order: linear walk from the tail. Buffer depth is small in
+	// steady state (a few dozen packets at most), and out-of-order packets
+	// typically land within a few slots of the tail — cheaper and simpler
+	// than binary search under RFC 3550 wraparound semantics, where the
+	// comparator isn't a total order across the full 16-bit range.
+	insertAt := n
+	for insertAt > 0 && !seqLess(jb.entries[insertAt-1].pkt.Header.SequenceNumber, seq) {
+		insertAt--
+	}
+	jb.entries = slices.Insert(jb.entries, insertAt, entry)
 }
 
 // Pop returns the next packet in sequence order if its arrival time exceeds
@@ -59,26 +92,22 @@ func (jb *JitterBuffer) Pop() *rtp.Packet {
 		return nil
 	}
 
-	sort.Slice(jb.entries, func(i, j int) bool {
-		return seqLess(jb.entries[i].pkt.Header.SequenceNumber, jb.entries[j].pkt.Header.SequenceNumber)
-	})
-
-	now := time.Now()
-	if now.Sub(jb.entries[0].arrival) >= jb.depth {
-		pkt := jb.entries[0].pkt
-		delete(jb.seen, pkt.Header.SequenceNumber)
-		// Zero vacated slot to allow GC of the popped packet.
-		jb.entries[0] = jitterEntry{}
-		jb.entries = jb.entries[1:]
-		// Compact when backing array is oversized to prevent unbounded growth.
-		if cap(jb.entries) > 64 && cap(jb.entries) > 4*len(jb.entries) {
-			compacted := make([]jitterEntry, len(jb.entries))
-			copy(compacted, jb.entries)
-			jb.entries = compacted
-		}
-		return pkt
+	if time.Since(jb.entries[0].arrival) < jb.depth {
+		return nil
 	}
-	return nil
+
+	pkt := jb.entries[0].pkt
+	delete(jb.seen, pkt.Header.SequenceNumber)
+	// Zero vacated slot to allow GC of the popped packet.
+	jb.entries[0] = jitterEntry{}
+	jb.entries = jb.entries[1:]
+	// Compact when backing array is oversized to prevent unbounded growth.
+	if cap(jb.entries) > 64 && cap(jb.entries) > 4*len(jb.entries) {
+		compacted := make([]jitterEntry, len(jb.entries))
+		copy(compacted, jb.entries)
+		jb.entries = compacted
+	}
+	return pkt
 }
 
 // Flush returns all buffered packets in sequence order and clears the buffer.
@@ -89,10 +118,6 @@ func (jb *JitterBuffer) Flush() []*rtp.Packet {
 	if len(jb.entries) == 0 {
 		return nil
 	}
-
-	sort.Slice(jb.entries, func(i, j int) bool {
-		return seqLess(jb.entries[i].pkt.Header.SequenceNumber, jb.entries[j].pkt.Header.SequenceNumber)
-	})
 
 	pkts := make([]*rtp.Packet, len(jb.entries))
 	for i, e := range jb.entries {

--- a/internal/media/jitterbuffer.go
+++ b/internal/media/jitterbuffer.go
@@ -124,6 +124,6 @@ func (jb *JitterBuffer) Flush() []*rtp.Packet {
 		pkts[i] = e.pkt
 	}
 	jb.entries = nil
-	jb.seen = make(map[uint16]bool)
+	clear(jb.seen)
 	return pkts
 }

--- a/internal/media/jitterbuffer_test.go
+++ b/internal/media/jitterbuffer_test.go
@@ -1,6 +1,7 @@
 package media
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -105,4 +106,82 @@ func TestJitterBuffer_Empty(t *testing.T) {
 	// Pop with nothing pushed.
 	pkt := jb.Pop()
 	assert.Nil(t, pkt)
+}
+
+// TestJitterBuffer_PopOrderAfterShuffledPush verifies that Pop returns
+// packets in sequence order regardless of arrival order — i.e., that
+// Push maintains the sorted invariant rather than relying on a Pop-time
+// sort.
+func TestJitterBuffer_PopOrderAfterShuffledPush(t *testing.T) {
+	// 50ms depth + 100ms sleep gives a 50ms margin so the test stays
+	// reliable on loaded CI runners.
+	jb := NewJitterBuffer(50 * time.Millisecond)
+
+	rng := rand.New(rand.NewSource(42))
+	const n = 64
+	seqs := make([]uint16, n)
+	for i := range seqs {
+		seqs[i] = uint16(1000 + i)
+	}
+	rng.Shuffle(n, func(i, j int) { seqs[i], seqs[j] = seqs[j], seqs[i] })
+
+	for _, s := range seqs {
+		jb.Push(&rtp.Packet{Header: rtp.Header{SequenceNumber: s}})
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	for i := uint16(0); i < n; i++ {
+		pkt := jb.Pop()
+		require.NotNil(t, pkt, "expected packet at index %d", i)
+		assert.Equal(t, 1000+i, pkt.SequenceNumber)
+	}
+	assert.Nil(t, jb.Pop(), "buffer should be empty after draining")
+}
+
+// TestJitterBuffer_OutOfOrderInsertNearWrap covers inserting late-arriving
+// packets whose sequence numbers straddle the 16-bit wrap boundary —
+// the regime where a naive total-order comparator would misorder them.
+func TestJitterBuffer_OutOfOrderInsertNearWrap(t *testing.T) {
+	jb := NewJitterBuffer(10 * time.Millisecond)
+
+	// Arrive: 65535, 65533, 0, 65534, 1 (across the wrap, shuffled).
+	for _, s := range []uint16{65535, 65533, 0, 65534, 1} {
+		jb.Push(&rtp.Packet{Header: rtp.Header{SequenceNumber: s}})
+	}
+
+	pkts := jb.Flush()
+	require.Len(t, pkts, 5)
+	assert.Equal(t, uint16(65533), pkts[0].SequenceNumber)
+	assert.Equal(t, uint16(65534), pkts[1].SequenceNumber)
+	assert.Equal(t, uint16(65535), pkts[2].SequenceNumber)
+	assert.Equal(t, uint16(0), pkts[3].SequenceNumber)
+	assert.Equal(t, uint16(1), pkts[4].SequenceNumber)
+}
+
+// BenchmarkJitterBuffer_PushPopEmpty measures the per-call cost when the
+// buffer never holds more than one entry (depth=0 drains immediately).
+// Lower bound on Pop cost; the production hot path is
+// BenchmarkJitterBuffer_PopWithBacklog.
+func BenchmarkJitterBuffer_PushPopEmpty(b *testing.B) {
+	jb := NewJitterBuffer(0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		jb.Push(&rtp.Packet{Header: rtp.Header{SequenceNumber: uint16(i)}})
+		_ = jb.Pop()
+	}
+}
+
+// BenchmarkJitterBuffer_PopWithBacklog models the dominant production
+// pattern: the 5ms drainJB ticker fires while the buffer holds a handful
+// of packets that are not yet depth-aged. Previously this paid a full
+// sort.Slice on every tick; now Pop is O(1) and returns immediately.
+func BenchmarkJitterBuffer_PopWithBacklog(b *testing.B) {
+	jb := NewJitterBuffer(time.Hour) // depth large enough that Pop never drains
+	for i := 0; i < 8; i++ {
+		jb.Push(&rtp.Packet{Header: rtp.Header{SequenceNumber: uint16(i)}})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = jb.Pop()
+	}
 }


### PR DESCRIPTION
## Summary

- Eliminates the `sort.Slice` call on every `JitterBuffer.Pop`/`Flush`. The buffer now maintains RTP sequence order on insertion: fast path on in-order arrivals (`append`), linear walk from the tail on out-of-order packets (then `slices.Insert`).
- On the production hot path — buffer holds ~8 not-yet-aged packets, drained by the 5 ms `drainJB` ticker — `Pop` drops from **~103 ns/op with 3 allocations** to **~20 ns/op with zero allocations** (Apple M3 Pro, `benchstat`-style comparison via stash/restore on `BenchmarkJitterBuffer_PopWithBacklog`).
- Matches the ~20% production CPU reduction in the pprof attached to issue #114.

## Why a linear walk and not a binary search

`seqLess` is the RFC 3550 wraparound comparator — it is **not** a total order across the full 16-bit range (returns false in both directions at the 2^15 antipode). `sort.Search`-style binary search would need a stable anchor + window invariant that's harder to reason about than a linear walk over the tail. At realistic buffer depth (a few dozen packets), linear is also cheaper. The invariant is documented on `seqLess`.

## Test plan

- [x] `go test ./internal/media/` (8 tests, all pass)
- [x] Added `TestJitterBuffer_PopOrderAfterShuffledPush` — 64-packet shuffled-push, asserts Pop returns in sequence order
- [x] Added `TestJitterBuffer_OutOfOrderInsertNearWrap` — exercises insertion across the 16-bit wrap boundary
- [x] Added `BenchmarkJitterBuffer_PopWithBacklog` (production-representative) and `BenchmarkJitterBuffer_PushPopEmpty` (lower bound)
- [x] `go test ./...` full suite passes
- [x] `gofmt -s -w` clean, `go vet ./...` clean

## Notes for future work

A follow-up could extract `seqLess` to `internal/util/` — review surfaced that the same wraparound math is inlined in `internal/rtcp/rtcp.go:85-91` and `internal/srtp/srtp.go:556/567/570`. Deferred out of scope for this bug fix to keep the diff focused.

Closes #114