### PR TITLE
release: v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.5
+
 ### Features
 - `SetDtmfMode(mode DtmfMode)` on the concrete `*call` (not the `Call` interface; reach it via type assertion) overrides a single call's DTMF mode independent of the phone's registration-wide `DtmfMode` config and without affecting any other call. Covers B2BUA legs that must send DTMF differently than the leg they're bridging (e.g. relaying to a far end that only detects SIP INFO while the near end keeps sending/receiving RFC 4733). The mode gates both directions on that leg: `SendDTMF` picks RTP telephone-event vs SIP INFO accordingly, and inbound DTMF recognition follows the same mode.
 


### PR DESCRIPTION
## Summary

Release. Cuts `SetDtmfMode` (#119) into v0.6.5.

## Contents

### Features
- `SetDtmfMode(mode DtmfMode)` on the concrete `*call` — per-call DTMF mode override, independent of the phone's registration-wide config, without affecting other calls. (#119)

## Test plan
- [x] All tests pass on main since #119 merge
- [x] CHANGELOG.md updated (Unreleased → v0.6.5)
- [ ] Merge → tag main with `v0.6.5` → push tag