### PR TITLE
feat(call): B2BUA media-redirect methods (SendReInvite, Suspend/RestoreMediaTimeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v0.6.4
+
+### Features
+- B2BUA media-redirect methods on the concrete `*call` (not the `Call` interface; reach them via type assertion): `SendReInvite(sdpOffer []byte) error` sends a re-INVITE with caller-supplied SDP (e.g. pointing the leg's media at a foreign RTP endpoint to bridge two legs into direct media), leaving `state`/`localSDP` unchanged so the caller can restore later; `SuspendMediaTimeout()` extends the RTP-inactivity watchdog to the hold timeout while media is intentionally redirected away from this endpoint; `RestoreMediaTimeout()` returns the watchdog to the configured timeout once media returns. All additive and backward-compatible. Known limitation: a Session-Timer refresh or inbound re-INVITE during the redirect window re-sends this endpoint's own SDP and undoes the redirect.
+
 ## v0.6.3
 
 ### Bug fixes

--- a/call.go
+++ b/call.go
@@ -1279,6 +1279,47 @@ func (c *call) Resume() error {
 	return nil
 }
 
+// SendReInvite sends a re-INVITE carrying the given raw SDP offer. Unlike
+// Hold/Resume — which always emit this endpoint's own SDP via buildLocalSDP —
+// this lets a B2BUA point the leg's media at a foreign endpoint, e.g. to bridge
+// two legs into direct media (customer <-> collector) so RTP bypasses this app.
+// The caller owns SDP construction; the call's stored localSDP and state are left
+// unchanged, so a follow-up Hold/Resume or a re-INVITE with the original localSDP
+// restores media to this endpoint. Not part of the Call interface (advanced/B2BUA
+// use); reach it via a type assertion on the concrete call.
+func (c *call) SendReInvite(sdpOffer []byte) error {
+	c.mu.Lock()
+	state := c.state
+	c.mu.Unlock()
+	if state != StateActive && state != StateOnHold {
+		return ErrInvalidState
+	}
+	return c.dlg.SendReInvite(sdpOffer)
+}
+
+// SuspendMediaTimeout extends the RTP inactivity watchdog to the (longer) hold
+// timeout. Use it when this leg's media has been intentionally redirected to a
+// third party via SendReInvite (B2BUA media bypass): no RTP is expected at this
+// endpoint, so the normal inactivity watchdog would otherwise tear the leg down.
+// Pair with RestoreMediaTimeout once media returns. Safe on an active call;
+// no-op if the media session has not started.
+func (c *call) SuspendMediaTimeout() {
+	// Hold c.mu like every other signalMediaTimerReset caller (Hold/Resume/
+	// refresh) — it guards c.mediaTimerReset and c.mediaTimeout against the media
+	// goroutine and concurrent re-INVITE handling.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.signalMediaTimerReset(defaultHoldMediaTimeout)
+}
+
+// RestoreMediaTimeout returns the RTP inactivity watchdog to the normal
+// (configured) timeout after a SuspendMediaTimeout.
+func (c *call) RestoreMediaTimeout() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.signalMediaTimerReset(c.effectiveMediaTimeout())
+}
+
 func (c *call) Mute() error {
 	c.mu.Lock()
 	if c.state != StateActive {


### PR DESCRIPTION
Adds three additive methods on the concrete `*call` for B2BUA media bypass — bridging two legs into direct media (e.g. customer ↔ secure collector during PCI card capture) and keeping the media-less leg alive:

- `SendReInvite(sdpOffer []byte) error` — re-INVITE with caller-supplied SDP (its `c=`/`m=` may point at a foreign RTP endpoint). Guards state ∈ {Active, OnHold}; intentionally leaves `state`/`localSDP` unchanged so the caller owns SDP construction and restore.
- `SuspendMediaTimeout()` — extends the RTP-inactivity watchdog to the hold timeout while media is redirected away from this endpoint.
- `RestoreMediaTimeout()` — returns the watchdog to the configured timeout.

All additive and backward-compatible; kept off the `Call` interface (advanced use, reached via type assertion with graceful fallback).

Known limitation (documented): a Session-Timer refresh or inbound re-INVITE during the redirect window re-sends this endpoint's own SDP and undoes the redirect. Acceptable for the short secure_line collection window; a first-class `RedirectMedia(...)` helper is a possible follow-up.

Testing: `go build`/`go vet` clean, 603 package tests pass; exercised end-to-end from voiceapp on real SIP calls (Asterisk/3CX honored the foreign-SDP re-INVITE, watchdog suspend prevented teardown, restore reattached media).

After merge: cut v0.6.4 (release branch flow), then voiceapp switches to `go get github.com/x-phone/xphone-go@v0.6.4` and drops its vendored patch.