### PR TITLE
release: v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.3
+
 ### Bug fixes
 - `internal/media.JitterBuffer.Pop` and `Flush` no longer re-sort the full entry slice on every call. The buffer now maintains sequence order on insertion (fast path on in-order arrivals, linear walk from the tail on out-of-order packets), so the 5 ms drain ticker — which runs ~200 times/sec per active media stream — pays O(1) per Pop instead of O(N log N) plus the `sort.Slice` reflect/closure overhead. On the ticker-drain hot path (buffer holds a handful of not-yet-aged packets) Pop drops from ~103 ns/op with 3 allocations to ~20 ns/op with zero allocations, matching the ~20% production CPU reduction reported in the issue. (#114)
 


### PR DESCRIPTION
## Summary

Patch release. Cuts the JitterBuffer hot-path fix from #114 into v0.6.3.

## Contents

### Bug fixes
- **`internal/media.JitterBuffer`**: removed per-Pop `sort.Slice`; buffer now maintains sequence order on insertion. Drops `Pop` from ~103 ns/op (3 allocs) to ~20 ns/op (0 allocs) on the production hot path (5 ms `drainJB` ticker × concurrent streams), matching the ~20% production CPU reduction reported in the issue. (#114, merged via #115)

### Internal
- CI: exempt `release/*` branches from the CHANGELOG-updated check. (#112)

## Test plan
- [x] All tests pass on main since #115 merge
- [x] CHANGELOG.md updated (Unreleased → v0.6.3)
- [ ] Merge → tag main with `v0.6.3` → push tag → force pkg.go.dev / Go proxy / checksum DB