### PR TITLE
feat(call): SetDtmfMode override for per-call DTMF mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- `SetDtmfMode(mode DtmfMode)` on the concrete `*call` (not the `Call` interface; reach it via type assertion) overrides a single call's DTMF mode independent of the phone's registration-wide `DtmfMode` config and without affecting any other call. Covers B2BUA legs that must send DTMF differently than the leg they're bridging (e.g. relaying to a far end that only detects SIP INFO while the near end keeps sending/receiving RFC 4733). The mode gates both directions on that leg: `SendDTMF` picks RTP telephone-event vs SIP INFO accordingly, and inbound DTMF recognition follows the same mode.
+
 ## v0.6.4
 
 ### Features

--- a/call.go
+++ b/call.go
@@ -1320,6 +1320,22 @@ func (c *call) RestoreMediaTimeout() {
 	c.signalMediaTimerReset(c.effectiveMediaTimeout())
 }
 
+// SetDtmfMode overrides this call's DTMF mode, independent of the phone's
+// registration-wide DtmfMode config and unaffecting any other call. Useful
+// for a B2BUA leg that must send DTMF differently than the inbound leg it's
+// bridging (e.g. relaying to a far end that only detects SIP INFO while the
+// near end keeps sending/receiving RFC 4733).
+// The mode gates both directions on this leg: SendDTMF picks RTP
+// telephone-event vs SIP INFO accordingly, and inbound DTMF recognition is
+// gated the same way — e.g. switching to DtmfSipInfo also stops this leg
+// from recognizing inbound RFC 4733. Not part of the Call interface
+// (advanced/B2BUA use); reach it via a type assertion on the concrete call.
+func (c *call) SetDtmfMode(mode DtmfMode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dtmfMode = mode
+}
+
 func (c *call) Mute() error {
 	c.mu.Lock()
 	if c.state != StateActive {

--- a/call_test.go
+++ b/call_test.go
@@ -814,6 +814,32 @@ func TestCall_SendDTMF_SipInfoMode_InvalidDigitReturnsError(t *testing.T) {
 	assert.ErrorIs(t, c.SendDTMF("X"), ErrInvalidDTMFDigit)
 }
 
+// --- Per-call DTMF mode override ---
+
+func TestCall_SetDtmfMode_SendUsesNewMode(t *testing.T) {
+	dlg := testutil.NewMockDialog()
+	c := testOutboundCall(t, dlg)
+	require.Equal(t, DtmfRfc4733, c.dtmfMode, "default mode before override")
+
+	c.SetDtmfMode(DtmfSipInfo)
+	c.state = StateActive
+
+	err := c.SendDTMF("5")
+	require.NoError(t, err)
+	assert.True(t, dlg.InfoSent(), "expected SIP INFO after SetDtmfMode(DtmfSipInfo)")
+	assert.Equal(t, "5", dlg.LastInfoDigit())
+}
+
+func TestCall_SetDtmfMode_DoesNotAffectOtherCalls(t *testing.T) {
+	collector := testOutboundCall(t, testutil.NewMockDialog())
+	other := testOutboundCall(t, testutil.NewMockDialog())
+
+	collector.SetDtmfMode(DtmfSipInfo)
+
+	assert.Equal(t, DtmfSipInfo, collector.dtmfMode)
+	assert.Equal(t, DtmfRfc4733, other.dtmfMode, "unrelated call must keep its own mode")
+}
+
 // --- Session timers ---
 
 func TestCall_SessionTimer_SendsRefreshReInvite(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `SetDtmfMode(mode DtmfMode)` on the concrete `*call` — advanced/B2BUA use, not on the `Call` interface, reached via type assertion (same convention as `SendReInvite`/`SuspendMediaTimeout` from #118).

Lets a single leg's DTMF mode be overridden independent of the phone's registration-wide `DtmfMode` config, without touching any other call. `dtmfMode` was already a per-call field (just one-way seeded from phone config at call creation, with no setter) — this exposes a setter for it, nothing more.

## Why

voiceapp's `secure_line` transfer relays customer DTMF to a 3CX collector leg on the media mixer. 3CX only detects SIP INFO DTMF, not RFC 4733 — but the same voiceapp instance must keep *receiving* RFC 4733 from inbound 3CX callers elsewhere, so flipping the mode globally isn't an option (this broke in-band DTMF collection in prod once already). `SetDtmfMode` lets voiceapp flip just the collector leg to `DtmfSipInfo` after dialing it, leaving the phone-level config and every other call untouched.

Note the mode gates both directions on that leg: `SendDTMF` picks RTP telephone-event vs SIP INFO accordingly, and inbound DTMF recognition follows the same mode — documented on the method.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] Full test suite passes (`go test ./...`)
- [x] New tests: `TestCall_SetDtmfMode_SendUsesNewMode`, `TestCall_SetDtmfMode_DoesNotAffectOtherCalls`
- [x] CHANGELOG.md updated (Unreleased)